### PR TITLE
fix(db): build workspace deps before compiling

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -50,6 +50,7 @@
     "dist"
   ],
   "scripts": {
+    "prebuild": "pnpm --filter @cio/question-types run build && pnpm --filter @cio/utils run build && pnpm --filter @cio/email run build",
     "build": "rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias",
     "dev": "tsc --watch",
     "db": "drizzle-kit",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc && tsc-alias",
+    "build": "rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias",
     "dev": "tsc --watch",
     "format": "prettier --write \"src/**/*.ts\"",
     "test": "vitest run",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -71,7 +71,7 @@
     }
   },
   "scripts": {
-    "build": "tsc && tsc-alias",
+    "build": "rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias",
     "dev": "tsc --watch",
     "format": "prettier --write ."
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `@cio/db` failing to build in isolation with:

```
Cannot find module '@cio/utils/notifications'
```

## Root cause

`email-preferences.ts` imports from `@cio/utils/notifications`, which is resolved via `@cio/utils` package exports to `dist/notifications/`. That folder only exists after `@cio/utils` is built.

Building from `packages/db` directly did not build workspace dependencies first. Additionally, `@cio/utils` and `@cio/email` used incremental `tsc` without cleaning `tsconfig.tsbuildinfo`, so a deleted/missing `dist/` could leave builds appearing successful while emitting nothing.

## Fix

1. **`packages/db`**: add `prebuild` to compile `question-types`, `utils`, and `email` before db
2. **`packages/utils`** and **`packages/email`**: clean `dist` + `tsconfig.tsbuildinfo` before `tsc`, matching the pattern already used by `@cio/db`

## Test plan

- [ ] `cd packages/db && pnpm build` succeeds on a clean checkout
- [ ] `rm -rf packages/utils/dist && cd packages/db && pnpm build` still succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f620d-46c5-713f-b535-fca3226dd7fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f620d-46c5-713f-b535-fca3226dd7fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

