### PR TITLE
feat(dashboard): show course progress in student sidebar

### DIFF
--- a/apps/dashboard/src/lib/features/course/components/course-header.svelte
+++ b/apps/dashboard/src/lib/features/course/components/course-header.svelte
@@ -17,6 +17,7 @@
   import { toggleAiAssistant } from '$features/ai-assistant/utils/store';
   import { openCoursePreview } from '$features/course/utils/course-preview';
   import { t } from '$lib/utils/functions/translations';
+  import CourseProgressPopover from './course-progress-popover.svelte';
   import CoursePublishBadge from './course-publish-badge.svelte';
   import CoursePublicBadge from './course-public-badge.svelte';
   import CourseContextMenuContent from './course-context-menu-content.svelte';
@@ -84,6 +85,10 @@
     </div>
 
     <span class="grow"></span>
+
+    {#if $isStudentExperience}
+      <CourseProgressPopover class="md:hidden" />
+    {/if}
 
     <Button
       size="sm"

--- a/apps/dashboard/src/lib/features/course/components/course-progress-card.svelte
+++ b/apps/dashboard/src/lib/features/course/components/course-progress-card.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { Progress } from '@cio/ui/base/progress';
+  import { t } from '$lib/utils/functions/translations';
+  import type { ContentProgress } from '$features/course/utils/content';
+
+  interface Props {
+    progress: ContentProgress;
+    class?: string;
+  }
+
+  let { progress, class: className = '' }: Props = $props();
+</script>
+
+<div class={className}>
+  <div class="flex items-baseline justify-between gap-2">
+    <span class="text-xs font-medium">{$t('course.sidebar.progress.title')}</span>
+    <span class="ui:text-primary text-xs font-semibold tabular-nums">{progress.percent}%</span>
+  </div>
+  <Progress value={progress.percent} max={100} class="ui:h-1.5 mt-2" />
+  <p class="ui:text-muted-foreground mt-2 truncate text-[11px]">
+    {$t('course.sidebar.progress.lessons', {
+      completed: progress.lessonsComplete,
+      total: progress.lessonsTotal
+    })}{#if progress.exercisesTotal > 0}
+      · {$t('course.sidebar.progress.exercises', {
+        completed: progress.exercisesComplete,
+        total: progress.exercisesTotal
+      })}{/if}
+  </p>
+</div>

--- a/apps/dashboard/src/lib/features/course/components/course-progress-popover.svelte
+++ b/apps/dashboard/src/lib/features/course/components/course-progress-popover.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import * as Popover from '@cio/ui/base/popover';
+  import { PercentRingProgress } from '@cio/ui/custom/percent-ring-progress';
+  import { courseApi } from '$features/course/api';
+  import { getCourseProgress } from '$features/course/utils/content';
+  import { t } from '$lib/utils/functions/translations';
+  import CourseProgressCard from './course-progress-card.svelte';
+
+  interface Props {
+    class?: string;
+  }
+
+  let { class: className = '' }: Props = $props();
+
+  const progress = $derived(getCourseProgress(courseApi.course));
+</script>
+
+{#if progress.total > 0}
+  <Popover.Root>
+    <Popover.Trigger class="shrink-0 {className}" aria-label={$t('course.sidebar.progress.title')}>
+      <PercentRingProgress value={progress.percent} size="small" />
+    </Popover.Trigger>
+    <Popover.Content class="w-72" align="end">
+      <CourseProgressCard {progress} />
+    </Popover.Content>
+  </Popover.Root>
+{/if}

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-content-tree.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-content-tree.svelte
@@ -8,7 +8,7 @@
   import * as Collapsible from '@cio/ui/base/collapsible';
   import { ContentType } from '@cio/utils/constants/content';
   import { courseApi } from '$features/course/api';
-  import { getContentRoute, getCourseContent } from '$features/course/utils/content';
+  import { getContentItemsProgress, getContentRoute, getCourseContent } from '$features/course/utils/content';
   import { CircleCheckIcon } from '$features/ui/icons';
   import { t } from '$lib/utils/functions/translations';
   import { IconButton } from '@cio/ui/custom/icon-button';
@@ -54,6 +54,18 @@
                   <span class="flex-1 truncate">{section.title}</span>
 
                   <div class="ml-auto flex items-center gap-1">
+                    {#if isStudent}
+                      {@const sectionProgress = getContentItemsProgress(section.items)}
+                      {#if sectionProgress.total > 0}
+                        <span
+                          class="shrink-0 text-[11px] font-medium tabular-nums {sectionProgress.percent === 100
+                            ? 'ui:text-green-600'
+                            : 'ui:text-muted-foreground'}"
+                        >
+                          {sectionProgress.percent}%
+                        </span>
+                      {/if}
+                    {/if}
                     {#if canOpenContentModal}
                       <IconButton
                         variant="ghost-outline"

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-logo.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-logo.svelte
@@ -3,7 +3,6 @@
   import * as Sidebar from '@cio/ui/base/sidebar';
   import { Skeleton } from '@cio/ui/base/skeleton';
   import { PercentRingProgress } from '@cio/ui/custom/percent-ring-progress';
-  import { useSidebar } from '@cio/ui/base/sidebar';
   import { resolve } from '$app/paths';
   import { currentOrg } from '$lib/utils/store/org';
   import { shortenName } from '$lib/utils/functions/string';
@@ -18,7 +17,7 @@
 
   let { isStudent = false }: Props = $props();
 
-  const sidebar = useSidebar();
+  const sidebar = Sidebar.useSidebar();
   const courseTitle = $derived(courseApi.course?.title);
   const courseId = $derived(courseApi.course?.id);
   const progress = $derived(getCourseProgress(courseApi.course));
@@ -43,9 +42,9 @@
                 <Skeleton class="h-4 w-24" />
               {/if}
               <span class="ui:text-muted-foreground truncate text-xs">
-                {$t('course.sidebar.progress.lessons_completed', {
-                  completed: progress.lessonsComplete,
-                  total: progress.lessonsTotal
+                {$t('course.sidebar.progress.completed', {
+                  completed: progress.completed,
+                  total: progress.total
                 })}
               </span>
             </div>

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-logo.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-logo.svelte
@@ -2,25 +2,54 @@
   import * as Avatar from '@cio/ui/base/avatar';
   import * as Sidebar from '@cio/ui/base/sidebar';
   import { Skeleton } from '@cio/ui/base/skeleton';
+  import { PercentRingProgress } from '@cio/ui/custom/percent-ring-progress';
+  import { useSidebar } from '@cio/ui/base/sidebar';
   import { resolve } from '$app/paths';
   import { currentOrg } from '$lib/utils/store/org';
   import { shortenName } from '$lib/utils/functions/string';
   import { courseApi } from '$features/course/api';
   import { getNavItemRoute } from '$features/course/utils/functions';
+  import { getCourseProgress } from '$features/course/utils/content';
+  import { t } from '$lib/utils/functions/translations';
 
+  interface Props {
+    isStudent?: boolean;
+  }
+
+  let { isStudent = false }: Props = $props();
+
+  const sidebar = useSidebar();
   const courseTitle = $derived(courseApi.course?.title);
   const courseId = $derived(courseApi.course?.id);
+  const progress = $derived(getCourseProgress(courseApi.course));
+  const isSidebarExpanded = $derived(sidebar.open || sidebar.isMobile);
+  const showProgressRing = $derived(isStudent && progress.total > 0 && isSidebarExpanded);
 </script>
 
 <Sidebar.Menu>
   <Sidebar.MenuItem>
     <Sidebar.MenuButton
-      size="sm"
+      size={showProgressRing ? 'lg' : 'sm'}
       class="ui:data-[state=open]:bg-sidebar-accent ui:data-[state=open]:text-sidebar-accent-foreground"
     >
       {#snippet child({ props })}
         <a href={courseId ? resolve(getNavItemRoute(courseId), {}) : '#'} {...props}>
-          {#if $currentOrg.name}
+          {#if showProgressRing}
+            <PercentRingProgress value={progress.percent} size="small" />
+            <div class="flex min-w-0 flex-1 flex-col">
+              {#if courseTitle}
+                <span class="truncate text-sm font-medium">{courseTitle}</span>
+              {:else}
+                <Skeleton class="h-4 w-24" />
+              {/if}
+              <span class="ui:text-muted-foreground truncate text-xs">
+                {$t('course.sidebar.progress.lessons_completed', {
+                  completed: progress.lessonsComplete,
+                  total: progress.lessonsTotal
+                })}
+              </span>
+            </div>
+          {:else if $currentOrg.name}
             <Avatar.Root class="flex size-6! items-center justify-center rounded-md!">
               <Avatar.Image src={$currentOrg.avatarUrl} alt={$currentOrg.name} />
               <Avatar.Fallback class="rounded-md! text-xs">{shortenName($currentOrg.name)}</Avatar.Fallback>

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/state';
   import * as Sidebar from '@cio/ui/base/sidebar';
   import { Skeleton } from '@cio/ui/base/skeleton';
+  import { Progress } from '@cio/ui/base/progress';
   import { profile } from '$lib/utils/store/user';
   import { orgs } from '$lib/utils/store/org';
   import { isStudentExperience } from '$lib/utils/store/app';
@@ -11,6 +12,8 @@
   import SidebarSkeleton from '$features/ui/sidebar/sidebar-skeleton.svelte';
   import PoweredBy from '$features/ui/powered-by.svelte';
   import { courseApi } from '$features/course/api';
+  import { getCourseProgress } from '$features/course/utils/content';
+  import { t } from '$lib/utils/functions/translations';
   import { useSidebar } from '@cio/ui/base/sidebar';
   import { startResizablePanelDrag } from '$lib/utils/functions/resizable-panel';
   import { COURSE_SIDEBAR_DEFAULT_WIDTH, COURSE_SIDEBAR_MAX_WIDTH, COURSE_SIDEBAR_MIN_WIDTH } from './constants';
@@ -45,6 +48,10 @@
   let stopSidebarResize: (() => void) | null = null;
 
   const attributionCourseSlug = $derived(courseApi.course?.slug ?? null);
+  const courseProgress = $derived(getCourseProgress(courseApi.course));
+  const showCourseProgress = $derived(
+    $isStudentExperience && isCourseReady && sidebar.open && !sidebar.isMobile && courseProgress.total > 0
+  );
 
   function clampSidebarWidth(width: number) {
     return Math.min(COURSE_SIDEBAR_MAX_WIDTH, Math.max(COURSE_SIDEBAR_MIN_WIDTH, width));
@@ -114,7 +121,7 @@
 {:else}
   <Sidebar.Root collapsible="icon" class="z-app-bar-elevated!" mobileOverlayClass="z-app-bar-elevated!">
     <Sidebar.Header>
-      <CourseSidebarLogo />
+      <CourseSidebarLogo isStudent={$isStudentExperience} />
     </Sidebar.Header>
 
     <Sidebar.Content>
@@ -143,6 +150,25 @@
     <Sidebar.Rail onclick={handleRailClick} onpointerdown={handleRailPointerDown} />
 
     <Sidebar.Footer>
+      {#if showCourseProgress}
+        <div class="ui:border-sidebar-border ui:bg-sidebar-accent/50 rounded-lg border p-3">
+          <div class="flex items-baseline justify-between gap-2">
+            <span class="text-xs font-medium">{$t('course.sidebar.progress.title')}</span>
+            <span class="ui:text-primary text-xs font-semibold tabular-nums">{courseProgress.percent}%</span>
+          </div>
+          <Progress value={courseProgress.percent} max={100} class="ui:h-1.5 mt-2" />
+          <p class="ui:text-muted-foreground mt-2 truncate text-[11px]">
+            {$t('course.sidebar.progress.lessons', {
+              completed: courseProgress.lessonsComplete,
+              total: courseProgress.lessonsTotal
+            })}{#if courseProgress.exercisesTotal > 0}
+              · {$t('course.sidebar.progress.exercises', {
+                completed: courseProgress.exercisesComplete,
+                total: courseProgress.exercisesTotal
+              })}{/if}
+          </p>
+        </div>
+      {/if}
       <PoweredBy
         variant="sidebar"
         sidebarUtmSource="lms-course-sidebar"

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar.svelte
@@ -3,7 +3,6 @@
   import { page } from '$app/state';
   import * as Sidebar from '@cio/ui/base/sidebar';
   import { Skeleton } from '@cio/ui/base/skeleton';
-  import { Progress } from '@cio/ui/base/progress';
   import { profile } from '$lib/utils/store/user';
   import { orgs } from '$lib/utils/store/org';
   import { isStudentExperience } from '$lib/utils/store/app';
@@ -13,8 +12,8 @@
   import PoweredBy from '$features/ui/powered-by.svelte';
   import { courseApi } from '$features/course/api';
   import { getCourseProgress } from '$features/course/utils/content';
-  import { t } from '$lib/utils/functions/translations';
   import { useSidebar } from '@cio/ui/base/sidebar';
+  import CourseProgressCard from '$features/course/components/course-progress-card.svelte';
   import { startResizablePanelDrag } from '$lib/utils/functions/resizable-panel';
   import { COURSE_SIDEBAR_DEFAULT_WIDTH, COURSE_SIDEBAR_MAX_WIDTH, COURSE_SIDEBAR_MIN_WIDTH } from './constants';
 
@@ -151,23 +150,10 @@
 
     <Sidebar.Footer>
       {#if showCourseProgress}
-        <div class="ui:border-sidebar-border ui:bg-sidebar-accent/50 rounded-lg border p-3">
-          <div class="flex items-baseline justify-between gap-2">
-            <span class="text-xs font-medium">{$t('course.sidebar.progress.title')}</span>
-            <span class="ui:text-primary text-xs font-semibold tabular-nums">{courseProgress.percent}%</span>
-          </div>
-          <Progress value={courseProgress.percent} max={100} class="ui:h-1.5 mt-2" />
-          <p class="ui:text-muted-foreground mt-2 truncate text-[11px]">
-            {$t('course.sidebar.progress.lessons', {
-              completed: courseProgress.lessonsComplete,
-              total: courseProgress.lessonsTotal
-            })}{#if courseProgress.exercisesTotal > 0}
-              · {$t('course.sidebar.progress.exercises', {
-                completed: courseProgress.exercisesComplete,
-                total: courseProgress.exercisesTotal
-              })}{/if}
-          </p>
-        </div>
+        <CourseProgressCard
+          progress={courseProgress}
+          class="ui:border-sidebar-border ui:bg-sidebar-accent/50 rounded-lg border p-3"
+        />
       {/if}
       <PoweredBy
         variant="sidebar"

--- a/apps/dashboard/src/lib/features/course/utils/content.ts
+++ b/apps/dashboard/src/lib/features/course/utils/content.ts
@@ -56,6 +56,42 @@ export function getCourseContent(course: Course | null) {
 
 const NAVIGABLE_CONTENT_TYPES = [CourseContentType.Lesson, CourseContentType.Exercise] as const;
 
+export type ContentProgress = {
+  lessonsTotal: number;
+  lessonsComplete: number;
+  exercisesTotal: number;
+  exercisesComplete: number;
+  total: number;
+  completed: number;
+  percent: number;
+};
+
+export function getContentItemsProgress(items: ContentItem[]): ContentProgress {
+  const lessons = items.filter((item) => item.type === CourseContentType.Lesson);
+  const exercises = items.filter((item) => item.type === CourseContentType.Exercise);
+  const lessonsComplete = lessons.filter((item) => item.isComplete).length;
+  const exercisesComplete = exercises.filter((item) => item.isComplete).length;
+  const total = lessons.length + exercises.length;
+  const completed = lessonsComplete + exercisesComplete;
+  const percent = total === 0 ? 0 : Math.round((completed / total) * 100);
+
+  return {
+    lessonsTotal: lessons.length,
+    lessonsComplete,
+    exercisesTotal: exercises.length,
+    exercisesComplete,
+    total,
+    completed,
+    percent
+  };
+}
+
+export function getCourseProgress(course: Course | null): ContentProgress {
+  const content = getCourseContent(course);
+  const items = content.grouped ? content.sections.flatMap((section) => section.items) : content.items;
+  return getContentItemsProgress(items);
+}
+
 export function getOrderedNavigableContent(course: Course | null): ContentItem[] {
   const content = getCourseContent(course);
   const items = content.grouped ? content.sections.flatMap((s) => s.items) : content.items;

--- a/apps/dashboard/src/lib/utils/translations/da.json
+++ b/apps/dashboard/src/lib/utils/translations/da.json
@@ -2373,7 +2373,7 @@
       },
       "progress": {
         "title": "Dine fremskridt",
-        "lessons_completed": "{completed} af {total} lektioner fuldført",
+        "completed": "{completed} af {total} fuldført",
         "lessons": "{completed} af {total} lektioner",
         "exercises": "{completed} af {total} øvelser"
       }

--- a/apps/dashboard/src/lib/utils/translations/da.json
+++ b/apps/dashboard/src/lib/utils/translations/da.json
@@ -2370,6 +2370,12 @@
         "title": "Overholdelse",
         "due_date": "Forfalder",
         "valid_until": "Gælder indtil kl"
+      },
+      "progress": {
+        "title": "Dine fremskridt",
+        "lessons_completed": "{completed} af {total} lektioner fuldført",
+        "lessons": "{completed} af {total} lektioner",
+        "exercises": "{completed} af {total} øvelser"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/de.json
+++ b/apps/dashboard/src/lib/utils/translations/de.json
@@ -2373,7 +2373,7 @@
       },
       "progress": {
         "title": "Ihr Fortschritt",
-        "lessons_completed": "{completed} von {total} Lektionen abgeschlossen",
+        "completed": "{completed} von {total} abgeschlossen",
         "lessons": "{completed} von {total} Lektionen",
         "exercises": "{completed} von {total} Übungen"
       }

--- a/apps/dashboard/src/lib/utils/translations/de.json
+++ b/apps/dashboard/src/lib/utils/translations/de.json
@@ -2370,6 +2370,12 @@
         "title": "Compliance",
         "due_date": "Fällig",
         "valid_until": "Gültig bis"
+      },
+      "progress": {
+        "title": "Ihr Fortschritt",
+        "lessons_completed": "{completed} von {total} Lektionen abgeschlossen",
+        "lessons": "{completed} von {total} Lektionen",
+        "exercises": "{completed} von {total} Übungen"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/en.json
+++ b/apps/dashboard/src/lib/utils/translations/en.json
@@ -2006,7 +2006,7 @@
       },
       "progress": {
         "title": "Your progress",
-        "lessons_completed": "{completed} of {total} lessons completed",
+        "completed": "{completed} of {total} completed",
         "lessons": "{completed} of {total} lessons",
         "exercises": "{completed} of {total} exercises"
       }

--- a/apps/dashboard/src/lib/utils/translations/en.json
+++ b/apps/dashboard/src/lib/utils/translations/en.json
@@ -2003,6 +2003,12 @@
       "content_count": {
         "lessons": "{count} lessons",
         "exercises": "{count} exercises"
+      },
+      "progress": {
+        "title": "Your progress",
+        "lessons_completed": "{completed} of {total} lessons completed",
+        "lessons": "{completed} of {total} lessons",
+        "exercises": "{completed} of {total} exercises"
       }
     },
     "search": {

--- a/apps/dashboard/src/lib/utils/translations/es.json
+++ b/apps/dashboard/src/lib/utils/translations/es.json
@@ -2370,6 +2370,12 @@
         "title": "Cumplimiento",
         "due_date": "debido",
         "valid_until": "Válido hasta"
+      },
+      "progress": {
+        "title": "Tu progreso",
+        "lessons_completed": "{completed} de {total} lecciones completadas",
+        "lessons": "{completed} de {total} lecciones",
+        "exercises": "{completed} de {total} ejercicios"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/es.json
+++ b/apps/dashboard/src/lib/utils/translations/es.json
@@ -2373,7 +2373,7 @@
       },
       "progress": {
         "title": "Tu progreso",
-        "lessons_completed": "{completed} de {total} lecciones completadas",
+        "completed": "{completed} de {total} completados",
         "lessons": "{completed} de {total} lecciones",
         "exercises": "{completed} de {total} ejercicios"
       }

--- a/apps/dashboard/src/lib/utils/translations/fr.json
+++ b/apps/dashboard/src/lib/utils/translations/fr.json
@@ -2370,6 +2370,12 @@
         "title": "Conformité",
         "due_date": "Due",
         "valid_until": "Valable jusqu'au"
+      },
+      "progress": {
+        "title": "Votre progression",
+        "lessons_completed": "{completed} sur {total} leçons terminées",
+        "lessons": "{completed} sur {total} leçons",
+        "exercises": "{completed} sur {total} exercices"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/fr.json
+++ b/apps/dashboard/src/lib/utils/translations/fr.json
@@ -2373,7 +2373,7 @@
       },
       "progress": {
         "title": "Votre progression",
-        "lessons_completed": "{completed} sur {total} leçons terminées",
+        "completed": "{completed} sur {total} terminés",
         "lessons": "{completed} sur {total} leçons",
         "exercises": "{completed} sur {total} exercices"
       }

--- a/apps/dashboard/src/lib/utils/translations/hi.json
+++ b/apps/dashboard/src/lib/utils/translations/hi.json
@@ -2373,7 +2373,7 @@
       },
       "progress": {
         "title": "आपकी प्रगति",
-        "lessons_completed": "{total} में से {completed} पाठ पूर्ण",
+        "completed": "{total} में से {completed} पूर्ण",
         "lessons": "{total} में से {completed} पाठ",
         "exercises": "{total} में से {completed} अभ्यास"
       }

--- a/apps/dashboard/src/lib/utils/translations/hi.json
+++ b/apps/dashboard/src/lib/utils/translations/hi.json
@@ -2370,6 +2370,12 @@
         "title": "अनुपालन",
         "due_date": "देय",
         "valid_until": "तक वैध है"
+      },
+      "progress": {
+        "title": "आपकी प्रगति",
+        "lessons_completed": "{total} में से {completed} पाठ पूर्ण",
+        "lessons": "{total} में से {completed} पाठ",
+        "exercises": "{total} में से {completed} अभ्यास"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/pl.json
+++ b/apps/dashboard/src/lib/utils/translations/pl.json
@@ -2370,6 +2370,12 @@
         "title": "Zgodność",
         "due_date": "Termin",
         "valid_until": "Ważne do"
+      },
+      "progress": {
+        "title": "Twój postęp",
+        "lessons_completed": "Ukończono {completed} z {total} lekcji",
+        "lessons": "{completed} z {total} lekcji",
+        "exercises": "{completed} z {total} ćwiczeń"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/pl.json
+++ b/apps/dashboard/src/lib/utils/translations/pl.json
@@ -2373,7 +2373,7 @@
       },
       "progress": {
         "title": "Twój postęp",
-        "lessons_completed": "Ukończono {completed} z {total} lekcji",
+        "completed": "Ukończono {completed} z {total}",
         "lessons": "{completed} z {total} lekcji",
         "exercises": "{completed} z {total} ćwiczeń"
       }

--- a/apps/dashboard/src/lib/utils/translations/pt.json
+++ b/apps/dashboard/src/lib/utils/translations/pt.json
@@ -2373,7 +2373,7 @@
       },
       "progress": {
         "title": "Seu progresso",
-        "lessons_completed": "{completed} de {total} aulas concluídas",
+        "completed": "{completed} de {total} concluídos",
         "lessons": "{completed} de {total} aulas",
         "exercises": "{completed} de {total} exercícios"
       }

--- a/apps/dashboard/src/lib/utils/translations/pt.json
+++ b/apps/dashboard/src/lib/utils/translations/pt.json
@@ -2370,6 +2370,12 @@
         "title": "Conformidade",
         "due_date": "Devido",
         "valid_until": "Válido até"
+      },
+      "progress": {
+        "title": "Seu progresso",
+        "lessons_completed": "{completed} de {total} aulas concluídas",
+        "lessons": "{completed} de {total} aulas",
+        "exercises": "{completed} de {total} exercícios"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/ru.json
+++ b/apps/dashboard/src/lib/utils/translations/ru.json
@@ -2373,7 +2373,7 @@
       },
       "progress": {
         "title": "Ваш прогресс",
-        "lessons_completed": "Пройдено {completed} из {total} уроков",
+        "completed": "Завершено {completed} из {total}",
         "lessons": "{completed} из {total} уроков",
         "exercises": "{completed} из {total} упражнений"
       }

--- a/apps/dashboard/src/lib/utils/translations/ru.json
+++ b/apps/dashboard/src/lib/utils/translations/ru.json
@@ -2370,6 +2370,12 @@
         "title": "Соответствие",
         "due_date": "Срок погашения",
         "valid_until": "Действительно до"
+      },
+      "progress": {
+        "title": "Ваш прогресс",
+        "lessons_completed": "Пройдено {completed} из {total} уроков",
+        "lessons": "{completed} из {total} уроков",
+        "exercises": "{completed} из {total} упражнений"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/vi.json
+++ b/apps/dashboard/src/lib/utils/translations/vi.json
@@ -2373,7 +2373,7 @@
       },
       "progress": {
         "title": "Tiến độ của bạn",
-        "lessons_completed": "Đã hoàn thành {completed} trong số {total} bài học",
+        "completed": "Đã hoàn thành {completed} trong số {total}",
         "lessons": "{completed} trong số {total} bài học",
         "exercises": "{completed} trong số {total} bài tập"
       }

--- a/apps/dashboard/src/lib/utils/translations/vi.json
+++ b/apps/dashboard/src/lib/utils/translations/vi.json
@@ -2370,6 +2370,12 @@
         "title": "Tuân thủ",
         "due_date": "Đến hạn",
         "valid_until": "Có hiệu lực cho đến khi"
+      },
+      "progress": {
+        "title": "Tiến độ của bạn",
+        "lessons_completed": "Đã hoàn thành {completed} trong số {total} bài học",
+        "lessons": "{completed} trong số {total} bài học",
+        "exercises": "{completed} trong số {total} bài tập"
       }
     },
     "navItems": {


### PR DESCRIPTION
## Summary

Implements the [Student Course Progress Bar](https://feedback.classroomio.com/board/p/student-course-progress-bar) feedback request: students can now see how far they've come in a course directly in the sidebar.

Four student-only indicators, all derived from the existing per-item `isComplete` flags on `courseApi.course.content` (so they update live when a lesson is marked complete or auto-completes via video watch):

- **Header ring** — the course title row shows a percent ring (reusing `PercentRingProgress`) with a "X of Y lessons completed" subtitle. Teachers/admins and the collapsed icon sidebar keep the org-avatar layout.
- **Per-section percentages** — each section header in the content tree shows its own completion percent, turning green at 100%.
- **Footer progress card** — a "Your progress" card above the PoweredBy footer with the overall percent, a linear progress bar, and a "X of Y lessons · A of B exercises" breakdown (exercise part hidden when the course has none). Desktop only.
- **Mobile header ring** — on mobile (where the sidebar footer card is hidden), a progress ring appears in the course top nav beside the Assistant button, mirroring the org nav setup ring; tapping it opens a popover with the same progress card.

## Changes

- `features/course/utils/content.ts` — new `getContentItemsProgress` / `getCourseProgress` helpers (lessons + exercises counted).
- `course-sidebar-logo.svelte` — student header variant with ring + subtitle.
- `course-content-tree.svelte` — per-section percent badge.
- `course-sidebar.svelte` — footer progress card (shared `course-progress-card` component), `isStudent` passed to the logo.
- `course-progress-card.svelte` / `course-progress-popover.svelte` — new shared card + ring/popover components.
- `course-header.svelte` — mobile-only progress popover for students.
- Translations — 4 new keys under `course.sidebar.progress` in all 10 locales, placeholders verified.

## Testing

- `svelte-check`: no errors in touched files (pre-existing baseline unchanged).
- `pnpm format:check` passes; locale placeholder `{completed}`/`{total}` integrity manually verified in all locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds four student-facing course progress indicators to the sidebar and mobile header — all derived from the existing per-item `isComplete` flags so they update live without new data fetching. The implementation is clean, well-scoped to students, and the previously-reported ring/subtitle mismatch and duplicate import have both been resolved.

- **New helpers** (`getContentItemsProgress` / `getCourseProgress`) are pure functions with zero-division guards and no async inside object literals, consistent with the codebase's code-style rule.
- **Progress surfaces**: header ring + subtitle (sidebar expanded), per-section percentage badges (grouped courses), desktop footer card, and mobile popover — each gated behind the appropriate `isStudent` / `isMobile` / `total > 0` conditions.
- **Translations**: all 10 locales carry correct target-language strings; Hindi's reversed `{total}`/`{completed}` order is intentional natural-language word order and works correctly with named placeholder substitution.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive, student-only, and derived from already-loaded data with no new API calls.

The new utilities are pure and well-guarded, all four progress surfaces gate correctly on student role and content availability, and the two issues flagged in the previous review round have been fixed. The only remaining note is a cosmetic edge case in CourseProgressCard (lessons line visible when lessonsTotal is zero) that would only surface for exercise-only courses.

course-progress-card.svelte — the lessons subtitle line has no lessonsTotal > 0 guard, unlike the exercises line which is already gated.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/course/utils/content.ts | Adds ContentProgress type and two pure helper functions (getContentItemsProgress, getCourseProgress); zero-division guarded, no async in object literals, correctly reuses getCourseContent. |
| apps/dashboard/src/lib/features/course/components/course-progress-card.svelte | New shared progress card component; exercises part is correctly guarded by exercisesTotal > 0 but the lessons line has no equivalent guard, producing '0 of 0 lessons' for exercise-only courses. |
| apps/dashboard/src/lib/features/course/components/course-progress-popover.svelte | New mobile popover wrapping PercentRingProgress + CourseProgressCard; correctly gated on progress.total > 0 and uses $derived for reactivity. |
| apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-logo.svelte | Student header variant with progress ring; previously-flagged issues (mismatched ring/subtitle counts, duplicate import) are both resolved — subtitle now uses all-content counts and Sidebar.useSidebar() is called via namespace. |
| apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar.svelte | Footer progress card added behind showCourseProgress guard (student + desktop + course ready + has content); clean $derived composition with no async in object literals. |
| apps/dashboard/src/lib/features/course/components/sidebar/course-content-tree.svelte | Per-section percentage badge added via {@const} inside the grouped sections loop; only visible to students when sectionProgress.total > 0, turns green at 100%. |
| apps/dashboard/src/lib/features/course/components/course-header.svelte | Mobile-only (md:hidden) progress popover injected for students between the spacer and the AI assistant button; minimal, clean change. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CA[courseApi.course] --> GCP[getCourseProgress]
    CA --> GCIP[getContentItemsProgress]

    GCP -->|"all sections flatMap"| GCIP
    GCIP -->|"ContentProgress"| CP

    CP[ContentProgress\npercent · completed · total\nlessonsComplete · lessonsTotal\nexercisesComplete · exercisesTotal]

    CP --> Logo["CourseSidebarLogo\n(header ring + subtitle)\ndesktop expanded only"]
    CP --> SidebarCard["CourseProgressCard in sidebar footer\n(desktop, sidebar open, student)"]
    CP --> Popover["CourseProgressPopover\n(mobile header, md:hidden)"]

    GCIP -->|"section.items"| SectionBadge["Per-section % badge\nin CourseContentTree\n(grouped courses only)"]

    Logo --> CourseSidebarLogo["PercentRingProgress\n+ title + subtitle"]
    SidebarCard --> CPC["CourseProgressCard\n% bar + lessons · exercises"]
    Popover --> Ring["PercentRingProgress trigger"]
    Popover --> PopCard["CourseProgressCard in popover"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    CA[courseApi.course] --> GCP[getCourseProgress]
    CA --> GCIP[getContentItemsProgress]

    GCP -->|"all sections flatMap"| GCIP
    GCIP -->|"ContentProgress"| CP

    CP[ContentProgress\npercent · completed · total\nlessonsComplete · lessonsTotal\nexercisesComplete · exercisesTotal]

    CP --> Logo["CourseSidebarLogo\n(header ring + subtitle)\ndesktop expanded only"]
    CP --> SidebarCard["CourseProgressCard in sidebar footer\n(desktop, sidebar open, student)"]
    CP --> Popover["CourseProgressPopover\n(mobile header, md:hidden)"]

    GCIP -->|"section.items"| SectionBadge["Per-section % badge\nin CourseContentTree\n(grouped courses only)"]

    Logo --> CourseSidebarLogo["PercentRingProgress\n+ title + subtitle"]
    SidebarCard --> CPC["CourseProgressCard\n% bar + lessons · exercises"]
    Popover --> Ring["PercentRingProgress trigger"]
    Popover --> PopCard["CourseProgressCard in popover"]
```

</a>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;release&#39; into feat/student..."](https://github.com/classroomio/classroomio/commit/97316ae66109a81a8f67a1c0b0e290748cea5b3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44731766)</sub>

<!-- /greptile_comment -->