### PR TITLE
fix(billing): downgrade orgs when Polar subscription is revoked

### DIFF
--- a/apps/dashboard/src/routes/api/polar/webhook/+server.ts
+++ b/apps/dashboard/src/routes/api/polar/webhook/+server.ts
@@ -157,6 +157,16 @@ async function onPayload(payload: PolarWebhookPayload) {
     case 'subscription.active':
       break;
     case 'subscription.revoked':
+      try {
+        const result = await OrgPlanApiServer.cancelOrgPlan({
+          subscriptionId,
+          payload: data as unknown as Record<string, unknown>
+        });
+        console.log('Subscription revoked', result);
+      } catch (error) {
+        console.error('Error revoking org plan', error);
+      }
+
       break;
     case 'subscription.canceled':
       break;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -71,6 +71,7 @@
     "db:backfill-profile-email-verification": "tsx src/scripts/backfill-profile-email-verification.ts",
     "db:update-user-email": "tsx src/scripts/update-user-email.ts",
     "db:notify-students-over-limit": "tsx src/scripts/notify-students-over-limit.ts",
+    "db:downgrade-expired-subscriptions": "tsx src/scripts/downgrade-expired-subscriptions.ts",
     "move-users": "tsx src/scripts/supabase-to-betterauth.ts",
     "pull": "drizzle-kit pull --config drizzle.config.ts",
     "generate-types": "tsx scripts/generate-types.ts && pnpm format",

--- a/packages/db/src/queries/organization/organization.ts
+++ b/packages/db/src/queries/organization/organization.ts
@@ -8,7 +8,21 @@ import type {
   TOrganization,
   TOrganizationPlan
 } from '@db/types';
-import { and, asc, count, desc, eq, gt, ilike, inArray, isNotNull, notInArray, or, sql } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  getTableColumns,
+  gt,
+  ilike,
+  inArray,
+  isNotNull,
+  notInArray,
+  or,
+  sql
+} from 'drizzle-orm';
 
 import { PLAN } from '@cio/utils/plans';
 import { ROLE } from '@cio/utils/constants';
@@ -1004,6 +1018,33 @@ export const getOrganizationPlanBySubscriptionId = async (
   } catch (error) {
     console.error('getOrganizationPlanBySubscriptionId error:', error);
     throw new Error(`Failed to fetch organization plan: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+};
+
+/**
+ * Gets every active organization plan that has a Polar subscription ID attached.
+ * Used by one-off backfills that need to re-verify subscription status against Polar.
+ * @param dbClient Optional DB or transaction client for use within transactions
+ * @returns Active organization plans with org name/siteName for readable logging
+ */
+export const getActiveOrganizationPlansWithSubscription = async (
+  dbClient: DbOrTxClient = db
+): Promise<Array<TOrganizationPlan & { orgName: string; orgSiteName: string | null }>> => {
+  try {
+    return await dbClient
+      .select({
+        ...getTableColumns(schema.organizationPlan),
+        orgName: schema.organization.name,
+        orgSiteName: schema.organization.siteName
+      })
+      .from(schema.organizationPlan)
+      .innerJoin(schema.organization, eq(schema.organization.id, schema.organizationPlan.orgId))
+      .where(and(eq(schema.organizationPlan.isActive, true), isNotNull(schema.organizationPlan.subscriptionId)));
+  } catch (error) {
+    console.error('getActiveOrganizationPlansWithSubscription error:', error);
+    throw new Error(
+      `Failed to fetch active organization plans: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
   }
 };
 

--- a/packages/db/src/scripts/downgrade-expired-subscriptions.ts
+++ b/packages/db/src/scripts/downgrade-expired-subscriptions.ts
@@ -70,11 +70,11 @@ async function main() {
           `subscription ${subscriptionId} is "${subscription.status}"`
       );
 
-      downgraded++;
-
       if (execute) {
         await cancelOrganizationPlan(subscriptionId, subscription);
       }
