### PR TITLE
feat: add Render.com one-click self-host deployment template

### DIFF
--- a/apps/docs/content/docs/self-hosted/meta.json
+++ b/apps/docs/content/docs/self-hosted/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Self Hosting",
-  "pages": ["docker", "railway", "coolify"]
+  "pages": ["docker", "railway", "coolify", "render"]
 }

--- a/apps/docs/content/docs/self-hosted/render.mdx
+++ b/apps/docs/content/docs/self-hosted/render.mdx
@@ -1,0 +1,138 @@
+---
+title: Render
+description: Deploy ClassroomIO on Render with the one-click Blueprint.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+[Render](https://render.com) deploys ClassroomIO from an in-repo [Blueprint](https://render.com/docs/infrastructure-as-code) ([`render.yaml`](https://github.com/classroomio/classroomio/blob/main/render.yaml)). One click provisions the API, dashboard, and jobs worker, plus Postgres, Redis (Key Value), and a self-hosted MinIO — all by **pulling** the published `classroomio/*` images, so Render never builds anything.
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/classroomio/classroomio)
+
+<Callout type="warn" title="Render self-hosting is a paid setup">
+  Render's free tier does **not** cover background **workers**, **private services**, or
+  **persistent disks** — and ClassroomIO needs all three (the jobs worker and the MinIO disk).
+  The Blueprint defaults every service to a paid `starter` plan. Render's free Postgres/Key Value
+  also expire, so use a paid database tier for anything beyond a quick trial.
+</Callout>
+
+## What the Blueprint provisions
+
+| Service | Type | Image | Networking |
+|---------|------|-------|------------|
+| `cio-postgres` | Managed Postgres 16 | — | private |
+| `cio-redis` | Key Value (Redis) | — | private |
+| `cio-api` | Private service | `classroomio/api` | private (runs DB setup on boot) |
+| `cio-dashboard` | Web service | `classroomio/dashboard` | **public** |
+| `cio-jobs` | Background worker | `classroomio/jobs` | none |
+| `cio-minio` | Web service + disk | `minio/minio` | **public** (S3 API on `9000`) + private |
+
+The API self-migrates: it runs database setup on first boot (skip with `SKIP_DB_SETUP=true`).
+
+To pin a release instead of tracking `latest`, change the image tags in `render.yaml` (e.g. `classroomio/api:1.4.2`) before deploying.
+
+## Finish the setup (one-time)
+
+Render's Blueprint auto-wires everything it can: the database and Redis URLs, the auth secrets
+(`BETTER_AUTH_SECRET`, `PRIVATE_SERVER_KEY`), and the MinIO credentials. A few variables are
+**cross-service full URLs** that Render can't assemble for you (it can reference another service's
+host, but not prepend `https://` or a port). The Blueprint leaves these blank — fill them in once
+from the service URLs shown in your Render dashboard, then redeploy.
+
+<Callout type="error" title="Set DASHBOARD_ORIGIN before cio-api goes live">
+  `DASHBOARD_ORIGIN` is better-auth's base URL. If it's blank or scheme-less when the API boots,
+  the API crashes with `Invalid base URL`. Grab the dashboard's URL first, set it, then redeploy
+  the API.
+</Callout>
+
+After the first deploy, copy each service's URL/host from the Render dashboard and set:
+
+**`cio-api`** (Environment tab):
+
+```zsh title="env"
+DASHBOARD_ORIGIN=https://cio-dashboard-xxxx.onrender.com
+OBJECT_STORAGE_ENDPOINT=http://<cio-minio internal host>:9000   # internal address, port 9000
+OBJECT_STORAGE_PUBLIC_ENDPOINT=https://cio-minio-xxxx.onrender.com
+OBJECT_STORAGE_MEDIA_PUBLIC_BASE_URL=https://cio-minio-xxxx.onrender.com/media
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASSWORD=
+SMTP_SENDER=
+```
+
+**`cio-dashboard`**:
+
+```zsh title="env"
+ORIGIN=https://cio-dashboard-xxxx.onrender.com
+PRIVATE_APP_HOST=cio-dashboard-xxxx.onrender.com          # same host, no scheme
+PRIVATE_SERVER_URL=http://<cio-api internal host>:3081     # internal address, port 3081
+CSP_MEDIA_SRC_DOMAINS=https://cio-minio-xxxx.onrender.com  # so MinIO media isn't blocked by CSP
+```
+
+**`cio-jobs`** — same object-storage and SMTP values as `cio-api`:
+
+```zsh title="env"
+OBJECT_STORAGE_ENDPOINT=http://<cio-minio internal host>:9000
+OBJECT_STORAGE_PUBLIC_ENDPOINT=https://cio-minio-xxxx.onrender.com
+OBJECT_STORAGE_MEDIA_PUBLIC_BASE_URL=https://cio-minio-xxxx.onrender.com/media
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASSWORD=
+SMTP_SENDER=
+OPENAI_API_KEY=     # optional — transcription + AI course generation
+```
+
+<Callout title="Where to find the internal host">
+  On each service's **Connect** / networking panel, Render lists its internal address (used by
+  private traffic). `OBJECT_STORAGE_ENDPOINT` and `PRIVATE_SERVER_URL` use those internal hosts
+  with their ports (`9000` for MinIO, `3081` for the API). The public `…onrender.com` URLs are for
+  browser-facing traffic.
+</Callout>
+
+Redeploy `cio-api`, `cio-dashboard`, and `cio-jobs` after setting the variables.
+
+<Callout title="PRIVATE_SERVER_KEY">
+  `PRIVATE_SERVER_KEY` must be identical in `cio-api` and `cio-dashboard`. The Blueprint generates
+  it on the API and the dashboard references it automatically, so you don't set it by hand.
+</Callout>
+
+## Seed the MinIO buckets (one-time)
+
+The Blueprint has no `minio-init`, so create the buckets once with [`mc`](https://min.io/docs/minio/linux/reference/minio-mc.html)
+(run locally against the MinIO public URL). Get `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` from the
+`cio-minio` service's Environment tab:
+
+```zsh title="Terminal"
+mc alias set cio https://cio-minio-xxxx.onrender.com "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+mc mb cio/videos cio/documents cio/media --ignore-existing
+mc anonymous set download cio/media     # media bucket = public read (images)
+```
+
+<Callout type="warn" title="MinIO is your durability boundary">
+  Single-node MinIO has no redundancy — the Render disk is the only thing protecting your uploads.
+  Back it up. If you'd rather not operate storage, point the same `OBJECT_STORAGE_*` vars at
+  external **Cloudflare R2 / AWS S3** (R2 has no egress fees) and remove the `cio-minio` service.
+  See the [Cloudflare Setup](/docs/contributor-guides/cloudflare-setup) guide for R2.
+</Callout>
+
+## Upgrades & rollback
+
+Edit the image tags in `render.yaml` (e.g. `classroomio/api:1.4.2` → `1.5.0`) and sync the
+Blueprint, or bump them per-service in the Render dashboard. Roll back by setting the tags to the
+previous release. Pinning a version keeps a new release from restarting you onto changed images
+unattended.
+
+<Callout type="warn" title="Back up before upgrading">
+  Schema migrations run automatically on API startup. Back up your Postgres and the MinIO disk
+  before a major upgrade.
+</Callout>
+
+## SMTP Setup
+
+You need SMTP for email (signup verification, password reset, invites). See [Nodemailer SMTP docs](https://nodemailer.com/smtp/) for provider setup.
+
+## SSO (Enterprise)
+
+SSO requires a license key. Set `LICENSE_KEY` in your `cio-api` environment. [Book a call](http://cal.com/classroomio/enterprise) to get a license.

--- a/apps/website/src/blog/self-host.md
+++ b/apps/website/src/blog/self-host.md
@@ -17,7 +17,7 @@ Today we are happy to share that you can now easily self-host classroomio and us
 
 If you are interested in just trying out the product, it is advisable to use the [cloud version](https://app.classroomio.com). You can use almost all the features for free on the cloud version unless you need more students. Right now the main reason you'd have to upgrade is because your students are growing. If you don't want to upgrade and/or face this, then you'd be fine self hosting the whole application.
 
-For self-hosting, we have written up a [guide that uses Railway](https://classroomio.com/docs/self-hosted/railway) to help deploy our stack and you get to manage the servers on Railway as you wish. We hope this is a good step in helping you educate your audience at ease.
+For self-hosting, we have written up a [guide that uses Railway](https://classroomio.com/docs/self-hosted/railway) to help deploy our stack and you get to manage the servers on Railway as you wish. We've since added more one-click options too — including [Render](https://classroomio.com/docs/self-hosted/render) and [Coolify](https://classroomio.com/docs/self-hosted/coolify). We hope this is a good step in helping you educate your audience at ease.
 
 Below is a demo showing you step by step how to self host the project
 

--- a/apps/website/src/lib/components/deploy-section.svelte
+++ b/apps/website/src/lib/components/deploy-section.svelte
@@ -9,6 +9,12 @@
       href: 'https://railway.app'
     },
     {
+      icon: '🎨',
+      title: 'Render',
+      description: 'One-click Blueprint deploy on Render. Pulls our pre-built images.',
+      href: 'https://render.com/deploy?repo=https://github.com/classroomio/classroomio'
+    },
+    {
       icon: '🐳',
       title: 'Docker Compose',
       description: 'Standard Docker setup for any Linux server or VPS. Full control.',

--- a/docker/docs/SELF_HOST.md
+++ b/docker/docs/SELF_HOST.md
@@ -305,5 +305,5 @@ lsof -nP -iTCP:3082 -sTCP:LISTEN
 
 ## Related
 
-- [Self-hosting docs](https://classroomio.com/docs/self-hosted/docker) — published guide with Docker, Railway, and Coolify instructions
+- [Self-hosting docs](https://classroomio.com/docs/self-hosted/docker) — published guide with Docker, Railway, Coolify, and Render instructions
 - [`docker/docs/PUBLISHING_IMAGES.md`](PUBLISHING_IMAGES.md) — publishing Docker images to Docker Hub

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,201 @@
+# ClassroomIO — Render.com Blueprint (one-click self-host)
+#
+# Deploy with the button in the docs, or:
+#   https://render.com/deploy?repo=https://github.com/classroomio/classroomio
+#
+# This Blueprint PULLS the published classroomio/{api,dashboard,jobs} images from Docker Hub
+# (it does not build from source — that avoids Render's build-RAM limits). Pin a release by
+# changing `:latest` to a version tag (e.g. :1.4.2) on each image below.
+#
+# Render's free tier does NOT cover background workers, private services, or disks, so a working
+# ClassroomIO is a PAID setup (the jobs worker + the MinIO disk). The `starter` plans below are
+# the minimum; scale up as needed.
+#
+# IMPORTANT — one-time post-deploy step. render.yaml cannot prepend a scheme/port to a
+# `fromService` host, and better-auth needs a full URL. So the cross-service URL vars are marked
+# `sync: false`: Render leaves them blank, you fill them in once from the service URLs in your
+# Render dashboard, then redeploy. The full walkthrough is in:
+#   apps/docs/content/docs/self-hosted/render.mdx
+
+databases:
+  - name: cio-postgres
+    databaseName: classroomio
+    user: classroomio
+    plan: basic-256mb
+    postgresMajorVersion: '16'
+
+services:
+  # ── Redis / Key Value (BullMQ queue) ───────────────────────────────────────
+  - type: keyvalue
+    name: cio-redis
+    plan: starter
+    ipAllowList: [] # internal-only (no public access)
+    maxmemoryPolicy: noeviction # never evict queued jobs
+
+  # ── Object storage (MinIO) — public S3 API on :9000 + internal ─────────────
+  - type: web
+    name: cio-minio
+    runtime: image
+    plan: starter
+    image:
+      url: docker.io/minio/minio:latest
+    dockerCommand: server /data --console-address ":9001"
+    disk:
+      name: minio-data
+      mountPath: /data
+      sizeGB: 10 # your durability boundary — back it up
+    envVars:
+      - key: MINIO_ROOT_USER
+        generateValue: true
+      - key: MINIO_ROOT_PASSWORD
+        generateValue: true
+      # Optional: silence console redirect warnings. Set to this service's own public URL
+      # (https://cio-minio-xxxx.onrender.com) after first deploy.
+      - key: MINIO_SERVER_URL
+        sync: false
+
+  # ── API (private) — runs DB setup on boot via the image entrypoint ─────────
+  - type: pserv
+    name: cio-api
+    runtime: image
+    plan: starter
+    image:
+      url: docker.io/classroomio/api:latest
+    envVars:
+      - key: PORT
+        value: 3081
+      - key: PUBLIC_IS_SELFHOSTED
+        value: true
+      - key: DATABASE_URL
+        fromDatabase:
+          name: cio-postgres
+          property: connectionString
+      - key: REDIS_URL
+        fromService:
+          type: keyvalue
+          name: cio-redis
+          property: connectionString
+      - key: BETTER_AUTH_SECRET
+        generateValue: true
+      - key: PRIVATE_SERVER_KEY
+        generateValue: true
+      - key: OBJECT_STORAGE_ACCESS_KEY_ID
+        fromService:
+          type: web
+          name: cio-minio
+          envVarKey: MINIO_ROOT_USER
+      - key: OBJECT_STORAGE_SECRET_ACCESS_KEY
+        fromService:
+          type: web
+          name: cio-minio
+          envVarKey: MINIO_ROOT_PASSWORD
+      - key: OBJECT_STORAGE_FORCE_PATH_STYLE
+        value: true
+      # ── Fill these in after first deploy (see render.mdx) ──
+      # Dashboard URL — better-auth base URL. Must be a full https:// URL.
+      - key: DASHBOARD_ORIGIN
+        sync: false
+      # Internal MinIO endpoint: http://<cio-minio internal host>:9000
+      - key: OBJECT_STORAGE_ENDPOINT
+        sync: false
+      # Public MinIO URL: https://cio-minio-xxxx.onrender.com
+      - key: OBJECT_STORAGE_PUBLIC_ENDPOINT
+        sync: false
+      # Public media base: https://cio-minio-xxxx.onrender.com/media
+      - key: OBJECT_STORAGE_MEDIA_PUBLIC_BASE_URL
+        sync: false
+      # Email (required for signup verification, password reset, invites)
+      - key: SMTP_HOST
+        sync: false
+      - key: SMTP_PORT
+        sync: false
+      - key: SMTP_USER
+        sync: false
+      - key: SMTP_PASSWORD
+        sync: false
+      - key: SMTP_SENDER
+        sync: false
+      # Optional — transcription + AI course generation
+      - key: OPENAI_API_KEY
+        sync: false
+
+  # ── Dashboard (public web) ─────────────────────────────────────────────────
+  - type: web
+    name: cio-dashboard
+    runtime: image
+    plan: starter
+    image:
+      url: docker.io/classroomio/dashboard:latest
+    envVars:
+      - key: PUBLIC_IS_SELFHOSTED
+        value: true
+      - key: PRIVATE_APP_SUBDOMAINS
+        value: app
+      # Same value as cio-api — authenticates server-side dashboard → API calls.
+      - key: PRIVATE_SERVER_KEY
+        fromService:
+          type: pserv
+          name: cio-api
+          envVarKey: PRIVATE_SERVER_KEY
+      # ── Fill these in after first deploy (see render.mdx) ──
+      # This dashboard's own public URL: https://cio-dashboard-xxxx.onrender.com
+      - key: ORIGIN
+        sync: false
+      # This dashboard's own public host (no scheme): cio-dashboard-xxxx.onrender.com
+      - key: PRIVATE_APP_HOST
+        sync: false
+      # Internal API URL: http://<cio-api internal host>:3081
+      - key: PRIVATE_SERVER_URL
+        sync: false
+      # The MinIO public URL, so uploaded media isn't blocked by CSP.
+      - key: CSP_MEDIA_SRC_DOMAINS
+        sync: false
+
+  # ── Background jobs worker (no public URL) ─────────────────────────────────
+  - type: worker
+    name: cio-jobs
+    runtime: image
+    plan: starter
+    image:
+      url: docker.io/classroomio/jobs:latest
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: cio-postgres
+          property: connectionString
+      - key: REDIS_URL
+        fromService:
+          type: keyvalue
+          name: cio-redis
+          property: connectionString
+      - key: OBJECT_STORAGE_ACCESS_KEY_ID
+        fromService:
+          type: web
+          name: cio-minio
+          envVarKey: MINIO_ROOT_USER
+      - key: OBJECT_STORAGE_SECRET_ACCESS_KEY
+        fromService:
+          type: web
+          name: cio-minio
+          envVarKey: MINIO_ROOT_PASSWORD
+      - key: OBJECT_STORAGE_FORCE_PATH_STYLE
+        value: true
+      # ── Fill these in after first deploy (same values as cio-api) ──
+      - key: OBJECT_STORAGE_ENDPOINT
+        sync: false
+      - key: OBJECT_STORAGE_PUBLIC_ENDPOINT
+        sync: false
+      - key: OBJECT_STORAGE_MEDIA_PUBLIC_BASE_URL
+        sync: false
+      - key: SMTP_HOST
+        sync: false
+      - key: SMTP_PORT
+        sync: false
+      - key: SMTP_USER
+        sync: false
+      - key: SMTP_PASSWORD
+        sync: false
+      - key: SMTP_SENDER
+        sync: false
+      - key: OPENAI_API_KEY
+        sync: false


### PR DESCRIPTION
## What does this PR do?

Adds **Render.com** as a one-click self-hosting option, alongside the existing Docker, Railway, and Coolify paths. Render reads an in-repo `render.yaml` Blueprint plus a "Deploy to Render" button, so the whole template ships in this repo — no external template registration needed.

- **`render.yaml`** (new) — a Blueprint that provisions all 6 components (Postgres, Redis/Key Value, api, dashboard, jobs worker, and a MinIO web service + disk) by **pulling** the published `classroomio/{api,dashboard,jobs}` images, so Render never builds from source (avoids the ~8 GB dashboard-build RAM limit). It auto-wires the database/Redis URLs, generates the auth secrets, and keeps `PRIVATE_SERVER_KEY` identical across api and dashboard. Cross-service full-URL vars are `sync: false` (Render can't prepend a scheme/port to a service host) and documented as a one-time post-deploy step.
- **`apps/docs/content/docs/self-hosted/render.mdx`** (new) — Deploy-to-Render button, the "what the Blueprint provisions" table, the paid-tier caveat, the post-deploy env values to fill in, MinIO bucket seeding, upgrades/rollback, and the external R2/S3 alternative.
- Surfaced Render in the docs nav (`meta.json`), the marketing deploy section (`deploy-section.svelte`), `docker/docs/SELF_HOST.md`, and the self-host blog post.

Fixes # N/A

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How should this be tested?

- `render.yaml` parses and every `fromService` / `fromDatabase` reference resolves to a defined service/database (validated locally).
- `fumadocs-mdx` compiles the docs content including the new page (exit 0); the **Render** page shows in the Self-Hosting nav.
- The marketing deploy section renders the new **Render** card linking to the deploy URL.
- Recommended before merge: a click-through Blueprint deploy on a fork to smoke-test the live one-click flow, then the railway.mdx checklist (sign up, create org/course, upload an image → renders, upload a video → leaves "processing" once the jobs worker drains it).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits (render.yaml is heavily commented)
- [ ] Ran `pnpm build` (validated via `fumadocs-mdx` + render.yaml parse instead — docs/config only)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs` (none added)
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the ClassroomIO Docs if changes were necessary

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Render.com as a one-click self-hosting option via an in-repo `render.yaml` Blueprint, a new `render.mdx` docs page, and surface-level additions to the marketing site, blog post, and Docker docs.

- **`render.yaml`** provisions Postgres, Redis, MinIO, the API (private service), dashboard (public web service), and a jobs worker — all by pulling published Docker Hub images, with `sync: false` env vars for the post-deploy URL wiring step.
- **`render.mdx`** guides users through the deploy button, what the Blueprint provisions, the mandatory post-deploy env fill-in, MinIO bucket seeding, and upgrade/rollback instructions.
- Two issues in `render.yaml` need fixing before the Blueprint is deployable: the MinIO web service is missing `PORT=9000` (causing Render health checks to permanently fail on port 10000) and `PRIVATE_APP_SUBDOMAINS` is hardcoded to `app`, which implies a wildcard subdomain URL that `onrender.com` does not support.

<h3>Confidence Score: 3/5</h3>

The Blueprint has two defects that will prevent a working deployment out of the box.

The MinIO web service never becomes healthy because Render health-checks port 10000 while MinIO binds to 9000 — every deploy of cio-minio will time out, making all object storage unavailable. Hardcoding PRIVATE_APP_SUBDOMAINS=app produces a subdomain URL that onrender.com cannot route to, breaking dashboard routing for any user without a custom domain. Both issues are in render.yaml and straightforward to fix, but until they are the one-click deploy will not produce a working stack.

render.yaml and apps/docs/content/docs/self-hosted/render.mdx need attention; the remaining four files are safe.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| render.yaml | New Render Blueprint provisioning 6 services; two issues: cio-minio web service missing PORT=9000 (Render health-checks port 10000 but MinIO binds to 9000), and PRIVATE_APP_SUBDOMAINS hardcoded to "app" which produces a wildcard subdomain URL incompatible with onrender.com. |
| apps/docs/content/docs/self-hosted/render.mdx | New Render self-hosting guide with deploy button, service table, post-deploy env instructions, and MinIO bucket seeding steps; doesn't mention the custom-domain requirement for subdomain routing. |
| apps/docs/content/docs/self-hosted/meta.json | Adds "render" entry to the self-hosted nav pages list; trivial one-line change. |
| apps/website/src/lib/components/deploy-section.svelte | Adds a Render card with the correct one-click deploy URL to the marketing deploy section. |
| apps/website/src/blog/self-host.md | Appends a mention of Render and Coolify self-hosting options to the existing Railway sentence. |
| docker/docs/SELF_HOST.md | Updates the Related links section to include Render alongside Docker, Railway, and Coolify; no issues. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant cio-dashboard as cio-dashboard (web, public)
    participant cio-api as cio-api (pserv, private)
    participant cio-jobs as cio-jobs (worker)
    participant cio-postgres as cio-postgres (Postgres)
    participant cio-redis as cio-redis (Key Value)
    participant cio-minio as cio-minio (web, public)

    Browser->>cio-dashboard: HTTPS request
    cio-dashboard->>cio-api: SSR / API proxy (PRIVATE_SERVER_URL, internal)
    cio-api->>cio-postgres: DB queries (DATABASE_URL)
    cio-api->>cio-redis: BullMQ enqueue (REDIS_URL)
    cio-api->>cio-minio: Object storage (OBJECT_STORAGE_ENDPOINT, internal :9000)
    cio-redis-->>cio-jobs: BullMQ dequeue (REDIS_URL)
    cio-jobs->>cio-postgres: Media job writes
    cio-jobs->>cio-minio: Stream video/media (internal :9000)
    Browser->>cio-minio: Media download (public URL :443→9000)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant cio-dashboard as cio-dashboard (web, public)
    participant cio-api as cio-api (pserv, private)
    participant cio-jobs as cio-jobs (worker)
    participant cio-postgres as cio-postgres (Postgres)
    participant cio-redis as cio-redis (Key Value)
    participant cio-minio as cio-minio (web, public)

    Browser->>cio-dashboard: HTTPS request
    cio-dashboard->>cio-api: SSR / API proxy (PRIVATE_SERVER_URL, internal)
    cio-api->>cio-postgres: DB queries (DATABASE_URL)
    cio-api->>cio-redis: BullMQ enqueue (REDIS_URL)
    cio-api->>cio-minio: Object storage (OBJECT_STORAGE_ENDPOINT, internal :9000)
    cio-redis-->>cio-jobs: BullMQ dequeue (REDIS_URL)
    cio-jobs->>cio-postgres: Media job writes
    cio-jobs->>cio-minio: Stream video/media (internal :9000)
    Browser->>cio-minio: Media download (public URL :443→9000)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat: add Render deployment option and u..."](https://github.com/classroomio/classroomio/commit/daceb8747a6ce4d621d9cd6d9cb9ceede171e6b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39826343)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->