### PR TITLE
chore(dev): build api workspace deps before api:dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "db:studio": "pnpm --filter @cio/db db:studio",
     "db:backfill-profile-email-verification": "pnpm --filter @cio/db db:backfill-profile-email-verification",
     "dashboard:dev": "pnpm concurrently -n dashboard,ui -c blue,yellow \"pnpm --filter=@cio/dashboard run dev\" \"pnpm --filter=@cio/ui run dev\"",
-    "api:dev": "pnpm concurrently -n api,jobs -c blue,yellow \"pnpm --filter=@cio/api run dev\" \"pnpm --filter=@cio/jobs-worker run dev\"",
+    "api:dev": "pnpm turbo run build --filter=@cio/api^... --filter=@cio/jobs-worker^... && pnpm concurrently -n api,jobs -c blue,yellow \"pnpm --filter=@cio/api run dev\" \"pnpm --filter=@cio/jobs-worker run dev\"",
     "jobs:dev": "pnpm --filter=@cio/jobs-worker run dev",
     "docs:dev": "pnpm --filter @cio/docs dev",
     "docs:build": "pnpm --filter @cio/docs build",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`pnpm api:dev` now builds all workspace package dependencies before starting the API and jobs worker dev servers.

## Change

```json
"api:dev": "pnpm turbo run build --filter=@cio/api^... --filter=@cio/jobs-worker^... && pnpm concurrently ..."
```

Uses the same turbo filter pattern as CI (`upload-openapi-spec.yml`) to build only upstream workspace packages:

- `@cio/question-types`
- `@cio/utils`
- `@cio/email`
- `@cio/db`
- `@cio/jobs`
- `@cio/core`
- `@cio/analytics`
- `@cio/certificates`
- `@cio/ai-assistant`

`@cio/api` and `@cio/jobs-worker` themselves are not built (tsx watch handles those).

## Test plan

- [ ] `pnpm api:dev` builds deps, then starts API + workers
- [ ] Fresh clone without prior `pnpm build` can start API dev successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f620d-46c5-713f-b535-fca3226dd7fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f620d-46c5-713f-b535-fca3226dd7fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