+
+      downgraded++;
     } catch (error) {
       errored++;
       console.error(`Skipping ${plan.orgName} (${plan.orgId}): ${error instanceof Error ? error.message : error}`);

--- a/packages/db/src/scripts/downgrade-expired-subscriptions.ts
+++ b/packages/db/src/scripts/downgrade-expired-subscriptions.ts
@@ -1,0 +1,96 @@
+/**
+ * One-time (manual, not cron) backfill: for every org with an `organization_plan`
+ * row still marked active, re-check the real subscription status with Polar and
+ * downgrade (deactivate the plan row) any whose subscription has actually ended
+ * — covers subscriptions that expired or didn't renew before the webhook handler
+ * started reacting to `subscription.revoked`. Dry-run by default; pass --execute
+ * to actually deactivate.
+ *
+ * Usage:
+ *   pnpm db:downgrade-expired-subscriptions             # dry run (default)
+ *   pnpm db:downgrade-expired-subscriptions -- --execute # deactivate
+ *
+ * Env:
+ *   POLAR_ACCESS_TOKEN - required
+ *   POLAR_SERVER        - "production" (default) or "sandbox"
+ */
+import 'dotenv/config';
+
+import {
+  cancelOrganizationPlan,
+  getActiveOrganizationPlansWithSubscription
+} from '../queries/organization/organization';
+
+const POLAR_SERVER = process.env.POLAR_SERVER === 'sandbox' ? 'sandbox' : 'production';
+const POLAR_API_BASE = POLAR_SERVER === 'sandbox' ? 'https://sandbox-api.polar.sh' : 'https://api.polar.sh';
+
+async function fetchSubscription(subscriptionId: string, accessToken: string): Promise<Record<string, unknown>> {
+  const response = await fetch(`${POLAR_API_BASE}/v1/subscriptions/${subscriptionId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Polar responded ${response.status} for subscription ${subscriptionId}`);
+  }
+
+  return response.json();
+}
+
+async function main() {
+  const execute = process.argv.includes('--execute');
+  const accessToken = process.env.POLAR_ACCESS_TOKEN;
+
+  if (!accessToken) {
+    throw new Error('POLAR_ACCESS_TOKEN is required');
+  }
+
+  console.log(`Checking active org plans against Polar (${POLAR_SERVER})...`);
+
+  const activePlans = await getActiveOrganizationPlansWithSubscription();
+
+  let downgraded = 0;
+  let stillActive = 0;
+  let errored = 0;
+
+  for (const plan of activePlans) {
+    const subscriptionId = plan.subscriptionId;
+
+    if (!subscriptionId) continue;
+
+    try {
+      const subscription = await fetchSubscription(subscriptionId, accessToken);
+
+      if (subscription.status === 'active') {
+        stillActive++;
+        continue;
+      }
+
+      console.log(
+        `${execute ? 'Downgrading' : '[dry-run] Would downgrade'} ${plan.orgName} (${plan.orgId}): ` +
+          `subscription ${subscriptionId} is "${subscription.status}"`
+      );
+
+      downgraded++;
+
+      if (execute) {
+        await cancelOrganizationPlan(subscriptionId, subscription);
+      }
+    } catch (error) {
+      errored++;
+      console.error(`Skipping ${plan.orgName} (${plan.orgId}): ${error instanceof Error ? error.message : error}`);
+    }
+  }
+
+  console.log(
+    `\nChecked ${activePlans.length} active org plan(s): ${stillActive} still active, ` +
+      `${downgraded} to downgrade${errored ? `, ${errored} error(s)` : ''}.`
+  );
+  console.log(execute ? `Done. Downgraded ${downgraded} org(s).` : 'Dry run — re-run with --execute to downgrade.');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- Handle Polar's `subscription.revoked` webhook event (was a no-op) by deactivating the org's `organization_plan` row, same as the existing inactive-`subscription.updated` path — this is what actually downgrades an org back to the free plan when a subscription expires or fails to renew. `subscription.canceled` is left as a no-op since the org is still entitled until the current period ends at that point.
- Add a one-time backfill script (`pnpm db:downgrade-expired-subscriptions`, dry-run by default, `--execute` to apply) that re-checks every currently-active org plan directly against Polar and downgrades any whose subscription has already ended, to fix orgs affected before this webhook fix shipped.
- Add `getActiveOrganizationPlansWithSubscription` query helper used by the backfill script.

## Test plan
- [x] `pnpm --filter @cio/db build` passes
- [x] `pnpm format:check` / pre-commit hooks pass
- [ ] Replay a `subscription.revoked` Polar webhook payload against `/api/polar/webhook` locally and confirm the matching `organization_plan` row flips to `isActive = false`
- [ ] Run `pnpm db:downgrade-expired-subscriptions` (dry-run) against staging/prod data and review the log before running with `--execute`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a webhook handling gap where Polar's `subscription.revoked` event was a no-op, meaning orgs whose subscriptions expired or failed to renew were never downgraded back to the free plan. It mirrors the existing inactive-`subscription.updated` logic for the revoked case, and adds a one-time backfill script to retroactively downgrade affected orgs.

- **Webhook fix**: The `subscription.revoked` case now calls `OrgPlanApiServer.cancelOrgPlan`, identical in structure to the existing inactive-`subscription.updated` handler.
- **Backfill script** (`downgrade-expired-subscriptions.ts`): Dry-run by default, re-checks each active org plan against the Polar API and deactivates any whose subscription status is no longer `'active'`, using `--execute` to apply.
- **Query helper**: `getActiveOrganizationPlansWithSubscription` correctly inner-joins `organization_plan` with `organization` and filters for `isActive = true` AND `subscriptionId IS NOT NULL`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the webhook fix is a minimal, targeted addition that mirrors the existing inactive-subscription.updated path, and the backfill script is dry-run by default with no runtime impact.

The webhook change is a single case added to an existing switch with identical structure to the already-proven subscription.updated handler. The backfill script correctly guards writes behind --execute, places the downgraded counter after the awaited DB call so error counts remain accurate, and the new query helper is straightforwardly correct. No logic errors or data-integrity risks were found across any of the four changed files.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/routes/api/polar/webhook/+server.ts | Adds handling for subscription.revoked; mirrors the existing inactive-subscription.updated path exactly. Error is caught and logged; consistent with all other handlers in the switch. |
| packages/db/src/queries/organization/organization.ts | Adds getActiveOrganizationPlansWithSubscription: correct inner join, proper where clause (isActive=true AND subscriptionId IS NOT NULL), and uses getTableColumns spread for full plan columns plus org name fields. |
| packages/db/src/scripts/downgrade-expired-subscriptions.ts | Backfill script correctly checks each active plan against Polar, skips active subscriptions, and deactivates the rest only when --execute is passed. downgraded++ is correctly placed after the awaited cancelOrganizationPlan call, so errors leave counters accurate. |
| packages/db/package.json | Adds the db:downgrade-expired-subscriptions script entry; consistent with the other tsx-based script entries in this file. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Polar
    participant Webhook as /api/polar/webhook
    participant OrgPlan as OrgPlanApiServer
    participant DB as organization_plan

    Note over Polar,DB: Normal subscription lifecycle
    Polar->>Webhook: "subscription.created (status=active)"
    Webhook->>OrgPlan: createOrgPlan()
    OrgPlan->>DB: "INSERT organization_plan (isActive=true)"

    Polar->>Webhook: "subscription.canceled (cancelAtPeriodEnd=true)"
    Note over Webhook: no-op — org still entitled until period end

    Note over Polar,DB: Period ends — subscription revoked (this PR)
    Polar->>Webhook: subscription.revoked
    Webhook->>OrgPlan: cancelOrgPlan(subscriptionId)
    OrgPlan->>DB: "UPDATE SET isActive=false, deactivatedAt=now()"

    Note over Polar,DB: Backfill script (one-time)
    participant Script as backfill script
    Script->>DB: getActiveOrganizationPlansWithSubscription()
    DB-->>Script: active plans with subscriptionId
    loop each plan
        Script->>Polar: "GET /v1/subscriptions/{id}"
        Polar-->>Script: "{ status }"
        alt "status !== 'active'"
            Script->>DB: cancelOrganizationPlan(subscriptionId)
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Polar
    participant Webhook as /api/polar/webhook
    participant OrgPlan as OrgPlanApiServer
    participant DB as organization_plan

    Note over Polar,DB: Normal subscription lifecycle
    Polar->>Webhook: "subscription.created (status=active)"
    Webhook->>OrgPlan: createOrgPlan()
    OrgPlan->>DB: "INSERT organization_plan (isActive=true)"

    Polar->>Webhook: "subscription.canceled (cancelAtPeriodEnd=true)"
    Note over Webhook: no-op — org still entitled until period end

    Note over Polar,DB: Period ends — subscription revoked (this PR)
    Polar->>Webhook: subscription.revoked
    Webhook->>OrgPlan: cancelOrgPlan(subscriptionId)
    OrgPlan->>DB: "UPDATE SET isActive=false, deactivatedAt=now()"

    Note over Polar,DB: Backfill script (one-time)
    participant Script as backfill script
    Script->>DB: getActiveOrganizationPlansWithSubscription()
    DB-->>Script: active plans with subscriptionId
    loop each plan
        Script->>Polar: "GET /v1/subscriptions/{id}"
        Polar-->>Script: "{ status }"
        alt "status !== 'active'"
            Script->>DB: cancelOrganizationPlan(subscriptionId)
        end
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Update packages/db/src/scripts/downgrade..."](https://github.com/classroomio/classroomio/commit/80b28724d6d88f7b9e35f2c110f8708390b62418) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44648425)</sub>

<!-- /greptile_comment -->