### PR TITLE
fix(dashboard): show locked notice instead of teacher empty state on lessons

### DIFF
--- a/apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte
+++ b/apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte
@@ -8,6 +8,7 @@
   import * as Tooltip from '@cio/ui/base/tooltip';
   import { PercentRingProgress } from '@cio/ui/custom/percent-ring-progress';
   import { isOrgStudent } from '$lib/utils/store/app';
+  import { getStudentContentLockReason } from '$features/ai-assistant/utils/content-ask-ai-bar';
   import { t } from '$lib/utils/functions/translations';
   import { courseApi, lessonApi } from '$features/course/api';
   import { getOrderedNavigableContent, getContentRoute } from '$features/course/utils/content';
@@ -69,8 +70,10 @@
   const showMarkComplete = $derived(!!lessonId && !exerciseId);
 
   const currentLessonItem = $derived(lessonId ? lessonItems.find((l) => l.id === lessonId) : null);
-  const isTeacherLocked = $derived($isOrgStudent && currentLessonItem && !(currentLessonItem.isUnlocked ?? false));
-  const isProgressionLocked = $derived($isOrgStudent && currentLessonItem?.accessible === false && !isTeacherLocked);
+  const contentLockReason = $derived(
+    lessonId ? getStudentContentLockReason(courseApi.course, lessonId, ContentType.Lesson) : null
+  );
+  const isLessonLocked = $derived($isOrgStudent === true && contentLockReason !== null);
   const isVideoWatchLesson = $derived.by(() => {
     if (!lessonId) return false;
 
@@ -98,7 +101,6 @@
 
   const watchVideosRequired = $derived(lessonApi.lesson?.watchProgress?.videosRequired ?? 0);
   const watchVideosComplete = $derived(lessonApi.lesson?.watchProgress?.videosComplete ?? 0);
-  const isLessonLocked = $derived(isTeacherLocked || isProgressionLocked);
   const isVideoWatchComplete = $derived(isVideoWatchLesson && (lessonApi.lesson?.watchProgress?.isComplete ?? false));
   const showVideoWatchCompleteState = $derived(isVideoWatchComplete || (isVideoWatchLesson && isLessonComplete));
   const isMarkCompleteDisabled = $derived(

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-content-tree.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-content-tree.svelte
@@ -14,6 +14,7 @@
   import { IconButton } from '@cio/ui/custom/icon-button';
   import { RadioIcon } from '@cio/ui/custom/moving-icons';
   import CourseContentIcon from '$features/course/components/course-content-icon.svelte';
+  import { isOrgStudent } from '$lib/utils/store/app';
 
   interface Props {
     path: string;
@@ -85,7 +86,8 @@
                     <Sidebar.MenuSubButton isActive={(path || page.url.pathname).includes(contentItem.id)}>
                       {#snippet child({ props })}
                         {@const isContentLocked = (contentItem.isUnlocked ?? true) === false}
-                        {@const isLockedForStudent = isStudent && (isContentLocked || contentItem.accessible === false)}
+                        {@const isLockedForStudent =
+                          $isOrgStudent === true && (isContentLocked || contentItem.accessible === false)}
                         <a
                           href={resolve(getContentRoute(id, contentItem), {})}
                           aria-disabled={isLockedForStudent}
@@ -137,7 +139,8 @@
         <Sidebar.MenuSubButton isActive={(path || page.url.pathname).includes(contentItem.id)}>
           {#snippet child({ props })}
             {@const isContentLocked = (contentItem.isUnlocked ?? true) === false}
-            {@const isLockedForStudent = isStudent && (isContentLocked || contentItem.accessible === false)}
+            {@const isLockedForStudent =
+              $isOrgStudent === true && (isContentLocked || contentItem.accessible === false)}
             <a
               href={resolve(getContentRoute(id, contentItem), {})}
               aria-disabled={isLockedForStudent}

--- a/apps/dashboard/src/lib/features/course/pages/lesson.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/lesson.svelte
@@ -17,6 +17,7 @@
   import MODES from '$lib/utils/constants/mode';
   import { profile } from '$lib/utils/store/user';
   import { isOrgStudent, isStudentExperience } from '$lib/utils/store/app';
+  import { getStudentContentLockReason } from '$features/ai-assistant/utils/content-ask-ai-bar';
   import { currentOrg } from '$lib/utils/store/org';
   import { snackbar } from '$features/ui/snackbar/store';
   import { RefreshPageData, UnsavedChanges } from '$features/ui';
@@ -33,6 +34,7 @@
   import * as Page from '@cio/ui/base/page';
   import * as UnderlineTabs from '@cio/ui/custom/underline-tabs';
   import { Empty } from '@cio/ui/custom/empty';
+  import { Spinner } from '@cio/ui/base/spinner';
   import { RoleBasedSecurity } from '$features/ui';
 
   import {
@@ -83,17 +85,19 @@
     )
   );
   const lessonTitle = $derived(currentLessonContentItem?.title || lessonApi.lesson?.title || 'Lesson');
-  const isTeacherLocked = $derived.by(() => {
-    if ($isOrgStudent && currentLessonContentItem) {
-      return (currentLessonContentItem.isUnlocked ?? false) === false;
+  const isCourseContentReady = $derived(courseApi.course?.id === courseId);
+  const contentLockReason = $derived(getStudentContentLockReason(courseApi.course, lessonId, ContentType.Lesson));
+  const isLessonAccessibleForStudent = $derived.by(() => {
+    if ($isOrgStudent !== true) {
+      return true;
     }
 
-    return (lessonApi.lesson?.isUnlocked ?? false) === false;
+    if (!currentLessonContentItem) {
+      return false;
+    }
+
+    return contentLockReason === null;
   });
-  const isProgressionLocked = $derived(
-    $isOrgStudent && currentLessonContentItem?.accessible === false && !isTeacherLocked
-  );
-  const isLessonUnlocked = $derived(!isTeacherLocked && !isProgressionLocked);
   const lessonSlug = $derived(lessonApi.lesson?.slug ?? '');
   const isPublicCourse = $derived(courseApi.course?.type === 'PUBLIC');
   const isLiveSessionLesson = $derived(Boolean(lessonApi.lesson?.callUrl && lessonApi.lesson?.lessonAt));
@@ -450,7 +454,7 @@
 <Page.Body>
   {#snippet child()}
     <div class={`overflow-x-hidden pb-6 ${mode === MODES.edit ? 'lg:w-full xl:w-11/12' : 'mx-auto w-full max-w-3xl'}`}>
-      {#if isLiveSessionLesson && mode === MODES.view && !($isOrgStudent && !isLessonUnlocked)}
+      {#if isLiveSessionLesson && mode === MODES.view && !($isOrgStudent === true && !isLessonAccessibleForStudent)}
         <div class="mb-4">
           <LiveSessionCard
             title={lessonTitle}
@@ -461,9 +465,13 @@
         </div>
       {/if}
 
-      {#if $isOrgStudent && !isLessonUnlocked}
+      {#if $isOrgStudent === true && !isCourseContentReady}
+        <div class="flex justify-center py-16">
+          <Spinner />
+        </div>
+      {:else if $isOrgStudent === true && !isLessonAccessibleForStudent}
         <StudentContentLockedNotice
-          reason={isProgressionLocked ? 'progression_locked' : 'teacher_locked'}
+          reason={contentLockReason === 'progression_locked' ? 'progression_locked' : 'teacher_locked'}
           contentType={ContentType.Lesson}
         />
       {:else if mode === MODES.edit}
@@ -541,6 +549,13 @@
             {/if}
           </div>
         {/key}
+      {:else if $isOrgStudent === true}
+        <Empty
+          title={$t('course.navItem.lessons.materials.no_content')}
+          icon={VideoIcon}
+          variant="page"
+          class="text-center"
+        />
       {:else}
         <Empty
           title={$t('course.navItem.lessons.materials.body_heading')}
@@ -554,11 +569,9 @@
           variant="page"
           class="text-center"
         >
-          {#if !$isOrgStudent}
-            <Button onclick={toggleMode}>
-              {$t('course.navItem.lessons.materials.get_started')}
-            </Button>
-          {/if}
+          <Button onclick={toggleMode}>
+            {$t('course.navItem.lessons.materials.get_started')}
+          </Button>
         </Empty>
       {/if}
     </div>

--- a/apps/dashboard/src/lib/features/course/pages/lesson.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/lesson.svelte
@@ -85,18 +85,30 @@
     )
   );
   const lessonTitle = $derived(currentLessonContentItem?.title || lessonApi.lesson?.title || 'Lesson');
-  const isCourseContentReady = $derived(courseApi.course?.id === courseId);
   const contentLockReason = $derived(getStudentContentLockReason(courseApi.course, lessonId, ContentType.Lesson));
-  const isLessonAccessibleForStudent = $derived.by(() => {
+  const isLessonLockedForStudent = $derived($isOrgStudent === true && contentLockReason !== null);
+  const isStudentLessonStateReady = $derived.by(() => {
     if ($isOrgStudent !== true) {
       return true;
     }
 
-    if (!currentLessonContentItem) {
+    if (courseApi.course?.id !== courseId) {
       return false;
     }
 
-    return contentLockReason === null;
+    if (contentLockReason !== null) {
+      return true;
+    }
+
+    if (currentLessonContentItem) {
+      return true;
+    }
+
+    if (lessonApi.lesson?.id === lessonId) {
+      return true;
+    }
+
+    return courseApi.course?.content != null;
   });
   const lessonSlug = $derived(lessonApi.lesson?.slug ?? '');
   const isPublicCourse = $derived(courseApi.course?.type === 'PUBLIC');
@@ -454,7 +466,7 @@
 <Page.Body>
   {#snippet child()}
     <div class={`overflow-x-hidden pb-6 ${mode === MODES.edit ? 'lg:w-full xl:w-11/12' : 'mx-auto w-full max-w-3xl'}`}>
-      {#if isLiveSessionLesson && mode === MODES.view && !($isOrgStudent === true && !isLessonAccessibleForStudent)}
+      {#if isLiveSessionLesson && mode === MODES.view && !isLessonLockedForStudent}
         <div class="mb-4">
           <LiveSessionCard
             title={lessonTitle}
@@ -465,15 +477,12 @@
         </div>
       {/if}
 
-      {#if $isOrgStudent === true && !isCourseContentReady}
+      {#if $isOrgStudent === true && !isStudentLessonStateReady}
         <div class="flex justify-center py-16">
           <Spinner />
         </div>
-      {:else if $isOrgStudent === true && !isLessonAccessibleForStudent}
-        <StudentContentLockedNotice
-          reason={contentLockReason === 'progression_locked' ? 'progression_locked' : 'teacher_locked'}
-          contentType={ContentType.Lesson}
-        />
+      {:else if isLessonLockedForStudent && contentLockReason}
+        <StudentContentLockedNotice reason={contentLockReason} contentType={ContentType.Lesson} />
       {:else if mode === MODES.edit}
         <UnderlineTabs.Root
           bind:value={currentTabValue}

--- a/apps/dashboard/src/routes/(app)/courses/[id]/lessons/[lessonId]/+page.svelte
+++ b/apps/dashboard/src/routes/(app)/courses/[id]/lessons/[lessonId]/+page.svelte
@@ -16,7 +16,16 @@
   let { data }: Props = $props();
 
   $effect(() => {
-    if (!data.lesson) return;
+    if (!data.lessonId) return;
+
+    if (!data.lesson) {
+      if (lessonApi.lesson?.id === data.lessonId) {
+        lessonApi.lesson = null;
+      }
+
+      return;
+    }
+
     const lesson = data.lesson;
     if (lessonApi.lesson?.id === lesson.id) return;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a student opened a locked lesson (teacher-locked or progression-blocked), the lesson page could fall through to the teacher empty state ("No note, video or slide added…" with **Get Started**) instead of the existing `StudentContentLockedNotice`.

## Root cause

Lesson access checks were implemented separately from the shared `getStudentContentLockReason` helper used by exercises and the course layout. That led to inconsistent lock detection—especially when course content was still loading, when navigating via prev/next on the app host, or when lock state came from the course content tree rather than the lesson API.

The sidebar also used `isStudentExperience` for lock blocking, which is `false` on the cloud app host even for enrolled students, so locked lessons could still be navigated to.

## Changes

- **Lesson page**: use `getStudentContentLockReason` and show `StudentContentLockedNotice` only when a real lock reason exists; show a student-appropriate "No Content" empty state for accessible-but-empty lessons; keep the teacher empty state for instructors only
- **Student loading**: wait for course/lesson state before dismissing the spinner (addresses Greptile feedback on premature `isCourseContentReady`)
- **Sidebar**: use `isOrgStudent` for student lock blocking so app-host students cannot open locked items from the tree
- **Navigation actions**: align mark-complete lock checks with the shared helper
- **Lesson route**: clear stale `lessonApi.lesson` when SSR returns no lesson (e.g. 403 for locked content)

## Greptile review

Addressed P1/P2 feedback: no longer defaulting to `teacher_locked` when the lesson is absent from the content tree; lock notice is shown only when `contentLockReason` is non-null.

## Test plan

- [ ] As a student, open a teacher-locked lesson → see "This content is locked" (not teacher empty state)
- [ ] As a student, open a progression-locked lesson → see "Complete previous content first"
- [ ] As a student on the app host (`/courses/...`), confirm locked sidebar items cannot be clicked
- [ ] As a teacher, open an empty locked lesson → still see teacher empty state with Get Started
- [ ] As a student, open an unlocked lesson with no materials → see "No Content" (no Get Started)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-033e3d1f-cc26-4a2e-93f4-1e6c23962126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-033e3d1f-cc26-4a2e-93f4-1e6c23962126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an issue where students viewing a locked or inaccessible lesson could see the teacher "empty state" (with "Get Started") instead of the `StudentContentLockedNotice`. The fix unifies lock detection via `getStudentContentLockReason` across the lesson page, navigation actions, and sidebar, adds a loading spinner to prevent premature state rendering, and clears stale `lessonApi.lesson` when SSR returns no lesson.

- **Lesson page** (`lesson.svelte`): replaces the old `isTeacherLocked`/`isProgressionLocked` pair with `contentLockReason` from the shared helper; adds `isStudentLessonStateReady` to defer rendering until course/lesson state is known; adds a student-appropriate "No Content" empty state for accessible-but-empty lessons.
- **Sidebar** (`course-content-tree.svelte`): switches `isLockedForStudent` from the unreliable `isStudent` prop to `$isOrgStudent` store so app-host students are correctly blocked from locked items.
- **Navigation actions** and **lesson route**: align mark-complete lock checks with the shared helper and clear stale lesson state on 403 responses.

<h3>Confidence Score: 5/5</h3>

The changes are a targeted, well-scoped fix: lock detection is now routed through a single shared helper across the lesson page, sidebar, and navigation actions, eliminating the inconsistencies that caused students to see the teacher empty state or a spurious lock notice.

All three independently-maintained lock-check paths now use the same getStudentContentLockReason helper, the sidebar's dependency on the unreliable isStudent prop is removed in favour of the $isOrgStudent store, and the +page.svelte stale-state clearing is a small, defensive addition. The only finding is a stylistic redundancy in the template condition that has no behavioural impact.

No files require special attention — the changes are consistent and the logic paths are straightforward to verify.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/course/pages/lesson.svelte | Core fix: replaces ad-hoc lock checks with shared helper; adds isStudentLessonStateReady spinner guard; adds student-only 'No Content' state. Minor redundant guard in the template. |
| apps/dashboard/src/lib/features/course/components/sidebar/course-content-tree.svelte | Switches isLockedForStudent from unreliable isStudent prop to $isOrgStudent store — correct fix for app-host students. |
| apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte | Replaces isTeacherLocked/isProgressionLocked pair with getStudentContentLockReason — consistent with other lock checks. |
| apps/dashboard/src/routes/(app)/courses/[id]/lessons/[lessonId]/+page.svelte | Clears stale lessonApi.lesson when SSR returns null (e.g. 403 for locked lesson) — prevents stale state from a previous lesson persisting. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Student opens lesson] --> B{courseApi.course.id
=== courseId?}
    B -- No --> SPIN[Show Spinner]
    B -- Yes --> C{contentLockReason
!== null?}
    C -- Yes --> LOCK[StudentContentLockedNotice]
    C -- No --> D{currentLessonContentItem
exists?}
    D -- Yes --> READY[State Ready]
    D -- No --> E{lessonApi.lesson.id
=== lessonId?}
    E -- Yes --> READY
    E -- No --> F{courseApi.course.content
!= null?}
    F -- Yes --> READY
    F -- No --> SPIN
    READY --> G{lessonApi.lesson
&& !isMaterialsEmpty?}
    G -- Yes --> CONTENT[Show Lesson Content]
    G -- No --> EMPTY[Student No Content state]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Student opens lesson] --> B{courseApi.course.id
=== courseId?}
    B -- No --> SPIN[Show Spinner]
    B -- Yes --> C{contentLockReason
!== null?}
    C -- Yes --> LOCK[StudentContentLockedNotice]
    C -- No --> D{currentLessonContentItem
exists?}
    D -- Yes --> READY[State Ready]
    D -- No --> E{lessonApi.lesson.id
=== lessonId?}
    E -- Yes --> READY
    E -- No --> F{courseApi.course.content
!= null?}
    F -- Yes --> READY
    F -- No --> SPIN
    READY --> G{lessonApi.lesson
&& !isMaterialsEmpty?}
    G -- Yes --> CONTENT[Show Lesson Content]
    G -- No --> EMPTY[Student No Content state]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): only show lesson lock no..."](https://github.com/classroomio/classroomio/commit/039c1e870a6c620dea8a03894e212d462d4fdceb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44730165)</sub>

<!-- /greptile_comment -->