### PR TITLE
chore(release): student course progress, email preference table, token auth docs & lesson lock fix

### DIFF
--- a/apps/api/src/routes/organization/member-email-notifications.ts
+++ b/apps/api/src/routes/organization/member-email-notifications.ts
@@ -1,0 +1,48 @@
+import { Hono } from '@api/utils/hono';
+import { authMiddleware } from '@api/middlewares/auth';
+import { orgMemberMiddleware } from '@api/middlewares/org-member';
+import { handleError } from '@api/utils/errors';
+import { zValidator } from '@hono/zod-validator';
+import { ZMemberEmailNotificationPreferencesUpdate } from '@cio/utils/validation/notifications';
+
+import {
+  getMemberEmailNotificationPreferences,
+  updateMemberEmailNotificationPreferences
+} from '@api/services/notification/member-email-notifications';
+
+/**
+ * Per-org personal email notification preferences for the authenticated member.
+ *
+ * GET /organization/member/email-notifications
+ * PUT /organization/member/email-notifications
+ */
+export const organizationMemberEmailNotificationsRouter = new Hono()
+  .get('/', authMiddleware, orgMemberMiddleware, async (c) => {
+    try {
+      const user = c.get('user')!;
+      const orgId = c.req.header('cio-org-id')!;
+      const preferences = await getMemberEmailNotificationPreferences(user.id, orgId);
+
+      return c.json({ success: true as const, data: preferences });
+    } catch (error) {
+      return handleError(c, error, 'Failed to fetch email notification preferences');
+    }
+  })
+  .put(
+    '/',
+    authMiddleware,
+    orgMemberMiddleware,
+    zValidator('json', ZMemberEmailNotificationPreferencesUpdate),
+    async (c) => {
+      try {
+        const user = c.get('user')!;
+        const orgId = c.req.header('cio-org-id')!;
+        const preferences = c.req.valid('json');
+        const updated = await updateMemberEmailNotificationPreferences(user.id, orgId, preferences);
+
+        return c.json({ success: true as const, data: updated });
+      } catch (error) {
+        return handleError(c, error, 'Failed to update email notification preferences');
+      }
+    }
+  );

--- a/apps/api/src/routes/organization/organization.ts
+++ b/apps/api/src/routes/organization/organization.ts
@@ -52,6 +52,7 @@ import { TOrganization } from '@db/types';
 import { assetsRouter } from '@api/routes/organization/assets';
 import { autoJoinOrg } from '@api/services/organization/auto-join';
 import { organizationAiTutorRouter } from '@api/routes/organization/ai-tutor';
+import { organizationMemberEmailNotificationsRouter } from '@api/routes/organization/member-email-notifications';
 import { authMiddleware } from '@api/middlewares/auth';
 import { authOrApiKeyMiddleware } from '@api/middlewares/auth-or-api-key';
 import { authOrAutomationKeyMiddleware } from '@api/middlewares/auth-or-automation-key';
@@ -768,4 +769,5 @@ export const organizationRouter = new Hono()
   .route('/widgets', widgetsRouter)
   .route('/assets', assetsRouter)
   .route('/ai-tutor', organizationAiTutorRouter)
+  .route('/member/email-notifications', organizationMemberEmailNotificationsRouter)
   .route('/:orgId/quiz', quizRouter);

--- a/apps/api/src/services/account/profile.ts
+++ b/apps/api/src/services/account/profile.ts
@@ -100,16 +100,7 @@ export async function getAccountData(userId: string): Promise<GetAccountDataResu
  */
 export async function updateUser(userId: string, data: TUpdateProfile) {
   try {
-    const { emailNotifications, ...profileFields } = data;
-    const updatePayload: Partial<Omit<TProfile, 'id' | 'email' | 'createdAt' | 'updatedAt'>> = {
-      ...profileFields
-    };
-
-    if (emailNotifications !== undefined) {
-      updatePayload.settings = { emailNotifications };
-    }
-
-    const updatedProfile = await updateProfile(userId, updatePayload);
+    const updatedProfile = await updateProfile(userId, data);
 
     if (!updatedProfile) {
       throw new AppError(`Profile not found for user ID: ${userId}`, ErrorCodes.PROFILE_NOT_FOUND, 404);

--- a/apps/api/src/services/notification/member-email-notifications.ts
+++ b/apps/api/src/services/notification/member-email-notifications.ts
@@ -1,0 +1,29 @@
+import { AppError, ErrorCodes } from '@api/utils/errors';
+import {
+  getOrganizationMemberEmailNotificationsForApi,
+  upsertOrganizationMemberEmailNotifications
+} from '@cio/db/queries/notifications';
+import { memberEmailNotificationRowToApiResponse } from '@cio/utils/notifications';
+import type { TMemberEmailNotificationPreferencesUpdate } from '@cio/utils/validation/notifications';
+
+export async function getMemberEmailNotificationPreferences(profileId: string, organizationId: string) {
+  return getOrganizationMemberEmailNotificationsForApi(profileId, organizationId);
+}
+
+export async function updateMemberEmailNotificationPreferences(
+  profileId: string,
+  organizationId: string,
+  preferences: TMemberEmailNotificationPreferencesUpdate
+) {
+  try {
+    const updated = await upsertOrganizationMemberEmailNotifications(profileId, organizationId, preferences);
+
+    return memberEmailNotificationRowToApiResponse(updated);
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Organization member not found') {
+      throw new AppError('Organization member not found', ErrorCodes.NOT_FOUND, 404);
+    }
+
+    throw error;
+  }
+}

--- a/apps/dashboard/src/lib/features/auth/api/profile.svelte.ts
+++ b/apps/dashboard/src/lib/features/auth/api/profile.svelte.ts
@@ -137,30 +137,6 @@ export class ProfileApi extends BaseApiWithErrors {
     }
   }
 
-  async updateEmailNotifications(emailNotifications: Record<string, boolean>) {
-    try {
-      this.isLoading = true;
-      this.errors = {};
-      this.success = false;
-
-      await this.execute<typeof classroomio.account.profile.$put>({
-        requestFn: () => classroomio.account.profile.$put({ json: { emailNotifications } }),
-        logContext: 'updating email notification preferences',
-        onSuccess: (response) => {
-          profileStore.update((_profile) => ({
-            ..._profile,
-            ...response.profile
-          }));
-          this.success = true;
-        }
-      });
-    } catch (error) {
-      this.handleError(error);
-    } finally {
-      this.isLoading = false;
-    }
-  }
-
   async changeEmail(fields: TChangeEmailForm) {
     // Validate email format
     const result = ZChangeEmail.safeParse({ newEmail: fields.newEmail });

--- a/apps/dashboard/src/lib/features/course/components/course-header.svelte
+++ b/apps/dashboard/src/lib/features/course/components/course-header.svelte
@@ -17,6 +17,7 @@
   import { toggleAiAssistant } from '$features/ai-assistant/utils/store';
   import { openCoursePreview } from '$features/course/utils/course-preview';
   import { t } from '$lib/utils/functions/translations';
+  import CourseProgressPopover from './course-progress-popover.svelte';
   import CoursePublishBadge from './course-publish-badge.svelte';
   import CoursePublicBadge from './course-public-badge.svelte';
   import CourseContextMenuContent from './course-context-menu-content.svelte';
@@ -84,6 +85,10 @@
     </div>
 
     <span class="grow"></span>
+
+    {#if $isStudentExperience}
+      <CourseProgressPopover class="md:hidden" />
+    {/if}
 
     <Button
       size="sm"

--- a/apps/dashboard/src/lib/features/course/components/course-progress-card.svelte
+++ b/apps/dashboard/src/lib/features/course/components/course-progress-card.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { Progress } from '@cio/ui/base/progress';
+  import { t } from '$lib/utils/functions/translations';
+  import type { ContentProgress } from '$features/course/utils/content';
+
+  interface Props {
+    progress: ContentProgress;
+    class?: string;
+  }
+
+  let { progress, class: className = '' }: Props = $props();
+</script>
+
+<div class={className}>
+  <div class="flex items-baseline justify-between gap-2">
+    <span class="text-xs font-medium">{$t('course.sidebar.progress.title')}</span>
+    <span class="ui:text-primary text-xs font-semibold tabular-nums">{progress.percent}%</span>
+  </div>
+  <Progress value={progress.percent} max={100} class="ui:h-1.5 mt-2" />
+  <p class="ui:text-muted-foreground mt-2 truncate text-[11px]">
+    {$t('course.sidebar.progress.lessons', {
+      completed: progress.lessonsComplete,
+      total: progress.lessonsTotal
+    })}{#if progress.exercisesTotal > 0}
+      · {$t('course.sidebar.progress.exercises', {
+        completed: progress.exercisesComplete,
+        total: progress.exercisesTotal
+      })}{/if}
+  </p>
+</div>

--- a/apps/dashboard/src/lib/features/course/components/course-progress-popover.svelte
+++ b/apps/dashboard/src/lib/features/course/components/course-progress-popover.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import * as Popover from '@cio/ui/base/popover';
+  import { PercentRingProgress } from '@cio/ui/custom/percent-ring-progress';
+  import { courseApi } from '$features/course/api';
+  import { getCourseProgress } from '$features/course/utils/content';
+  import { t } from '$lib/utils/functions/translations';
+  import CourseProgressCard from './course-progress-card.svelte';
+
+  interface Props {
+    class?: string;
+  }
+
+  let { class: className = '' }: Props = $props();
+
+  const progress = $derived(getCourseProgress(courseApi.course));
+</script>
+
+{#if progress.total > 0}
+  <Popover.Root>
+    <Popover.Trigger class="shrink-0 {className}" aria-label={$t('course.sidebar.progress.title')}>
+      <PercentRingProgress value={progress.percent} size="small" />
+    </Popover.Trigger>
+    <Popover.Content class="w-72" align="end">
+      <CourseProgressCard {progress} />
+    </Popover.Content>
+  </Popover.Root>
+{/if}

--- a/apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte
+++ b/apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte
@@ -8,6 +8,7 @@
   import * as Tooltip from '@cio/ui/base/tooltip';
   import { PercentRingProgress } from '@cio/ui/custom/percent-ring-progress';
   import { isOrgStudent } from '$lib/utils/store/app';
+  import { getStudentContentLockReason } from '$features/ai-assistant/utils/content-ask-ai-bar';
   import { t } from '$lib/utils/functions/translations';
   import { courseApi, lessonApi } from '$features/course/api';
   import { getOrderedNavigableContent, getContentRoute } from '$features/course/utils/content';
@@ -69,8 +70,10 @@
   const showMarkComplete = $derived(!!lessonId && !exerciseId);
 
   const currentLessonItem = $derived(lessonId ? lessonItems.find((l) => l.id === lessonId) : null);
-  const isTeacherLocked = $derived($isOrgStudent && currentLessonItem && !(currentLessonItem.isUnlocked ?? false));
-  const isProgressionLocked = $derived($isOrgStudent && currentLessonItem?.accessible === false && !isTeacherLocked);
+  const contentLockReason = $derived(
+    lessonId ? getStudentContentLockReason(courseApi.course, lessonId, ContentType.Lesson) : null
+  );
+  const isLessonLocked = $derived($isOrgStudent === true && contentLockReason !== null);
   const isVideoWatchLesson = $derived.by(() => {
     if (!lessonId) return false;
 
@@ -98,7 +101,6 @@
 
   const watchVideosRequired = $derived(lessonApi.lesson?.watchProgress?.videosRequired ?? 0);
   const watchVideosComplete = $derived(lessonApi.lesson?.watchProgress?.videosComplete ?? 0);
-  const isLessonLocked = $derived(isTeacherLocked || isProgressionLocked);
   const isVideoWatchComplete = $derived(isVideoWatchLesson && (lessonApi.lesson?.watchProgress?.isComplete ?? false));
   const showVideoWatchCompleteState = $derived(isVideoWatchComplete || (isVideoWatchLesson && isLessonComplete));
   const isMarkCompleteDisabled = $derived(

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-content-tree.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-content-tree.svelte
@@ -8,7 +8,7 @@
   import * as Collapsible from '@cio/ui/base/collapsible';
   import { ContentType } from '@cio/utils/constants/content';
   import { courseApi } from '$features/course/api';
-  import { getContentRoute, getCourseContent } from '$features/course/utils/content';
+  import { getContentItemsProgress, getContentRoute, getCourseContent } from '$features/course/utils/content';
   import { CircleCheckIcon } from '$features/ui/icons';
   import { t } from '$lib/utils/functions/translations';
   import { IconButton } from '@cio/ui/custom/icon-button';
@@ -55,6 +55,18 @@
                   <span class="flex-1 truncate">{section.title}</span>
 
                   <div class="ml-auto flex items-center gap-1">
+                    {#if isStudent}
+                      {@const sectionProgress = getContentItemsProgress(section.items)}
+                      {#if sectionProgress.total > 0}
+                        <span
+                          class="shrink-0 text-[11px] font-medium tabular-nums {sectionProgress.percent === 100
+                            ? 'ui:text-green-600'
+                            : 'ui:text-muted-foreground'}"
+                        >
+                          {sectionProgress.percent}%
+                        </span>
+                      {/if}
+                    {/if}
                     {#if canOpenContentModal}
                       <IconButton
                         variant="ghost-outline"

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-content-tree.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-content-tree.svelte
@@ -14,6 +14,7 @@
   import { IconButton } from '@cio/ui/custom/icon-button';
   import { RadioIcon } from '@cio/ui/custom/moving-icons';
   import CourseContentIcon from '$features/course/components/course-content-icon.svelte';
+  import { isOrgStudent } from '$lib/utils/store/app';
 
   interface Props {
     path: string;
@@ -85,7 +86,8 @@
                     <Sidebar.MenuSubButton isActive={(path || page.url.pathname).includes(contentItem.id)}>
                       {#snippet child({ props })}
                         {@const isContentLocked = (contentItem.isUnlocked ?? true) === false}
-                        {@const isLockedForStudent = isStudent && (isContentLocked || contentItem.accessible === false)}
+                        {@const isLockedForStudent =
+                          $isOrgStudent === true && (isContentLocked || contentItem.accessible === false)}
                         <a
                           href={resolve(getContentRoute(id, contentItem), {})}
                           aria-disabled={isLockedForStudent}
@@ -137,7 +139,8 @@
         <Sidebar.MenuSubButton isActive={(path || page.url.pathname).includes(contentItem.id)}>
           {#snippet child({ props })}
             {@const isContentLocked = (contentItem.isUnlocked ?? true) === false}
-            {@const isLockedForStudent = isStudent && (isContentLocked || contentItem.accessible === false)}
+            {@const isLockedForStudent =
+              $isOrgStudent === true && (isContentLocked || contentItem.accessible === false)}
             <a
               href={resolve(getContentRoute(id, contentItem), {})}
               aria-disabled={isLockedForStudent}

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-logo.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-logo.svelte
@@ -2,25 +2,53 @@
   import * as Avatar from '@cio/ui/base/avatar';
   import * as Sidebar from '@cio/ui/base/sidebar';
   import { Skeleton } from '@cio/ui/base/skeleton';
+  import { PercentRingProgress } from '@cio/ui/custom/percent-ring-progress';
   import { resolve } from '$app/paths';
   import { currentOrg } from '$lib/utils/store/org';
   import { shortenName } from '$lib/utils/functions/string';
   import { courseApi } from '$features/course/api';
   import { getNavItemRoute } from '$features/course/utils/functions';
+  import { getCourseProgress } from '$features/course/utils/content';
+  import { t } from '$lib/utils/functions/translations';
 
+  interface Props {
+    isStudent?: boolean;
+  }
+
+  let { isStudent = false }: Props = $props();
+
+  const sidebar = Sidebar.useSidebar();
   const courseTitle = $derived(courseApi.course?.title);
   const courseId = $derived(courseApi.course?.id);
+  const progress = $derived(getCourseProgress(courseApi.course));
+  const isSidebarExpanded = $derived(sidebar.open || sidebar.isMobile);
+  const showProgressRing = $derived(isStudent && progress.total > 0 && isSidebarExpanded);
 </script>
 
 <Sidebar.Menu>
   <Sidebar.MenuItem>
     <Sidebar.MenuButton
-      size="sm"
+      size={showProgressRing ? 'lg' : 'sm'}
       class="ui:data-[state=open]:bg-sidebar-accent ui:data-[state=open]:text-sidebar-accent-foreground"
     >
       {#snippet child({ props })}
         <a href={courseId ? resolve(getNavItemRoute(courseId), {}) : '#'} {...props}>
-          {#if $currentOrg.name}
+          {#if showProgressRing}
+            <PercentRingProgress value={progress.percent} size="small" />
+            <div class="flex min-w-0 flex-1 flex-col">
+              {#if courseTitle}
+                <span class="truncate text-sm font-medium">{courseTitle}</span>
+              {:else}
+                <Skeleton class="h-4 w-24" />
+              {/if}
+              <span class="ui:text-muted-foreground truncate text-xs">
+                {$t('course.sidebar.progress.completed', {
+                  completed: progress.completed,
+                  total: progress.total
+                })}
+              </span>
+            </div>
+          {:else if $currentOrg.name}
             <Avatar.Root class="flex size-6! items-center justify-center rounded-md!">
               <Avatar.Image src={$currentOrg.avatarUrl} alt={$currentOrg.name} />
               <Avatar.Fallback class="rounded-md! text-xs">{shortenName($currentOrg.name)}</Avatar.Fallback>

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar.svelte
@@ -11,7 +11,9 @@
   import SidebarSkeleton from '$features/ui/sidebar/sidebar-skeleton.svelte';
   import PoweredBy from '$features/ui/powered-by.svelte';
   import { courseApi } from '$features/course/api';
+  import { getCourseProgress } from '$features/course/utils/content';
   import { useSidebar } from '@cio/ui/base/sidebar';
+  import CourseProgressCard from '$features/course/components/course-progress-card.svelte';
   import { startResizablePanelDrag } from '$lib/utils/functions/resizable-panel';
   import { COURSE_SIDEBAR_DEFAULT_WIDTH, COURSE_SIDEBAR_MAX_WIDTH, COURSE_SIDEBAR_MIN_WIDTH } from './constants';
 
@@ -45,6 +47,10 @@
   let stopSidebarResize: (() => void) | null = null;
 
   const attributionCourseSlug = $derived(courseApi.course?.slug ?? null);
+  const courseProgress = $derived(getCourseProgress(courseApi.course));
+  const showCourseProgress = $derived(
+    $isStudentExperience && isCourseReady && sidebar.open && !sidebar.isMobile && courseProgress.total > 0
+  );
 
   function clampSidebarWidth(width: number) {
     return Math.min(COURSE_SIDEBAR_MAX_WIDTH, Math.max(COURSE_SIDEBAR_MIN_WIDTH, width));
@@ -114,7 +120,7 @@
 {:else}
   <Sidebar.Root collapsible="icon" class="z-app-bar-elevated!" mobileOverlayClass="z-app-bar-elevated!">
     <Sidebar.Header>
-      <CourseSidebarLogo />
+      <CourseSidebarLogo isStudent={$isStudentExperience} />
     </Sidebar.Header>
 
     <Sidebar.Content>
@@ -143,6 +149,12 @@
     <Sidebar.Rail onclick={handleRailClick} onpointerdown={handleRailPointerDown} />
 
     <Sidebar.Footer>
+      {#if showCourseProgress}
+        <CourseProgressCard
+          progress={courseProgress}
+          class="ui:border-sidebar-border ui:bg-sidebar-accent/50 rounded-lg border p-3"
+        />
+      {/if}
       <PoweredBy
         variant="sidebar"
         sidebarUtmSource="lms-course-sidebar"

--- a/apps/dashboard/src/lib/features/course/pages/lesson.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/lesson.svelte
@@ -17,6 +17,7 @@
   import MODES from '$lib/utils/constants/mode';
   import { profile } from '$lib/utils/store/user';
   import { isOrgStudent, isStudentExperience } from '$lib/utils/store/app';
+  import { getStudentContentLockReason } from '$features/ai-assistant/utils/content-ask-ai-bar';
   import { currentOrg } from '$lib/utils/store/org';
   import { snackbar } from '$features/ui/snackbar/store';
   import { RefreshPageData, UnsavedChanges } from '$features/ui';
@@ -33,6 +34,7 @@
   import * as Page from '@cio/ui/base/page';
   import * as UnderlineTabs from '@cio/ui/custom/underline-tabs';
   import { Empty } from '@cio/ui/custom/empty';
+  import { Spinner } from '@cio/ui/base/spinner';
   import { RoleBasedSecurity } from '$features/ui';
 
   import {
@@ -83,17 +85,31 @@
     )
   );
   const lessonTitle = $derived(currentLessonContentItem?.title || lessonApi.lesson?.title || 'Lesson');
-  const isTeacherLocked = $derived.by(() => {
-    if ($isOrgStudent && currentLessonContentItem) {
-      return (currentLessonContentItem.isUnlocked ?? false) === false;
+  const contentLockReason = $derived(getStudentContentLockReason(courseApi.course, lessonId, ContentType.Lesson));
+  const isLessonLockedForStudent = $derived($isOrgStudent === true && contentLockReason !== null);
+  const isStudentLessonStateReady = $derived.by(() => {
+    if ($isOrgStudent !== true) {
+      return true;
     }
 
-    return (lessonApi.lesson?.isUnlocked ?? false) === false;
+    if (courseApi.course?.id !== courseId) {
+      return false;
+    }
+
+    if (contentLockReason !== null) {
+      return true;
+    }
+
+    if (currentLessonContentItem) {
+      return true;
+    }
+
+    if (lessonApi.lesson?.id === lessonId) {
+      return true;
+    }
+
+    return courseApi.course?.content != null;
   });
-  const isProgressionLocked = $derived(
-    $isOrgStudent && currentLessonContentItem?.accessible === false && !isTeacherLocked
-  );
-  const isLessonUnlocked = $derived(!isTeacherLocked && !isProgressionLocked);
   const lessonSlug = $derived(lessonApi.lesson?.slug ?? '');
   const isPublicCourse = $derived(courseApi.course?.type === 'PUBLIC');
   const isLiveSessionLesson = $derived(Boolean(lessonApi.lesson?.callUrl && lessonApi.lesson?.lessonAt));
@@ -450,7 +466,7 @@
 <Page.Body>
   {#snippet child()}
     <div class={`overflow-x-hidden pb-6 ${mode === MODES.edit ? 'lg:w-full xl:w-11/12' : 'mx-auto w-full max-w-3xl'}`}>
-      {#if isLiveSessionLesson && mode === MODES.view && !($isOrgStudent && !isLessonUnlocked)}
+      {#if isLiveSessionLesson && mode === MODES.view && !isLessonLockedForStudent}
         <div class="mb-4">
           <LiveSessionCard
             title={lessonTitle}
@@ -461,11 +477,12 @@
         </div>
       {/if}
 
-      {#if $isOrgStudent && !isLessonUnlocked}
-        <StudentContentLockedNotice
-          reason={isProgressionLocked ? 'progression_locked' : 'teacher_locked'}
-          contentType={ContentType.Lesson}
-        />
+      {#if $isOrgStudent === true && !isStudentLessonStateReady}
+        <div class="flex justify-center py-16">
+          <Spinner />
+        </div>
+      {:else if isLessonLockedForStudent && contentLockReason}
+        <StudentContentLockedNotice reason={contentLockReason} contentType={ContentType.Lesson} />
       {:else if mode === MODES.edit}
         <UnderlineTabs.Root
           bind:value={currentTabValue}
@@ -541,6 +558,13 @@
             {/if}
           </div>
         {/key}
+      {:else if $isOrgStudent === true}
+        <Empty
+          title={$t('course.navItem.lessons.materials.no_content')}
+          icon={VideoIcon}
+          variant="page"
+          class="text-center"
+        />
       {:else}
         <Empty
           title={$t('course.navItem.lessons.materials.body_heading')}
@@ -554,11 +578,9 @@
           variant="page"
           class="text-center"
         >
-          {#if !$isOrgStudent}
-            <Button onclick={toggleMode}>
-              {$t('course.navItem.lessons.materials.get_started')}
-            </Button>
-          {/if}
+          <Button onclick={toggleMode}>
+            {$t('course.navItem.lessons.materials.get_started')}
+          </Button>
         </Empty>
       {/if}
     </div>

--- a/apps/dashboard/src/lib/features/course/utils/content.ts
+++ b/apps/dashboard/src/lib/features/course/utils/content.ts
@@ -56,6 +56,42 @@ export function getCourseContent(course: Course | null) {
 
 const NAVIGABLE_CONTENT_TYPES = [CourseContentType.Lesson, CourseContentType.Exercise] as const;
 
+export type ContentProgress = {
+  lessonsTotal: number;
+  lessonsComplete: number;
+  exercisesTotal: number;
+  exercisesComplete: number;
+  total: number;
+  completed: number;
+  percent: number;
+};
+
+export function getContentItemsProgress(items: ContentItem[]): ContentProgress {
+  const lessons = items.filter((item) => item.type === CourseContentType.Lesson);
+  const exercises = items.filter((item) => item.type === CourseContentType.Exercise);
+  const lessonsComplete = lessons.filter((item) => item.isComplete).length;
+  const exercisesComplete = exercises.filter((item) => item.isComplete).length;
+  const total = lessons.length + exercises.length;
+  const completed = lessonsComplete + exercisesComplete;
+  const percent = total === 0 ? 0 : Math.round((completed / total) * 100);
+
+  return {
+    lessonsTotal: lessons.length,
+    lessonsComplete,
+    exercisesTotal: exercises.length,
+    exercisesComplete,
+    total,
+    completed,
+    percent
+  };
+}
+
+export function getCourseProgress(course: Course | null): ContentProgress {
+  const content = getCourseContent(course);
+  const items = content.grouped ? content.sections.flatMap((section) => section.items) : content.items;
+  return getContentItemsProgress(items);
+}
+
 export function getOrderedNavigableContent(course: Course | null): ContentItem[] {
   const content = getCourseContent(course);
   const items = content.grouped ? content.sections.flatMap((s) => s.items) : content.items;

--- a/apps/dashboard/src/lib/features/settings/api/member-email-notifications.svelte.ts
+++ b/apps/dashboard/src/lib/features/settings/api/member-email-notifications.svelte.ts
@@ -1,0 +1,23 @@
+import { BaseApiWithErrors, classroomio } from '$lib/utils/services/api';
+import type {
+  GetMemberEmailNotificationsRequest,
+  UpdateMemberEmailNotificationsRequest
+} from '$features/settings/utils/types';
+
+class MemberEmailNotificationsApi extends BaseApiWithErrors {
+  async fetch() {
+    return this.execute<GetMemberEmailNotificationsRequest>({
+      requestFn: () => classroomio.organization.member['email-notifications'].$get(),
+      logContext: 'fetching member email notification preferences'
+    });
+  }
+
+  async update(preferences: Record<string, boolean>) {
+    return this.execute<UpdateMemberEmailNotificationsRequest>({
+      requestFn: () => classroomio.organization.member['email-notifications'].$put({ json: preferences }),
+      logContext: 'updating member email notification preferences'
+    });
+  }
+}
+
+export const memberEmailNotificationsApi = new MemberEmailNotificationsApi();

--- a/apps/dashboard/src/lib/features/settings/pages/notifications.svelte
+++ b/apps/dashboard/src/lib/features/settings/pages/notifications.svelte
@@ -6,12 +6,11 @@
     PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS,
     TUTOR_ONLY_PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS
   } from '@cio/utils/notifications';
-  import { profile } from '$lib/utils/store/user';
   import { currentOrg, isOrgAdmin } from '$lib/utils/store/org';
   import { isOrgStudent } from '$lib/utils/store/app';
   import { t } from '$lib/utils/functions/translations';
   import { snackbar } from '$features/ui/snackbar/store';
-  import { profileApi } from '$features/auth/api/profile.svelte';
+  import { memberEmailNotificationsApi } from '$features/settings/api/member-email-notifications.svelte';
   import { orgApi } from '$features/org/api/org.svelte';
   import * as Field from '@cio/ui/base/field';
   import { Switch } from '@cio/ui/base/switch';
@@ -26,10 +25,12 @@
   }
 
   let personalToggles = $state(buildToggleState(PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS));
+  let savedPersonalToggles = $state(buildToggleState(PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS));
   let orgToggles = $state(buildToggleState(EMAIL_NOTIFICATION_TOGGLE_KEYS));
   let isSavingPersonal = $state(false);
   let isSavingOrg = $state(false);
-  let hasHydratedFromStores = $state(false);
+  let isLoadingPersonal = $state(false);
+  let hasHydratedOrgToggles = $state(false);
 
   const tutorOnlyToggleKeys = new Set<string>(TUTOR_ONLY_PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS);
 
@@ -42,12 +43,18 @@
       : PERSONAL_EMAIL_NOTIFICATION_SECTIONS
   );
 
-  function syncPersonalTogglesFromProfile() {
-    const profileState = get(profile);
-    const next = buildToggleState(PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS, profileState.settings?.emailNotifications);
+  const personalDescription = $derived(
+    $currentOrg?.name
+      ? t.get('settings.notifications.personal.description_with_org', { orgName: $currentOrg.name })
+      : t.get('settings.notifications.personal.description')
+  );
+
+  function applyPersonalToggleState(source?: Partial<Record<string, boolean>> | null) {
+    const next = buildToggleState(PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS, source);
 
     for (const key of PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS) {
       personalToggles[key] = next[key];
+      savedPersonalToggles[key] = next[key];
     }
   }
 
@@ -63,41 +70,53 @@
     }
   }
 
-  function tryHydrateFromStores() {
-    if (hasHydratedFromStores) return;
+  async function loadPersonalPreferences() {
+    if (!$currentOrg?.id) return;
 
-    const profileState = get(profile);
-    if (!profileState.id) return;
+    isLoadingPersonal = true;
 
-    syncPersonalTogglesFromProfile();
+    const result = await memberEmailNotificationsApi.fetch();
 
-    if (get(isOrgAdmin)) {
-      if (!get(currentOrg)?.id) return;
-      syncOrgTogglesFromCurrentOrg();
+    if (result?.data) {
+      applyPersonalToggleState(result.data);
     }
 
-    hasHydratedFromStores = true;
+    isLoadingPersonal = false;
+  }
+
+  function tryHydrateOrgToggles() {
+    if (hasHydratedOrgToggles || !get(isOrgAdmin)) return;
+
+    if (!get(currentOrg)?.id) return;
+
+    syncOrgTogglesFromCurrentOrg();
+    hasHydratedOrgToggles = true;
   }
 
   onMount(() => {
-    tryHydrateFromStores();
+    tryHydrateOrgToggles();
   });
 
   $effect(() => {
-    if (hasHydratedFromStores) return;
+    const orgId = $currentOrg?.id;
 
-    const profileId = $profile.id;
-    const orgId = $isOrgAdmin ? $currentOrg?.id : 'ready';
+    if (!orgId) return;
 
-    if (!profileId || ($isOrgAdmin && !orgId)) return;
+    void loadPersonalPreferences();
+  });
 
-    tryHydrateFromStores();
+  $effect(() => {
+    if (hasHydratedOrgToggles) return;
+
+    const orgId = $isOrgAdmin ? $currentOrg?.id : null;
+
+    if (!orgId) return;
+
+    tryHydrateOrgToggles();
   });
 
   const personalHasChanges = $derived(
-    PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS.some(
-      (key) => personalToggles[key] !== ($profile.settings?.emailNotifications?.[key] !== false)
-    )
+    PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS.some((key) => personalToggles[key] !== savedPersonalToggles[key])
   );
 
   const orgHasChanges = $derived(
@@ -117,14 +136,16 @@
   }
 
   async function handleSavePersonal() {
+    if (!$currentOrg?.id) return;
+
     isSavingPersonal = true;
 
-    await profileApi.updateEmailNotifications(
+    const result = await memberEmailNotificationsApi.update(
       toStoredPreferences(PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS, personalToggles)
     );
 
-    if (profileApi.success) {
-      syncPersonalTogglesFromProfile();
+    if (memberEmailNotificationsApi.success && result?.data) {
+      applyPersonalToggleState(result.data);
       snackbar.success(t.get('settings.notifications.personal.save_success'));
     }
 
@@ -164,7 +185,7 @@
       {$t('settings.notifications.personal.heading')}
     </Field.Legend>
     <Field.Description>
-      {$t('settings.notifications.personal.description')}
+      {personalDescription}
     </Field.Description>
 
     <div class="mt-4 space-y-6">
@@ -182,7 +203,7 @@
           <div class="mt-4 space-y-4">
             {#each section.keys as key (key)}
               <Field.Field orientation="horizontal">
-                <Switch bind:checked={personalToggles[key]} disabled={isSavingPersonal} />
+                <Switch bind:checked={personalToggles[key]} disabled={isSavingPersonal || isLoadingPersonal} />
                 <div class="space-y-0.5">
                   <Field.Label>{$t(`settings.notifications.toggles.${key}.label`)}</Field.Label>
                   <Field.Description>
@@ -200,7 +221,7 @@
       <Button
         variant="secondary"
         loading={isSavingPersonal}
-        disabled={!personalHasChanges || isSavingPersonal}
+        disabled={!personalHasChanges || isSavingPersonal || isLoadingPersonal || !$currentOrg?.id}
         onclick={handleSavePersonal}
       >
         {$t('settings.notifications.personal.save')}

--- a/apps/dashboard/src/lib/features/settings/utils/types.ts
+++ b/apps/dashboard/src/lib/features/settings/utils/types.ts
@@ -16,3 +16,14 @@ export type AiUsageData = GetUsageSuccess['data'];
 export type PurchasedSummaryData = GetPurchasedSuccess['data'];
 export type LeaderboardData = GetLeaderboardSuccess['data'];
 export type LeaderboardEntry = LeaderboardData['entries'][number];
+
+export type GetMemberEmailNotificationsRequest =
+  (typeof classroomio.organization.member)['email-notifications']['$get'];
+export type UpdateMemberEmailNotificationsRequest =
+  (typeof classroomio.organization.member)['email-notifications']['$put'];
+
+export type GetMemberEmailNotificationsSuccess = Extract<
+  InferResponseType<GetMemberEmailNotificationsRequest>,
+  { success: true }
+>;
+export type MemberEmailNotificationPreferences = GetMemberEmailNotificationsSuccess['data'];

--- a/apps/dashboard/src/lib/features/ui/navigation/lms-navigation.ts
+++ b/apps/dashboard/src/lib/features/ui/navigation/lms-navigation.ts
@@ -117,8 +117,22 @@ export const baseNavConfig: NavItemConfig[] = [
         path: '/settings'
       },
       {
+        titleKey: 'Notifications',
+        path: '/settings/notifications'
+      },
+      {
         titleKey: 'Integrations',
         path: '/settings/integrations'
+      }
+    ],
+    nestedRoutes: [
+      {
+        path: 'notifications',
+        titleKey: 'settings.tabs.notifications_tab'
+      },
+      {
+        path: 'integrations',
+        titleKey: 'settings.tabs.integrations_tab'
       }
     ]
   }

--- a/apps/dashboard/src/lib/utils/translations/da.json
+++ b/apps/dashboard/src/lib/utils/translations/da.json
@@ -3463,7 +3463,7 @@
       "teams_tab": "Hold",
       "ai_credits_tab": "AI Credits",
       "ai_tutor_tab": "AI underviser",
-      "notifications_tab": "Notifications"
+      "notifications_tab": "Notifikationer"
     },
     "subheadings": {
       "view_site": "Åbent Akademi"
@@ -3639,73 +3639,75 @@
       }
     },
     "notifications": {
-      "heading": "Notifications",
-      "page_title": "Notifications",
-      "page_subtitle": "Choose which email notifications you receive and, as an admin, which emails your organization sends.",
+      "heading": "Notifikationer",
+      "page_title": "Notifikationer",
+      "page_subtitle": "Vælg hvilke e-mailnotifikationer du modtager, og som administrator hvilke e-mails din organisation sender.",
       "toggles": {
         "courseCompletion": {
-          "label": "Course completion and certificates",
-          "description": "Email students when they complete a course and earn a certificate."
+          "label": "Kursusafslutning og certifikater",
+          "description": "Send e-mail til studerende, når de gennemfører et kursus og opnår et certifikat."
         },
         "enrollmentWelcome": {
-          "label": "Enrollment welcome emails",
-          "description": "Send welcome emails when staff enroll students in courses or cohorts."
+          "label": "Velkomst-e-mails ved tilmelding",
+          "description": "Send velkomst-e-mails, når personalet tilmelder studerende til kurser eller kohorter."
         },
         "session": {
-          "label": "Live session reminders and updates",
-          "description": "Email students before live sessions and when session details change."
+          "label": "Påmindelser og opdateringer om livesessioner",
+          "description": "Send e-mail til studerende før livesessioner og når sessionsdetaljer ændres."
         },
         "cohortReminder": {
-          "label": "Cohort goal reminders",
-          "description": "Email students about upcoming or overdue cohort learning goals."
+          "label": "Påmindelser om kohortemål",
+          "description": "Send e-mail til studerende om kommende eller overskredne kohortlæringsmål."
         },
         "quizAssigned": {
-          "label": "Exercise assigned",
-          "description": "Email students when an exercise is assigned or nudged."
+          "label": "Øvelse tildelt",
+          "description": "Send e-mail til studerende, når en øvelse tildeles eller påmindes."
         },
         "newsfeed": {
-          "label": "Course announcements and comments",
-          "description": "Email course members about new posts and comments on the newsfeed."
+          "label": "Kursusmeddelelser og kommentarer",
+          "description": "Send e-mail til kursusmedlemmer om nye opslag og kommentarer på nyhedsfeedet."
         },
         "gradingResult": {
-          "label": "Grading results",
-          "description": "Email students when their submission is graded or updated."
+          "label": "Bedømmelsesresultater",
+          "description": "Send e-mail til studerende, når deres aflevering er bedømt eller opdateret."
         },
         "newSubmission": {
-          "label": "New submissions to grade",
-          "description": "Email tutors when a student submits work that needs grading."
+          "label": "Nye afleveringer til bedømmelse",
+          "description": "Send e-mail til undervisere, når en studerende afleverer arbejde, der skal bedømmes."
         },
         "newStudent": {
-          "label": "New student joins",
-          "description": "Email tutors when a student enrolls in a course."
+          "label": "Ny studerende tilmelder sig",
+          "description": "Send e-mail til undervisere, når en studerende tilmelder sig et kursus."
         }
       },
       "org": {
-        "heading": "Organization defaults",
-        "description": "When disabled here, nobody in your organization receives that email. Members can still opt out of emails you leave enabled.",
-        "save": "Save organization defaults",
-        "save_success": "Organization notification defaults saved"
+        "heading": "Organisationsstandarder",
+        "description": "Når deaktiveret her, modtager ingen i din organisation den e-mail. Medlemmer kan stadig fravælge e-mails, du lader være aktiveret.",
+        "save": "Gem organisationsstandarder",
+        "save_success": "Organisationsnotifikationsstandarder gemt"
       },
       "personal": {
-        "heading": "Your email preferences",
-        "description": "These apply to emails sent to you across every organization you belong to. Your organization may still disable certain emails for everyone.",
-        "save": "Save personal preferences",
-        "save_success": "Personal notification preferences saved"
+        "heading": "Dine e-mailpræferencer",
+        "save": "Gem personlige præferencer",
+        "save_success": "Personlige notifikationspræferencer gemt",
+        "description": "Disse gælder for e-mails sendt til dig i denne organisation. Din organisation kan stadig deaktivere visse e-mails for alle.",
+        "description_with_org": "Disse gælder for e-mails sendt til dig i {orgName}. Din organisation kan stadig deaktivere visse e-mails for alle."
       },
       "sections": {
         "enrollment": {
-          "heading": "Enrollment",
-          "description": "Welcome emails sent when staff add members to courses or cohorts."
+          "heading": "Tilmelding",
+          "description": "Velkomst-e-mails sendt, når personalet tilføjer medlemmer til kurser eller kohorter."
         },
         "cohort": {
-          "heading": "Cohort",
-          "description": "Reminders about cohort learning goals and deadlines."
+          "heading": "Kohorte",
+          "description": "Påmindelser om kohortens læringsmål og deadlines."
         },
         "course": {
-          "heading": "Course",
-          "description": "Enrollments, submissions, lessons, announcements, and completions in your courses."
+          "heading": "Kursus",
+          "description": "Tilmeldinger, afleveringer, lektioner, meddelelser og gennemførelser i dine kurser."
         }
-      }
+      },
+      "personal_page_subtitle": "Vælg hvilke e-mailnotifikationer du modtager fra ClassroomIO."
     }
   },
   "profileMenu": {

--- a/apps/dashboard/src/lib/utils/translations/da.json
+++ b/apps/dashboard/src/lib/utils/translations/da.json
@@ -2370,6 +2370,12 @@
         "title": "Overholdelse",
         "due_date": "Forfalder",
         "valid_until": "Gælder indtil kl"
+      },
+      "progress": {
+        "title": "Dine fremskridt",
+        "completed": "{completed} af {total} fuldført",
+        "lessons": "{completed} af {total} lektioner",
+        "exercises": "{completed} af {total} øvelser"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/de.json
+++ b/apps/dashboard/src/lib/utils/translations/de.json
@@ -2370,6 +2370,12 @@
         "title": "Compliance",
         "due_date": "Fällig",
         "valid_until": "Gültig bis"
+      },
+      "progress": {
+        "title": "Ihr Fortschritt",
+        "completed": "{completed} von {total} abgeschlossen",
+        "lessons": "{completed} von {total} Lektionen",
+        "exercises": "{completed} von {total} Übungen"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/de.json
+++ b/apps/dashboard/src/lib/utils/translations/de.json
@@ -3463,7 +3463,7 @@
       "teams_tab": "Mannschaften",
       "ai_credits_tab": "AI Credits",
       "ai_tutor_tab": "KI-Tutor",
-      "notifications_tab": "Notifications"
+      "notifications_tab": "Benachrichtigungen"
     },
     "subheadings": {
       "view_site": "Offene Akademie"
@@ -3639,73 +3639,75 @@
       }
     },
     "notifications": {
-      "heading": "Notifications",
-      "page_title": "Notifications",
-      "page_subtitle": "Choose which email notifications you receive and, as an admin, which emails your organization sends.",
+      "heading": "Benachrichtigungen",
+      "page_title": "Benachrichtigungen",
+      "page_subtitle": "Wählen Sie, welche E-Mail-Benachrichtigungen Sie erhalten, und als Administrator, welche E-Mails Ihre Organisation sendet.",
       "toggles": {
         "courseCompletion": {
-          "label": "Course completion and certificates",
-          "description": "Email students when they complete a course and earn a certificate."
+          "label": "Kursabschluss und Zertifikate",
+          "description": "E-Mail an Studenten senden, wenn sie einen Kurs abschließen und ein Zertifikat erhalten."
         },
         "enrollmentWelcome": {
-          "label": "Enrollment welcome emails",
-          "description": "Send welcome emails when staff enroll students in courses or cohorts."
+          "label": "Willkommens-E-Mails bei Anmeldung",
+          "description": "Willkommens-E-Mails senden, wenn Mitarbeitende Studenten zu Kursen oder Kohorten anmelden."
         },
         "session": {
-          "label": "Live session reminders and updates",
-          "description": "Email students before live sessions and when session details change."
+          "label": "Erinnerungen und Updates zu Live-Sitzungen",
+          "description": "E-Mail an Studenten vor Live-Sitzungen und bei Änderungen der Sitzungsdetails senden."
         },
         "cohortReminder": {
-          "label": "Cohort goal reminders",
-          "description": "Email students about upcoming or overdue cohort learning goals."
+          "label": "Erinnerungen an Kohortenlernziele",
+          "description": "E-Mail an Studenten über bevorstehende oder überfällige Kohortenlernziele senden."
         },
         "quizAssigned": {
-          "label": "Exercise assigned",
-          "description": "Email students when an exercise is assigned or nudged."
+          "label": "Übung zugewiesen",
+          "description": "E-Mail an Studenten senden, wenn eine Übung zugewiesen oder erinnert wird."
         },
         "newsfeed": {
-          "label": "Course announcements and comments",
-          "description": "Email course members about new posts and comments on the newsfeed."
+          "label": "Kursankündigungen und Kommentare",
+          "description": "E-Mail an Kursmitglieder über neue Beiträge und Kommentare im Newsfeed senden."
         },
         "gradingResult": {
-          "label": "Grading results",
-          "description": "Email students when their submission is graded or updated."
+          "label": "Bewertungsergebnisse",
+          "description": "E-Mail an Studenten senden, wenn ihre Abgabe bewertet oder aktualisiert wird."
         },
         "newSubmission": {
-          "label": "New submissions to grade",
-          "description": "Email tutors when a student submits work that needs grading."
+          "label": "Neue Abgaben zum Bewerten",
+          "description": "E-Mail an Tutoren senden, wenn ein Student Arbeit zur Bewertung einreicht."
         },
         "newStudent": {
-          "label": "New student joins",
-          "description": "Email tutors when a student enrolls in a course."
+          "label": "Neuer Student meldet sich an",
+          "description": "E-Mail an Tutoren senden, wenn sich ein Student für einen Kurs anmeldet."
         }
       },
       "org": {
-        "heading": "Organization defaults",
-        "description": "When disabled here, nobody in your organization receives that email. Members can still opt out of emails you leave enabled.",
-        "save": "Save organization defaults",
-        "save_success": "Organization notification defaults saved"
+        "heading": "Organisationsstandards",
+        "description": "Wenn hier deaktiviert, erhält niemand in Ihrer Organisation diese E-Mail. Mitglieder können sich weiterhin von E-Mails abmelden, die Sie aktiviert lassen.",
+        "save": "Organisationsstandards speichern",
+        "save_success": "Organisations-Benachrichtigungsstandards gespeichert"
       },
       "personal": {
-        "heading": "Your email preferences",
-        "description": "These apply to emails sent to you across every organization you belong to. Your organization may still disable certain emails for everyone.",
-        "save": "Save personal preferences",
-        "save_success": "Personal notification preferences saved"
+        "heading": "Ihre E-Mail-Einstellungen",
+        "save": "Persönliche Einstellungen speichern",
+        "save_success": "Persönliche Benachrichtigungseinstellungen gespeichert",
+        "description": "Diese Einstellungen gelten für E-Mails, die Ihnen in dieser Organisation gesendet werden. Ihre Organisation kann bestimmte E-Mails für alle deaktivieren.",
+        "description_with_org": "Diese Einstellungen gelten für E-Mails, die Ihnen in {orgName} gesendet werden. Ihre Organisation kann bestimmte E-Mails für alle deaktivieren."
       },
       "sections": {
         "enrollment": {
-          "heading": "Enrollment",
-          "description": "Welcome emails sent when staff add members to courses or cohorts."
+          "heading": "Anmeldung",
+          "description": "Willkommens-E-Mails, die gesendet werden, wenn Mitarbeitende Mitglieder zu Kursen oder Kohorten hinzufügen."
         },
         "cohort": {
-          "heading": "Cohort",
-          "description": "Reminders about cohort learning goals and deadlines."
+          "heading": "Kohorte",
+          "description": "Erinnerungen an Lernziele und Fristen der Kohorte."
         },
         "course": {
-          "heading": "Course",
-          "description": "Enrollments, submissions, lessons, announcements, and completions in your courses."
+          "heading": "Kurs",
+          "description": "Anmeldungen, Abgaben, Lektionen, Ankündigungen und Abschlüsse in Ihren Kursen."
         }
-      }
+      },
+      "personal_page_subtitle": "Wählen Sie, welche E-Mail-Benachrichtigungen Sie von ClassroomIO erhalten."
     }
   },
   "profileMenu": {

--- a/apps/dashboard/src/lib/utils/translations/en.json
+++ b/apps/dashboard/src/lib/utils/translations/en.json
@@ -440,9 +440,11 @@
       "heading": "Notifications",
       "page_title": "Notifications",
       "page_subtitle": "Choose which email notifications you receive and, as an admin, which emails your organization sends.",
+      "personal_page_subtitle": "Choose which email notifications you receive from ClassroomIO.",
       "personal": {
         "heading": "Your email preferences",
-        "description": "These apply to emails sent to you across every organization you belong to. Your organization may still disable certain emails for everyone.",
+        "description": "These apply to emails sent to you in this organization. Your organization may still disable certain emails for everyone.",
+        "description_with_org": "These apply to emails sent to you in {orgName}. Your organization may still disable certain emails for everyone.",
         "save": "Save personal preferences",
         "save_success": "Personal notification preferences saved"
       },

--- a/apps/dashboard/src/lib/utils/translations/en.json
+++ b/apps/dashboard/src/lib/utils/translations/en.json
@@ -2005,6 +2005,12 @@
       "content_count": {
         "lessons": "{count} lessons",
         "exercises": "{count} exercises"
+      },
+      "progress": {
+        "title": "Your progress",
+        "completed": "{completed} of {total} completed",
+        "lessons": "{completed} of {total} lessons",
+        "exercises": "{completed} of {total} exercises"
       }
     },
     "search": {

--- a/apps/dashboard/src/lib/utils/translations/es.json
+++ b/apps/dashboard/src/lib/utils/translations/es.json
@@ -2370,6 +2370,12 @@
         "title": "Cumplimiento",
         "due_date": "debido",
         "valid_until": "Válido hasta"
+      },
+      "progress": {
+        "title": "Tu progreso",
+        "completed": "{completed} de {total} completados",
+        "lessons": "{completed} de {total} lecciones",
+        "exercises": "{completed} de {total} ejercicios"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/es.json
+++ b/apps/dashboard/src/lib/utils/translations/es.json
@@ -3463,7 +3463,7 @@
       "teams_tab": "equipos",
       "ai_credits_tab": "AI Credits",
       "ai_tutor_tab": "Tutor de IA",
-      "notifications_tab": "Notifications"
+      "notifications_tab": "Notificaciones"
     },
     "subheadings": {
       "view_site": "Academia Abierta"
@@ -3639,73 +3639,75 @@
       }
     },
     "notifications": {
-      "heading": "Notifications",
-      "page_title": "Notifications",
-      "page_subtitle": "Choose which email notifications you receive and, as an admin, which emails your organization sends.",
+      "heading": "Notificaciones",
+      "page_title": "Notificaciones",
+      "page_subtitle": "Elige qué notificaciones por correo recibes y, como administrador, qué correos envía tu organización.",
       "toggles": {
         "courseCompletion": {
-          "label": "Course completion and certificates",
-          "description": "Email students when they complete a course and earn a certificate."
+          "label": "Finalización del curso y certificados",
+          "description": "Enviar correo a estudiantes cuando completan un curso y obtienen un certificado."
         },
         "enrollmentWelcome": {
-          "label": "Enrollment welcome emails",
-          "description": "Send welcome emails when staff enroll students in courses or cohorts."
+          "label": "Correos de bienvenida por inscripción",
+          "description": "Enviar correos de bienvenida cuando el personal inscribe estudiantes en cursos o cohortes."
         },
         "session": {
-          "label": "Live session reminders and updates",
-          "description": "Email students before live sessions and when session details change."
+          "label": "Recordatorios y actualizaciones de sesiones en vivo",
+          "description": "Enviar correo a estudiantes antes de sesiones en vivo y cuando cambian los detalles."
         },
         "cohortReminder": {
-          "label": "Cohort goal reminders",
-          "description": "Email students about upcoming or overdue cohort learning goals."
+          "label": "Recordatorios de objetivos de cohorte",
+          "description": "Enviar correo a estudiantes sobre objetivos de aprendizaje próximos o vencidos."
         },
         "quizAssigned": {
-          "label": "Exercise assigned",
-          "description": "Email students when an exercise is assigned or nudged."
+          "label": "Ejercicio asignado",
+          "description": "Enviar correo a estudiantes cuando se asigna o recuerda un ejercicio."
         },
         "newsfeed": {
-          "label": "Course announcements and comments",
-          "description": "Email course members about new posts and comments on the newsfeed."
+          "label": "Anuncios y comentarios del curso",
+          "description": "Enviar correo a los miembros del curso sobre nuevas publicaciones y comentarios en el feed."
         },
         "gradingResult": {
-          "label": "Grading results",
-          "description": "Email students when their submission is graded or updated."
+          "label": "Resultados de calificación",
+          "description": "Enviar correo a estudiantes cuando su entrega es calificada o actualizada."
         },
         "newSubmission": {
-          "label": "New submissions to grade",
-          "description": "Email tutors when a student submits work that needs grading."
+          "label": "Nuevas entregas para calificar",
+          "description": "Enviar correo a tutores cuando un estudiante entrega trabajo que necesita calificación."
         },
         "newStudent": {
-          "label": "New student joins",
-          "description": "Email tutors when a student enrolls in a course."
+          "label": "Nuevo estudiante se inscribe",
+          "description": "Enviar correo a tutores cuando un estudiante se inscribe en un curso."
         }
       },
       "org": {
-        "heading": "Organization defaults",
-        "description": "When disabled here, nobody in your organization receives that email. Members can still opt out of emails you leave enabled.",
-        "save": "Save organization defaults",
-        "save_success": "Organization notification defaults saved"
+        "heading": "Valores predeterminados de la organización",
+        "description": "Si se desactiva aquí, nadie en tu organización recibirá ese correo. Los miembros aún pueden darse de baja de los correos que dejes habilitados.",
+        "save": "Guardar valores predeterminados de la organización",
+        "save_success": "Valores predeterminados de notificación de la organización guardados"
       },
       "personal": {
-        "heading": "Your email preferences",
-        "description": "These apply to emails sent to you across every organization you belong to. Your organization may still disable certain emails for everyone.",
-        "save": "Save personal preferences",
-        "save_success": "Personal notification preferences saved"
+        "heading": "Tus preferencias de correo",
+        "save": "Guardar preferencias personales",
+        "save_success": "Preferencias de notificación personales guardadas",
+        "description": "Se aplican a los correos electrónicos que recibes en esta organización. Tu organización aún puede desactivar ciertos correos para todos.",
+        "description_with_org": "Se aplican a los correos electrónicos que recibes en {orgName}. Tu organización aún puede desactivar ciertos correos para todos."
       },
       "sections": {
         "enrollment": {
-          "heading": "Enrollment",
-          "description": "Welcome emails sent when staff add members to courses or cohorts."
+          "heading": "Inscripción",
+          "description": "Correos de bienvenida enviados cuando el personal añade miembros a cursos o cohortes."
         },
         "cohort": {
-          "heading": "Cohort",
-          "description": "Reminders about cohort learning goals and deadlines."
+          "heading": "Cohorte",
+          "description": "Recordatorios sobre objetivos de aprendizaje y plazos de la cohorte."
         },
         "course": {
-          "heading": "Course",
-          "description": "Enrollments, submissions, lessons, announcements, and completions in your courses."
+          "heading": "Curso",
+          "description": "Inscripciones, entregas, lecciones, anuncios y finalizaciones en tus cursos."
         }
-      }
+      },
+      "personal_page_subtitle": "Elige qué notificaciones por correo recibes de ClassroomIO."
     }
   },
   "profileMenu": {

--- a/apps/dashboard/src/lib/utils/translations/fr.json
+++ b/apps/dashboard/src/lib/utils/translations/fr.json
@@ -2370,6 +2370,12 @@
         "title": "Conformité",
         "due_date": "Due",
         "valid_until": "Valable jusqu'au"
+      },
+      "progress": {
+        "title": "Votre progression",
+        "completed": "{completed} sur {total} terminés",
+        "lessons": "{completed} sur {total} leçons",
+        "exercises": "{completed} sur {total} exercices"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/fr.json
+++ b/apps/dashboard/src/lib/utils/translations/fr.json
@@ -3641,71 +3641,73 @@
     "notifications": {
       "heading": "Notifications",
       "page_title": "Notifications",
-      "page_subtitle": "Choose which email notifications you receive and, as an admin, which emails your organization sends.",
+      "page_subtitle": "Choisissez les notifications par e-mail que vous recevez et, en tant qu’administrateur, celles que votre organisation envoie.",
       "toggles": {
         "courseCompletion": {
-          "label": "Course completion and certificates",
-          "description": "Email students when they complete a course and earn a certificate."
+          "label": "Achèvement du cours et certificats",
+          "description": "Envoyer un e-mail aux étudiants lorsqu'ils terminent un cours et obtiennent un certificat."
         },
         "enrollmentWelcome": {
-          "label": "Enrollment welcome emails",
-          "description": "Send welcome emails when staff enroll students in courses or cohorts."
+          "label": "E-mails de bienvenue d'inscription",
+          "description": "Envoyer des e-mails de bienvenue lorsque le personnel inscrit des étudiants à des cours ou cohortes."
         },
         "session": {
-          "label": "Live session reminders and updates",
-          "description": "Email students before live sessions and when session details change."
+          "label": "Rappels et mises à jour des sessions en direct",
+          "description": "Envoyer un e-mail aux étudiants avant les sessions en direct et lors des changements de détails."
         },
         "cohortReminder": {
-          "label": "Cohort goal reminders",
-          "description": "Email students about upcoming or overdue cohort learning goals."
+          "label": "Rappels d'objectifs de cohorte",
+          "description": "Envoyer un e-mail aux étudiants concernant les objectifs d'apprentissage à venir ou en retard."
         },
         "quizAssigned": {
-          "label": "Exercise assigned",
-          "description": "Email students when an exercise is assigned or nudged."
+          "label": "Exercice assigné",
+          "description": "Envoyer un e-mail aux étudiants lorsqu'un exercice est assigné ou rappelé."
         },
         "newsfeed": {
-          "label": "Course announcements and comments",
-          "description": "Email course members about new posts and comments on the newsfeed."
+          "label": "Annonces et commentaires du cours",
+          "description": "Envoyer un e-mail aux membres du cours concernant les nouvelles publications et commentaires."
         },
         "gradingResult": {
-          "label": "Grading results",
-          "description": "Email students when their submission is graded or updated."
+          "label": "Résultats de notation",
+          "description": "Envoyer un e-mail aux étudiants lorsque leur soumission est notée ou mise à jour."
         },
         "newSubmission": {
-          "label": "New submissions to grade",
-          "description": "Email tutors when a student submits work that needs grading."
+          "label": "Nouvelles soumissions à noter",
+          "description": "Envoyer un e-mail aux tuteurs lorsqu'un étudiant soumet un travail à noter."
         },
         "newStudent": {
-          "label": "New student joins",
-          "description": "Email tutors when a student enrolls in a course."
+          "label": "Nouvel étudiant s'inscrit",
+          "description": "Envoyer un e-mail aux tuteurs lorsqu'un étudiant s'inscrit à un cours."
         }
       },
       "org": {
-        "heading": "Organization defaults",
-        "description": "When disabled here, nobody in your organization receives that email. Members can still opt out of emails you leave enabled.",
-        "save": "Save organization defaults",
-        "save_success": "Organization notification defaults saved"
+        "heading": "Paramètres par défaut de l'organisation",
+        "description": "Lorsqu'ils sont désactivés ici, personne dans votre organisation ne reçoit cet e-mail. Les membres peuvent toujours se désabonner des e-mails que vous laissez activés.",
+        "save": "Enregistrer les paramètres par défaut de l'organisation",
+        "save_success": "Paramètres de notification de l'organisation enregistrés"
       },
       "personal": {
-        "heading": "Your email preferences",
-        "description": "These apply to emails sent to you across every organization you belong to. Your organization may still disable certain emails for everyone.",
-        "save": "Save personal preferences",
-        "save_success": "Personal notification preferences saved"
+        "heading": "Vos préférences e-mail",
+        "save": "Enregistrer les préférences personnelles",
+        "save_success": "Préférences de notification personnelles enregistrées",
+        "description": "Ces préférences s'appliquent aux e-mails qui vous sont envoyés dans cette organisation. Votre organisation peut toujours désactiver certains e-mails pour tout le monde.",
+        "description_with_org": "Ces préférences s'appliquent aux e-mails qui vous sont envoyés dans {orgName}. Votre organisation peut toujours désactiver certains e-mails pour tout le monde."
       },
       "sections": {
         "enrollment": {
-          "heading": "Enrollment",
-          "description": "Welcome emails sent when staff add members to courses or cohorts."
+          "heading": "Inscription",
+          "description": "E-mails de bienvenue envoyés lorsque le personnel ajoute des membres à des cours ou cohortes."
         },
         "cohort": {
-          "heading": "Cohort",
-          "description": "Reminders about cohort learning goals and deadlines."
+          "heading": "Cohorte",
+          "description": "Rappels concernant les objectifs d'apprentissage et les échéances de la cohorte."
         },
         "course": {
-          "heading": "Course",
-          "description": "Enrollments, submissions, lessons, announcements, and completions in your courses."
+          "heading": "Cours",
+          "description": "Inscriptions, soumissions, leçons, annonces et complétions dans vos cours."
         }
-      }
+      },
+      "personal_page_subtitle": "Choisissez les notifications par e-mail que vous recevez de ClassroomIO."
     }
   },
   "profileMenu": {

--- a/apps/dashboard/src/lib/utils/translations/hi.json
+++ b/apps/dashboard/src/lib/utils/translations/hi.json
@@ -2370,6 +2370,12 @@
         "title": "अनुपालन",
         "due_date": "देय",
         "valid_until": "तक वैध है"
+      },
+      "progress": {
+        "title": "आपकी प्रगति",
+        "completed": "{total} में से {completed} पूर्ण",
+        "lessons": "{total} में से {completed} पाठ",
+        "exercises": "{total} में से {completed} अभ्यास"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/hi.json
+++ b/apps/dashboard/src/lib/utils/translations/hi.json
@@ -3463,7 +3463,7 @@
       "teams_tab": "टीमें",
       "ai_credits_tab": "AI Credits",
       "ai_tutor_tab": "एआई ट्यूटर",
-      "notifications_tab": "Notifications"
+      "notifications_tab": "सूचनाएँ"
     },
     "subheadings": {
       "view_site": "अकादमी खोलें"
@@ -3639,73 +3639,75 @@
       }
     },
     "notifications": {
-      "heading": "Notifications",
-      "page_title": "Notifications",
-      "page_subtitle": "Choose which email notifications you receive and, as an admin, which emails your organization sends.",
+      "heading": "सूचनाएँ",
+      "page_title": "सूचनाएँ",
+      "page_subtitle": "चुनें कि आप कौन सी ईमेल सूचनाएँ प्राप्त करते हैं और व्यवस्थापक के रूप में आपका संगठन कौन से ईमेल भेजता है।",
       "toggles": {
         "courseCompletion": {
-          "label": "Course completion and certificates",
-          "description": "Email students when they complete a course and earn a certificate."
+          "label": "पाठ्यक्रम पूर्णता और प्रमाणपत्र",
+          "description": "जब छात्र पाठ्यक्रम पूरा करें और प्रमाणपत्र प्राप्त करें तो ईमेल भेजें।"
         },
         "enrollmentWelcome": {
-          "label": "Enrollment welcome emails",
-          "description": "Send welcome emails when staff enroll students in courses or cohorts."
+          "label": "नामांकन स्वागत ईमेल",
+          "description": "जब स्टाफ छात्रों को पाठ्यक्रमों या समूहों में नामांकित करे तो स्वागत ईमेल भेजें।"
         },
         "session": {
-          "label": "Live session reminders and updates",
-          "description": "Email students before live sessions and when session details change."
+          "label": "लाइव सत्र अनुस्मारक और अपडेट",
+          "description": "लाइव सत्रों से पहले और सत्र विवरण बदलने पर छात्रों को ईमेल भेजें।"
         },
         "cohortReminder": {
-          "label": "Cohort goal reminders",
-          "description": "Email students about upcoming or overdue cohort learning goals."
+          "label": "समूह लक्ष्य अनुस्मारक",
+          "description": "आगामी या अतिदेय समूह सीखने के लक्ष्यों के बारे में छात्रों को ईमेल भेजें।"
         },
         "quizAssigned": {
-          "label": "Exercise assigned",
-          "description": "Email students when an exercise is assigned or nudged."
+          "label": "अभ्यास असाइन किया गया",
+          "description": "जब अभ्यास असाइन या याद दिलाया जाए तो छात्रों को ईमेल भेजें।"
         },
         "newsfeed": {
-          "label": "Course announcements and comments",
-          "description": "Email course members about new posts and comments on the newsfeed."
+          "label": "पाठ्यक्रम घोषणाएँ और टिप्पणियाँ",
+          "description": "न्यूज़फ़ीड पर नई पोस्ट और टिप्पणियों के बारे में पाठ्यक्रम सदस्यों को ईमेल भेजें।"
         },
         "gradingResult": {
-          "label": "Grading results",
-          "description": "Email students when their submission is graded or updated."
+          "label": "ग्रेडिंग परिणाम",
+          "description": "जब उनका सबमिशन ग्रेड या अपडेट हो तो छात्रों को ईमेल भेजें।"
         },
         "newSubmission": {
-          "label": "New submissions to grade",
-          "description": "Email tutors when a student submits work that needs grading."
+          "label": "ग्रेडिंग के लिए नए सबमिशन",
+          "description": "जब छात्र ग्रेडिंग की आवश्यकता वाला कार्य जमा करे तो ट्यूटर्स को ईमेल भेजें।"
         },
         "newStudent": {
-          "label": "New student joins",
-          "description": "Email tutors when a student enrolls in a course."
+          "label": "नया छात्र शामिल होता है",
+          "description": "जब कोई छात्र पाठ्यक्रम में नामांकित हो तो ट्यूटर्स को ईमेल भेजें।"
         }
       },
       "org": {
-        "heading": "Organization defaults",
-        "description": "When disabled here, nobody in your organization receives that email. Members can still opt out of emails you leave enabled.",
-        "save": "Save organization defaults",
-        "save_success": "Organization notification defaults saved"
+        "heading": "संगठन डिफ़ॉल्ट",
+        "description": "यहाँ अक्षम करने पर, आपके संगठन में कोई भी वह ईमेल नहीं प्राप्त करेगा। सदस्य अभी भी उन ईमेल से ऑप्ट आउट कर सकते हैं जिन्हें आप सक्षम रखते हैं।",
+        "save": "संगठन डिफ़ॉल्ट सहेजें",
+        "save_success": "संगठन सूचना डिफ़ॉल्ट सहेजे गए"
       },
       "personal": {
-        "heading": "Your email preferences",
-        "description": "These apply to emails sent to you across every organization you belong to. Your organization may still disable certain emails for everyone.",
-        "save": "Save personal preferences",
-        "save_success": "Personal notification preferences saved"
+        "heading": "आपकी ईमेल प्राथमिकताएँ",
+        "save": "व्यक्तिगत प्राथमिकताएँ सहेजें",
+        "save_success": "व्यक्तिगत सूचना प्राथमिकताएँ सहेजी गईं",
+        "description": "ये उन ईमेल पर लागू होते हैं जो इस संगठन में आपको भेजे जाते हैं। आपका संगठन फिर भी कुछ ईमेल सभी के लिए बंद कर सकता है।",
+        "description_with_org": "ये उन ईमेल पर लागू होते हैं जो {orgName} में आपको भेजे जाते हैं। आपका संगठन फिर भी कुछ ईमेल सभी के लिए बंद कर सकता है।"
       },
       "sections": {
         "enrollment": {
-          "heading": "Enrollment",
-          "description": "Welcome emails sent when staff add members to courses or cohorts."
+          "heading": "नामांकन",
+          "description": "स्वागत ईमेल जब स्टाफ सदस्यों को पाठ्यक्रमों या समूहों में जोड़ता है।"
         },
         "cohort": {
-          "heading": "Cohort",
-          "description": "Reminders about cohort learning goals and deadlines."
+          "heading": "समूह",
+          "description": "समूह सीखने के लक्ष्यों और समय सीमा के बारे में अनुस्मारक।"
         },
         "course": {
-          "heading": "Course",
-          "description": "Enrollments, submissions, lessons, announcements, and completions in your courses."
+          "heading": "पाठ्यक्रम",
+          "description": "आपके पाठ्यक्रमों में नामांकन, सबमिशन, पाठ, घोषणाएँ और पूर्णता।"
         }
-      }
+      },
+      "personal_page_subtitle": "चुनें कि आप ClassroomIO से कौन सी ईमेल सूचनाएँ प्राप्त करते हैं।"
     }
   },
   "profileMenu": {

--- a/apps/dashboard/src/lib/utils/translations/pl.json
+++ b/apps/dashboard/src/lib/utils/translations/pl.json
@@ -3463,7 +3463,7 @@
       "teams_tab": "Zespoły",
       "ai_credits_tab": "AI Credits",
       "ai_tutor_tab": "Nauczyciel AI",
-      "notifications_tab": "Notifications"
+      "notifications_tab": "Powiadomienia"
     },
     "subheadings": {
       "view_site": "Otwarta Akademia"
@@ -3639,73 +3639,75 @@
       }
     },
     "notifications": {
-      "heading": "Notifications",
-      "page_title": "Notifications",
-      "page_subtitle": "Choose which email notifications you receive and, as an admin, which emails your organization sends.",
+      "heading": "Powiadomienia",
+      "page_title": "Powiadomienia",
+      "page_subtitle": "Wybierz, które powiadomienia e-mail otrzymujesz, a jako administrator, które e-maile wysyła Twoja organizacja.",
       "toggles": {
         "courseCompletion": {
-          "label": "Course completion and certificates",
-          "description": "Email students when they complete a course and earn a certificate."
+          "label": "Ukończenie kursu i certyfikaty",
+          "description": "Wyślij e-mail do studentów, gdy ukończą kurs i otrzymają certyfikat."
         },
         "enrollmentWelcome": {
-          "label": "Enrollment welcome emails",
-          "description": "Send welcome emails when staff enroll students in courses or cohorts."
+          "label": "Powitalne e-maile zapisów",
+          "description": "Wysyłaj e-maile powitalne, gdy personel zapisuje studentów na kursy lub kohorty."
         },
         "session": {
-          "label": "Live session reminders and updates",
-          "description": "Email students before live sessions and when session details change."
+          "label": "Przypomnienia i aktualizacje sesji na żywo",
+          "description": "Wyślij e-mail do studentów przed sesjami na żywo i gdy zmienią się szczegóły sesji."
         },
         "cohortReminder": {
-          "label": "Cohort goal reminders",
-          "description": "Email students about upcoming or overdue cohort learning goals."
+          "label": "Przypomnienia o celach kohorty",
+          "description": "Wyślij e-mail do studentów o nadchodzących lub zaległych celach nauki kohorty."
         },
         "quizAssigned": {
-          "label": "Exercise assigned",
-          "description": "Email students when an exercise is assigned or nudged."
+          "label": "Przypisane ćwiczenie",
+          "description": "Wyślij e-mail do studentów, gdy ćwiczenie zostanie przypisane lub przypomniane."
         },
         "newsfeed": {
-          "label": "Course announcements and comments",
-          "description": "Email course members about new posts and comments on the newsfeed."
+          "label": "Ogłoszenia kursu i komentarze",
+          "description": "Wyślij e-mail do członków kursu o nowych postach i komentarzach w aktualnościach."
         },
         "gradingResult": {
-          "label": "Grading results",
-          "description": "Email students when their submission is graded or updated."
+          "label": "Wyniki oceniania",
+          "description": "Wyślij e-mail do studentów, gdy ich zgłoszenie zostanie ocenione lub zaktualizowane."
         },
         "newSubmission": {
-          "label": "New submissions to grade",
-          "description": "Email tutors when a student submits work that needs grading."
+          "label": "Nowe zgłoszenia do oceny",
+          "description": "Wyślij e-mail do tutorów, gdy student prześle pracę wymagającą oceny."
         },
         "newStudent": {
-          "label": "New student joins",
-          "description": "Email tutors when a student enrolls in a course."
+          "label": "Nowy student dołącza",
+          "description": "Wyślij e-mail do tutorów, gdy student zapisze się na kurs."
         }
       },
       "org": {
-        "heading": "Organization defaults",
-        "description": "When disabled here, nobody in your organization receives that email. Members can still opt out of emails you leave enabled.",
-        "save": "Save organization defaults",
-        "save_success": "Organization notification defaults saved"
+        "heading": "Domyślne ustawienia organizacji",
+        "description": "Po wyłączeniu tutaj nikt w Twojej organizacji nie otrzyma tego e-maila. Członkowie nadal mogą zrezygnować z e-maili, które pozostawisz włączone.",
+        "save": "Zapisz domyślne ustawienia organizacji",
+        "save_success": "Domyślne ustawienia powiadomień organizacji zapisane"
       },
       "personal": {
-        "heading": "Your email preferences",
-        "description": "These apply to emails sent to you across every organization you belong to. Your organization may still disable certain emails for everyone.",
-        "save": "Save personal preferences",
-        "save_success": "Personal notification preferences saved"
+        "heading": "Twoje preferencje e-mail",
+        "save": "Zapisz preferencje osobiste",
+        "save_success": "Osobiste preferencje powiadomień zapisane",
+        "description": "Dotyczą wiadomości e-mail wysyłanych do Ciebie w tej organizacji. Twoja organizacja nadal może wyłączyć niektóre wiadomości dla wszystkich.",
+        "description_with_org": "Dotyczą wiadomości e-mail wysyłanych do Ciebie w {orgName}. Twoja organizacja nadal może wyłączyć niektóre wiadomości dla wszystkich."
       },
       "sections": {
         "enrollment": {
-          "heading": "Enrollment",
-          "description": "Welcome emails sent when staff add members to courses or cohorts."
+          "heading": "Zapisy",
+          "description": "E-maile powitalne wysyłane, gdy personel dodaje członków do kursów lub kohort."
         },
         "cohort": {
-          "heading": "Cohort",
-          "description": "Reminders about cohort learning goals and deadlines."
+          "heading": "Kohorta",
+          "description": "Przypomnienia o celach nauki kohorty i terminach."
         },
         "course": {
-          "heading": "Course",
-          "description": "Enrollments, submissions, lessons, announcements, and completions in your courses."
+          "heading": "Kurs",
+          "description": "Zapisy, zgłoszenia, lekcje, ogłoszenia i ukończenia w Twoich kursach."
         }
-      }
+      },
+      "personal_page_subtitle": "Wybierz, które powiadomienia e-mail otrzymujesz od ClassroomIO."
     }
   },
   "profileMenu": {

--- a/apps/dashboard/src/lib/utils/translations/pl.json
+++ b/apps/dashboard/src/lib/utils/translations/pl.json
@@ -2370,6 +2370,12 @@
         "title": "Zgodność",
         "due_date": "Termin",
         "valid_until": "Ważne do"
+      },
+      "progress": {
+        "title": "Twój postęp",
+        "completed": "Ukończono {completed} z {total}",
+        "lessons": "{completed} z {total} lekcji",
+        "exercises": "{completed} z {total} ćwiczeń"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/pt.json
+++ b/apps/dashboard/src/lib/utils/translations/pt.json
@@ -2370,6 +2370,12 @@
         "title": "Conformidade",
         "due_date": "Devido",
         "valid_until": "Válido até"
+      },
+      "progress": {
+        "title": "Seu progresso",
+        "completed": "{completed} de {total} concluídos",
+        "lessons": "{completed} de {total} aulas",
+        "exercises": "{completed} de {total} exercícios"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/pt.json
+++ b/apps/dashboard/src/lib/utils/translations/pt.json
@@ -3463,7 +3463,7 @@
       "teams_tab": "Equipes",
       "ai_credits_tab": "AI Credits",
       "ai_tutor_tab": "Tutor de IA",
-      "notifications_tab": "Notifications"
+      "notifications_tab": "Notificações"
     },
     "subheadings": {
       "view_site": "Academia Aberta"
@@ -3639,73 +3639,75 @@
       }
     },
     "notifications": {
-      "heading": "Notifications",
-      "page_title": "Notifications",
-      "page_subtitle": "Choose which email notifications you receive and, as an admin, which emails your organization sends.",
+      "heading": "Notificações",
+      "page_title": "Notificações",
+      "page_subtitle": "Escolha quais notificações por e-mail você recebe e, como administrador, quais e-mails sua organização envia.",
       "toggles": {
         "courseCompletion": {
-          "label": "Course completion and certificates",
-          "description": "Email students when they complete a course and earn a certificate."
+          "label": "Conclusão do curso e certificados",
+          "description": "Enviar e-mail aos alunos quando concluírem um curso e receberem um certificado."
         },
         "enrollmentWelcome": {
-          "label": "Enrollment welcome emails",
-          "description": "Send welcome emails when staff enroll students in courses or cohorts."
+          "label": "E-mails de boas-vindas de matrícula",
+          "description": "Enviar e-mails de boas-vindas quando a equipe matricular alunos em cursos ou coortes."
         },
         "session": {
-          "label": "Live session reminders and updates",
-          "description": "Email students before live sessions and when session details change."
+          "label": "Lembretes e atualizações de sessões ao vivo",
+          "description": "Enviar e-mail aos alunos antes de sessões ao vivo e quando os detalhes mudarem."
         },
         "cohortReminder": {
-          "label": "Cohort goal reminders",
-          "description": "Email students about upcoming or overdue cohort learning goals."
+          "label": "Lembretes de metas da coorte",
+          "description": "Enviar e-mail aos alunos sobre metas de aprendizagem próximas ou atrasadas."
         },
         "quizAssigned": {
-          "label": "Exercise assigned",
-          "description": "Email students when an exercise is assigned or nudged."
+          "label": "Exercício atribuído",
+          "description": "Enviar e-mail aos alunos quando um exercício for atribuído ou lembrado."
         },
         "newsfeed": {
-          "label": "Course announcements and comments",
-          "description": "Email course members about new posts and comments on the newsfeed."
+          "label": "Anúncios e comentários do curso",
+          "description": "Enviar e-mail aos membros do curso sobre novas publicações e comentários no feed."
         },
         "gradingResult": {
-          "label": "Grading results",
-          "description": "Email students when their submission is graded or updated."
+          "label": "Resultados de avaliação",
+          "description": "Enviar e-mail aos alunos quando o envio for avaliado ou atualizado."
         },
         "newSubmission": {
-          "label": "New submissions to grade",
-          "description": "Email tutors when a student submits work that needs grading."
+          "label": "Novos envios para avaliar",
+          "description": "Enviar e-mail aos tutores quando um aluno envia trabalho que precisa de avaliação."
         },
         "newStudent": {
-          "label": "New student joins",
-          "description": "Email tutors when a student enrolls in a course."
+          "label": "Novo aluno se inscreve",
+          "description": "Enviar e-mail aos tutores quando um aluno se matricula em um curso."
         }
       },
       "org": {
-        "heading": "Organization defaults",
-        "description": "When disabled here, nobody in your organization receives that email. Members can still opt out of emails you leave enabled.",
-        "save": "Save organization defaults",
-        "save_success": "Organization notification defaults saved"
+        "heading": "Padrões da organização",
+        "description": "Quando desativado aqui, ninguém na sua organização recebe esse e-mail. Os membros ainda podem optar por não receber e-mails que você mantiver ativados.",
+        "save": "Salvar padrões da organização",
+        "save_success": "Padrões de notificação da organização salvos"
       },
       "personal": {
-        "heading": "Your email preferences",
-        "description": "These apply to emails sent to you across every organization you belong to. Your organization may still disable certain emails for everyone.",
-        "save": "Save personal preferences",
-        "save_success": "Personal notification preferences saved"
+        "heading": "Suas preferências de e-mail",
+        "save": "Salvar preferências pessoais",
+        "save_success": "Preferências de notificação pessoais salvas",
+        "description": "Aplicam-se aos e-mails enviados para você nesta organização. Sua organização ainda pode desativar certos e-mails para todos.",
+        "description_with_org": "Aplicam-se aos e-mails enviados para você em {orgName}. Sua organização ainda pode desativar certos e-mails para todos."
       },
       "sections": {
         "enrollment": {
-          "heading": "Enrollment",
-          "description": "Welcome emails sent when staff add members to courses or cohorts."
+          "heading": "Matrícula",
+          "description": "E-mails de boas-vindas enviados quando a equipe adiciona membros a cursos ou coortes."
         },
         "cohort": {
-          "heading": "Cohort",
-          "description": "Reminders about cohort learning goals and deadlines."
+          "heading": "Coorte",
+          "description": "Lembretes sobre metas de aprendizagem e prazos da coorte."
         },
         "course": {
-          "heading": "Course",
-          "description": "Enrollments, submissions, lessons, announcements, and completions in your courses."
+          "heading": "Curso",
+          "description": "Matrículas, envios, aulas, anúncios e conclusões nos seus cursos."
         }
-      }
+      },
+      "personal_page_subtitle": "Escolha quais notificações por e-mail você recebe do ClassroomIO."
     }
   },
   "profileMenu": {

--- a/apps/dashboard/src/lib/utils/translations/ru.json
+++ b/apps/dashboard/src/lib/utils/translations/ru.json
@@ -3463,7 +3463,7 @@
       "teams_tab": "Команды",
       "ai_credits_tab": "AI Credits",
       "ai_tutor_tab": "Репетитор по искусственному интеллекту",
-      "notifications_tab": "Notifications"
+      "notifications_tab": "Уведомления"
     },
     "subheadings": {
       "view_site": "Открытая Академия"
@@ -3639,73 +3639,75 @@
       }
     },
     "notifications": {
-      "heading": "Notifications",
-      "page_title": "Notifications",
-      "page_subtitle": "Choose which email notifications you receive and, as an admin, which emails your organization sends.",
+      "heading": "Уведомления",
+      "page_title": "Уведомления",
+      "page_subtitle": "Выберите, какие уведомления по электронной почте вы получаете, а как администратор — какие письма отправляет ваша организация.",
       "toggles": {
         "courseCompletion": {
-          "label": "Course completion and certificates",
-          "description": "Email students when they complete a course and earn a certificate."
+          "label": "Завершение курса и сертификаты",
+          "description": "Отправлять письмо студентам, когда они завершают курс и получают сертификат."
         },
         "enrollmentWelcome": {
-          "label": "Enrollment welcome emails",
-          "description": "Send welcome emails when staff enroll students in courses or cohorts."
+          "label": "Приветственные письма при записи",
+          "description": "Отправлять приветственные письма, когда сотрудники записывают студентов на курсы или когорты."
         },
         "session": {
-          "label": "Live session reminders and updates",
-          "description": "Email students before live sessions and when session details change."
+          "label": "Напоминания и обновления живых сессий",
+          "description": "Отправлять письмо студентам перед живыми сессиями и при изменении деталей сессии."
         },
         "cohortReminder": {
-          "label": "Cohort goal reminders",
-          "description": "Email students about upcoming or overdue cohort learning goals."
+          "label": "Напоминания о целях когорты",
+          "description": "Отправлять письмо студентам о предстоящих или просроченных целях обучения когорты."
         },
         "quizAssigned": {
-          "label": "Exercise assigned",
-          "description": "Email students when an exercise is assigned or nudged."
+          "label": "Назначено упражнение",
+          "description": "Отправлять письмо студентам, когда упражнение назначено или напоминается."
         },
         "newsfeed": {
-          "label": "Course announcements and comments",
-          "description": "Email course members about new posts and comments on the newsfeed."
+          "label": "Объявления курса и комментарии",
+          "description": "Отправлять письмо участникам курса о новых публикациях и комментариях в ленте."
         },
         "gradingResult": {
-          "label": "Grading results",
-          "description": "Email students when their submission is graded or updated."
+          "label": "Результаты оценки",
+          "description": "Отправлять письмо студентам, когда их работа оценена или обновлена."
         },
         "newSubmission": {
-          "label": "New submissions to grade",
-          "description": "Email tutors when a student submits work that needs grading."
+          "label": "Новые работы для оценки",
+          "description": "Отправлять письмо наставникам, когда студент сдаёт работу, требующую оценки."
         },
         "newStudent": {
-          "label": "New student joins",
-          "description": "Email tutors when a student enrolls in a course."
+          "label": "Новый студент записывается",
+          "description": "Отправлять письмо наставникам, когда студент записывается на курс."
         }
       },
       "org": {
-        "heading": "Organization defaults",
-        "description": "When disabled here, nobody in your organization receives that email. Members can still opt out of emails you leave enabled.",
-        "save": "Save organization defaults",
-        "save_success": "Organization notification defaults saved"
+        "heading": "Настройки организации по умолчанию",
+        "description": "Если отключено здесь, никто в вашей организации не получит это письмо. Участники по-прежнему могут отказаться от писем, которые вы оставили включёнными.",
+        "save": "Сохранить настройки организации по умолчанию",
+        "save_success": "Настройки уведомлений организации сохранены"
       },
       "personal": {
-        "heading": "Your email preferences",
-        "description": "These apply to emails sent to you across every organization you belong to. Your organization may still disable certain emails for everyone.",
-        "save": "Save personal preferences",
-        "save_success": "Personal notification preferences saved"
+        "heading": "Ваши настройки электронной почты",
+        "save": "Сохранить личные настройки",
+        "save_success": "Личные настройки уведомлений сохранены",
+        "description": "Они применяются к письмам, которые вам отправляют в этой организации. Организация по-прежнему может отключить некоторые письма для всех.",
+        "description_with_org": "Они применяются к письмам, которые вам отправляют в {orgName}. Организация по-прежнему может отключить некоторые письма для всех."
       },
       "sections": {
         "enrollment": {
-          "heading": "Enrollment",
-          "description": "Welcome emails sent when staff add members to courses or cohorts."
+          "heading": "Запись",
+          "description": "Приветственные письма, отправляемые, когда сотрудники добавляют участников в курсы или когорты."
         },
         "cohort": {
-          "heading": "Cohort",
-          "description": "Reminders about cohort learning goals and deadlines."
+          "heading": "Когорта",
+          "description": "Напоминания о целях обучения когорты и сроках."
         },
         "course": {
-          "heading": "Course",
-          "description": "Enrollments, submissions, lessons, announcements, and completions in your courses."
+          "heading": "Курс",
+          "description": "Записи, сдачи, уроки, объявления и завершения в ваших курсах."
         }
-      }
+      },
+      "personal_page_subtitle": "Выберите, какие уведомления по электронной почте вы получаете от ClassroomIO."
     }
   },
   "profileMenu": {

--- a/apps/dashboard/src/lib/utils/translations/ru.json
+++ b/apps/dashboard/src/lib/utils/translations/ru.json
@@ -2370,6 +2370,12 @@
         "title": "Соответствие",
         "due_date": "Срок погашения",
         "valid_until": "Действительно до"
+      },
+      "progress": {
+        "title": "Ваш прогресс",
+        "completed": "Завершено {completed} из {total}",
+        "lessons": "{completed} из {total} уроков",
+        "exercises": "{completed} из {total} упражнений"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/lib/utils/translations/vi.json
+++ b/apps/dashboard/src/lib/utils/translations/vi.json
@@ -3463,7 +3463,7 @@
       "teams_tab": "Đội",
       "ai_credits_tab": "AI Credits",
       "ai_tutor_tab": "Gia sư AI",
-      "notifications_tab": "Notifications"
+      "notifications_tab": "Thông báo"
     },
     "subheadings": {
       "view_site": "Học viện mở"
@@ -3639,73 +3639,75 @@
       }
     },
     "notifications": {
-      "heading": "Notifications",
-      "page_title": "Notifications",
-      "page_subtitle": "Choose which email notifications you receive and, as an admin, which emails your organization sends.",
+      "heading": "Thông báo",
+      "page_title": "Thông báo",
+      "page_subtitle": "Chọn thông báo email bạn nhận và, với tư cách quản trị viên, email mà tổ chức của bạn gửi.",
       "toggles": {
         "courseCompletion": {
-          "label": "Course completion and certificates",
-          "description": "Email students when they complete a course and earn a certificate."
+          "label": "Hoàn thành khóa học và chứng chỉ",
+          "description": "Gửi email cho học viên khi họ hoàn thành khóa học và nhận chứng chỉ."
         },
         "enrollmentWelcome": {
-          "label": "Enrollment welcome emails",
-          "description": "Send welcome emails when staff enroll students in courses or cohorts."
+          "label": "Email chào mừng ghi danh",
+          "description": "Gửi email chào mừng khi nhân viên ghi danh học viên vào khóa học hoặc nhóm học."
         },
         "session": {
-          "label": "Live session reminders and updates",
-          "description": "Email students before live sessions and when session details change."
+          "label": "Nhắc nhở và cập nhật buổi học trực tiếp",
+          "description": "Gửi email cho học viên trước buổi học trực tiếp và khi chi tiết buổi học thay đổi."
         },
         "cohortReminder": {
-          "label": "Cohort goal reminders",
-          "description": "Email students about upcoming or overdue cohort learning goals."
+          "label": "Nhắc nhở mục tiêu nhóm học",
+          "description": "Gửi email cho học viên về mục tiêu học tập sắp tới hoặc quá hạn."
         },
         "quizAssigned": {
-          "label": "Exercise assigned",
-          "description": "Email students when an exercise is assigned or nudged."
+          "label": "Bài tập được giao",
+          "description": "Gửi email cho học viên khi bài tập được giao hoặc nhắc nhở."
         },
         "newsfeed": {
-          "label": "Course announcements and comments",
-          "description": "Email course members about new posts and comments on the newsfeed."
+          "label": "Thông báo và bình luận khóa học",
+          "description": "Gửi email cho thành viên khóa học về bài đăng và bình luận mới trên bảng tin."
         },
         "gradingResult": {
-          "label": "Grading results",
-          "description": "Email students when their submission is graded or updated."
+          "label": "Kết quả chấm điểm",
+          "description": "Gửi email cho học viên khi bài nộp được chấm hoặc cập nhật."
         },
         "newSubmission": {
-          "label": "New submissions to grade",
-          "description": "Email tutors when a student submits work that needs grading."
+          "label": "Bài nộp mới cần chấm",
+          "description": "Gửi email cho gia sư khi học viên nộp bài cần chấm điểm."
         },
         "newStudent": {
-          "label": "New student joins",
-          "description": "Email tutors when a student enrolls in a course."
+          "label": "Học viên mới tham gia",
+          "description": "Gửi email cho gia sư khi học viên ghi danh vào khóa học."
         }
       },
       "org": {
-        "heading": "Organization defaults",
-        "description": "When disabled here, nobody in your organization receives that email. Members can still opt out of emails you leave enabled.",
-        "save": "Save organization defaults",
-        "save_success": "Organization notification defaults saved"
+        "heading": "Mặc định của tổ chức",
+        "description": "Khi tắt ở đây, không ai trong tổ chức của bạn nhận email đó. Thành viên vẫn có thể từ chối các email bạn để bật.",
+        "save": "Lưu mặc định của tổ chức",
+        "save_success": "Đã lưu mặc định thông báo của tổ chức"
       },
       "personal": {
-        "heading": "Your email preferences",
-        "description": "These apply to emails sent to you across every organization you belong to. Your organization may still disable certain emails for everyone.",
-        "save": "Save personal preferences",
-        "save_success": "Personal notification preferences saved"
+        "heading": "Tùy chọn email của bạn",
+        "save": "Lưu tùy chọn cá nhân",
+        "save_success": "Đã lưu tùy chọn thông báo cá nhân",
+        "description": "Áp dụng cho email gửi đến bạn trong tổ chức này. Tổ chức của bạn vẫn có thể tắt một số email cho mọi người.",
+        "description_with_org": "Áp dụng cho email gửi đến bạn trong {orgName}. Tổ chức của bạn vẫn có thể tắt một số email cho mọi người."
       },
       "sections": {
         "enrollment": {
-          "heading": "Enrollment",
-          "description": "Welcome emails sent when staff add members to courses or cohorts."
+          "heading": "Ghi danh",
+          "description": "Email chào mừng được gửi khi nhân viên thêm thành viên vào khóa học hoặc nhóm học."
         },
         "cohort": {
-          "heading": "Cohort",
-          "description": "Reminders about cohort learning goals and deadlines."
+          "heading": "Nhóm học",
+          "description": "Nhắc nhở về mục tiêu học tập và hạn chót của nhóm học."
         },
         "course": {
-          "heading": "Course",
-          "description": "Enrollments, submissions, lessons, announcements, and completions in your courses."
+          "heading": "Khóa học",
+          "description": "Ghi danh, bài nộp, bài học, thông báo và hoàn thành trong các khóa học của bạn."
         }
-      }
+      },
+      "personal_page_subtitle": "Chọn thông báo email bạn nhận từ ClassroomIO."
     }
   },
   "profileMenu": {

--- a/apps/dashboard/src/lib/utils/translations/vi.json
+++ b/apps/dashboard/src/lib/utils/translations/vi.json
@@ -2370,6 +2370,12 @@
         "title": "Tuân thủ",
         "due_date": "Đến hạn",
         "valid_until": "Có hiệu lực cho đến khi"
+      },
+      "progress": {
+        "title": "Tiến độ của bạn",
+        "completed": "Đã hoàn thành {completed} trong số {total}",
+        "lessons": "{completed} trong số {total} bài học",
+        "exercises": "{completed} trong số {total} bài tập"
       }
     },
     "navItems": {

--- a/apps/dashboard/src/routes/(app)/courses/[id]/lessons/[lessonId]/+page.svelte
+++ b/apps/dashboard/src/routes/(app)/courses/[id]/lessons/[lessonId]/+page.svelte
@@ -16,7 +16,16 @@
   let { data }: Props = $props();
 
   $effect(() => {
-    if (!data.lesson) return;
+    if (!data.lessonId) return;
+
+    if (!data.lesson) {
+      if (lessonApi.lesson?.id === data.lessonId) {
+        lessonApi.lesson = null;
+      }
+
+      return;
+    }
+
     const lesson = data.lesson;
     if (lessonApi.lesson?.id === lesson.id) return;
 

--- a/apps/dashboard/src/routes/(app)/lms/settings/notifications/+page.svelte
+++ b/apps/dashboard/src/routes/(app)/lms/settings/notifications/+page.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { NotificationsPage } from '$features/settings/pages';
+  import { t } from '$lib/utils/functions/translations';
+  import * as Page from '@cio/ui/base/page';
+</script>
+
+<svelte:head>
+  <title>{t.get('settings.notifications.page_title')} - ClassroomIO</title>
+</svelte:head>
+
+<Page.Header>
+  <Page.HeaderContent>
+    <Page.Title>{$t('settings.notifications.heading')}</Page.Title>
+    <Page.Subtitle>{$t('settings.notifications.personal_page_subtitle')}</Page.Subtitle>
+  </Page.HeaderContent>
+</Page.Header>
+<Page.Body>
+  {#snippet child()}
+    <NotificationsPage />
+  {/snippet}
+</Page.Body>

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -16,7 +16,10 @@
     "community",
     "organization",
     "student-dashboard",
+
+    "---Enterprise---",
     "enterprise-sso",
+    "token-auth",
 
     "---Get started---",
     "create-first-course",

--- a/apps/docs/content/docs/token-auth.mdx
+++ b/apps/docs/content/docs/token-auth.mdx
@@ -1,0 +1,176 @@
+---
+title: Token Auth
+description: Sign users in to ClassroomIO from your own app with a short-lived JWT.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Step, Steps } from 'fumadocs-ui/components/steps';
+
+# Token Auth
+
+Token Auth lets an external app sign a user in to ClassroomIO without asking for a ClassroomIO password. Your backend signs a short-lived JWT with your organization's Token Auth secret, then redirects the user's browser to ClassroomIO's token exchange URL.
+
+Use Token Auth when you already authenticate users in another product and want a trusted handoff into your ClassroomIO academy.
+
+<Callout type="info" title="Enterprise Feature">
+  Token Auth requires an **Enterprise** plan.
+
+  **Cloud:** [Contact us](mailto:support@classroomio.com) to upgrade.
+
+  **Self-hosted:** Requires an Enterprise license key. Set `LICENSE_KEY` in the API service environment.
+</Callout>
+
+## How It Works
+
+1. An organization admin generates a Token Auth signing secret in ClassroomIO.
+2. Your backend authenticates the user in your own app.
+3. Your backend signs a short-lived `HS256` JWT with the ClassroomIO signing secret.
+4. Your app redirects the browser to `/api/auth/token-exchange?token=...&redirect=...`.
+5. ClassroomIO verifies the token, finds or creates the user, adds them to the organization, creates a session, and redirects them to the requested path.
+
+## Set Up Token Auth
+
+<Steps>
+  <Step>
+    Sign in to ClassroomIO as an organization admin.
+  </Step>
+  <Step>
+    Open **Settings** → **Authentication** → **Token Auth**.
+  </Step>
+  <Step>
+    Click **Generate secret** and copy the secret immediately. The full secret is shown only once.
+  </Step>
+  <Step>
+    Store the secret in your backend secret manager or environment variables.
+  </Step>
+  <Step>
+    Enable Token Auth after your integration is ready.
+  </Step>
+</Steps>
+
+## Token Exchange URL
+
+Cloud:
+
+```text
+https://api.classroomio.com/api/auth/token-exchange
+```
+
+Self-hosted:
+
+```text
+{PUBLIC_SERVER_URL}/api/auth/token-exchange
+```
+
+Query parameters:
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `token` | Yes | The signed JWT. |
+| `redirect` | No | A ClassroomIO path to open after login. Must start with `/`. Invalid external URLs are ignored and users are sent to `/`. |
+
+Example:
+
+```text
+https://api.classroomio.com/api/auth/token-exchange?token=eyJ...&redirect=/courses/my-course
+```
+
+## JWT Requirements
+
+Token Auth accepts `HS256` JWTs signed with your organization's Token Auth secret.
+
+Required claims:
+
+| Claim | Type | Description |
+| --- | --- | --- |
+| `sub` | string | Stable user identifier from your system. |
+| `email` | string | User email address. ClassroomIO lowercases it before lookup. |
+| `iat` | number | Issued-at timestamp. |
+| `exp` | number | Expiration timestamp. |
+
+Optional claims:
+
+| Claim | Type | Description |
+| --- | --- | --- |
+| `name` | string | Display name. If omitted, ClassroomIO uses the email username. |
+| `avatar` | string | Public image URL for the user's avatar. |
+
+Tokens must be fresh. ClassroomIO rejects tokens older than 5 minutes, so use a short expiration such as 2 minutes.
+
+## Node Example
+
+```js
+import { SignJWT } from 'jose';
+
+const tokenAuthSecret = process.env.CLASSROOMIO_TOKEN_AUTH_SECRET;
+const classroomioAuthUrl = 'https://api.classroomio.com/api/auth/token-exchange';
+
+export async function buildClassroomioLoginUrl(user) {
+  const secret = new TextEncoder().encode(tokenAuthSecret);
+
+  const token = await new SignJWT({
+    sub: user.id,
+    email: user.email,
+    name: user.name,
+    avatar: user.avatarUrl
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('2m')
+    .sign(secret);
+
+  const url = new URL(classroomioAuthUrl);
+  url.searchParams.set('token', token);
+  url.searchParams.set('redirect', '/');
+
+  return url.toString();
+}
+```
+
+Redirect the browser to the returned URL after the user clicks "Open ClassroomIO" or any equivalent action in your app.
+
+## User Provisioning
+
+When the token is valid:
+
+- If a ClassroomIO user already exists with the email address, that user is signed in.
+- If no user exists, ClassroomIO creates one with a random password.
+- ClassroomIO adds the user to the organization tied to the signing secret.
+- If the email has a pending invite or pre-created audience row, ClassroomIO links that record first. Otherwise, the user joins with the organization's default role.
+- If `avatar` is present, ClassroomIO updates the user's profile avatar.
+
+## Rotating the Secret
+
+Rotate the secret from **Settings** → **Authentication** → **Token Auth** when a secret may have been exposed or as part of regular credential rotation.
+
+After rotation, update your backend to sign new tokens with the new secret. Old tokens signed with the previous secret stop working.
+
+## Troubleshooting
+
+### "No active token auth configured"
+
+Token Auth is not enabled for the organization. Generate a secret and enable Token Auth in the dashboard.
+
+### "Invalid token"
+
+Check that:
+
+- The token uses `HS256`.
+- The token is signed with the current Token Auth secret.
+- The token has not expired.
+- The token was issued less than 5 minutes ago.
+
+### "Invalid token payload"
+
+Verify that the JWT includes `sub`, `email`, `iat`, and `exp`, and that `email` is a valid email address.
+
+### Redirect sends users to `/`
+
+The `redirect` value must be a relative path that starts with `/`. External URLs are ignored for safety.
+
+## Security Notes
+
+- Sign tokens only on your backend. Never expose the Token Auth secret in browser code.
+- Keep token lifetimes short. Two minutes is usually enough for a browser redirect.
+- Rotate the secret immediately if it is logged, leaked, or committed.
+- Use HTTPS in production.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -69,6 +69,7 @@
     "db:login-link": "tsx src/scripts/generate-login-link.ts",
     "db:sync-orphaned-profiles": "tsx src/scripts/sync-orphaned-profiles.ts",
     "db:backfill-profile-email-verification": "tsx src/scripts/backfill-profile-email-verification.ts",
+    "db:backfill-member-email-notifications": "tsx src/scripts/backfill-member-email-notifications-from-profile.ts",
     "db:update-user-email": "tsx src/scripts/update-user-email.ts",
     "db:notify-students-over-limit": "tsx src/scripts/notify-students-over-limit.ts",
     "db:downgrade-expired-subscriptions": "tsx src/scripts/downgrade-expired-subscriptions.ts",

--- a/packages/db/src/migrations/0004_organizationmember_email_notifications.sql
+++ b/packages/db/src/migrations/0004_organizationmember_email_notifications.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "organizationmember_email_notifications" (
+	"organization_member_id" bigint PRIMARY KEY NOT NULL,
+	"new_student" boolean DEFAULT true NOT NULL,
+	"new_submission" boolean DEFAULT true NOT NULL,
+	"grading_result" boolean DEFAULT true NOT NULL,
+	"newsfeed" boolean DEFAULT true NOT NULL,
+	"quiz_assigned" boolean DEFAULT true NOT NULL,
+	"cohort_reminder" boolean DEFAULT true NOT NULL,
+	"session" boolean DEFAULT true NOT NULL,
+	"course_completion" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "organizationmember_email_notifications" ADD CONSTRAINT "organizationmember_email_notifications_organization_member_id_fkey" FOREIGN KEY ("organization_member_id") REFERENCES "public"."organizationmember"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/src/migrations/meta/0004_snapshot.json
+++ b/packages/db/src/migrations/meta/0004_snapshot.json
@@ -1,0 +1,12241 @@
+{
+  "id": "1f0cde90-b46c-4f40-aa75-67078dbf800f",
+  "prevId": "17f4e73c-bf2c-4202-a0ec-0f3191ebdf8c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_agent_run": {
+      "name": "ai_agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "AI_AGENT_RUN_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "phase": {
+          "name": "phase",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planning'"
+        },
+        "progress_percent": {
+          "name": "progress_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_step_key": {
+          "name": "current_step_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_plan": {
+          "name": "approved_plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_cursor": {
+          "name": "execution_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source_ids": {
+          "name": "source_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model_summary": {
+          "name": "model_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "queued_instructions": {
+          "name": "queued_instructions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_agent_run_course_user": {
+          "name": "idx_ai_agent_run_course_user",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_agent_run_org_status": {
+          "name": "idx_ai_agent_run_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_agent_run_conversation": {
+          "name": "idx_ai_agent_run_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_agent_run_updated_at": {
+          "name": "idx_ai_agent_run_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_run_org_id_fkey": {
+          "name": "ai_agent_run_org_id_fkey",
+          "tableFrom": "ai_agent_run",
+          "tableTo": "organization",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_run_course_id_fkey": {
+          "name": "ai_agent_run_course_id_fkey",
+          "tableFrom": "ai_agent_run",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_run_conversation_id_fkey": {
+          "name": "ai_agent_run_conversation_id_fkey",
+          "tableFrom": "ai_agent_run",
+          "tableTo": "ai_chat_conversation",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_agent_run_user_id_fkey": {
+          "name": "ai_agent_run_user_id_fkey",
+          "tableFrom": "ai_agent_run",
+          "tableTo": "profile",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_agent_run_event": {
+      "name": "ai_agent_run_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "ai_agent_run_event_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_agent_run_event_run_created": {
+          "name": "idx_ai_agent_run_event_run_created",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_run_event_run_id_fkey": {
+          "name": "ai_agent_run_event_run_id_fkey",
+          "tableFrom": "ai_agent_run_event",
+          "tableTo": "ai_agent_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_agent_run_step": {
+      "name": "ai_agent_run_step",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_key": {
+          "name": "step_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "AI_AGENT_RUN_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_ids": {
+          "name": "output_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_agent_run_step_run_status": {
+          "name": "idx_ai_agent_run_step_run_status",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_run_step_run_id_fkey": {
+          "name": "ai_agent_run_step_run_id_fkey",
+          "tableFrom": "ai_agent_run_step",
+          "tableTo": "ai_agent_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_agent_run_step_run_step_unique": {
+          "name": "ai_agent_run_step_run_step_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id", "step_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_conversation": {
+      "name": "ai_chat_conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'New conversation'"
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_chat_conversation_course_user": {
+          "name": "idx_ai_chat_conversation_course_user",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_conversation_course_id_fkey": {
+          "name": "ai_chat_conversation_course_id_fkey",
+          "tableFrom": "ai_chat_conversation",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_document": {
+      "name": "ai_chat_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_chat_document_conversation": {
+          "name": "idx_ai_chat_document_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_document_conversation_id_fkey": {
+          "name": "ai_chat_document_conversation_id_fkey",
+          "tableFrom": "ai_chat_document",
+          "tableTo": "ai_chat_conversation",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_model_context": {
+      "name": "ai_chat_model_context",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_summary": {
+          "name": "model_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "compacted_through_message_id": {
+          "name": "compacted_through_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ids": {
+          "name": "source_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_chat_model_context_course_user": {
+          "name": "idx_ai_chat_model_context_course_user",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_model_context_conversation_id_fkey": {
+          "name": "ai_chat_model_context_conversation_id_fkey",
+          "tableFrom": "ai_chat_model_context",
+          "tableTo": "ai_chat_conversation",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_chat_model_context_course_id_fkey": {
+          "name": "ai_chat_model_context_course_id_fkey",
+          "tableFrom": "ai_chat_model_context",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_chat_model_context_user_id_fkey": {
+          "name": "ai_chat_model_context_user_id_fkey",
+          "tableFrom": "ai_chat_model_context",
+          "tableTo": "profile",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_credit_balance": {
+      "name": "ai_credit_balance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "ai_credit_balance_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_credit_balance_org_id_fkey": {
+          "name": "ai_credit_balance_org_id_fkey",
+          "tableFrom": "ai_credit_balance",
+          "tableTo": "organization",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_credit_balance_org_id_key": {
+          "name": "ai_credit_balance_org_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["org_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_credit_purchase": {
+      "name": "ai_credit_purchase",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "ai_credit_purchase_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'polar'"
+        },
+        "provider_order_id": {
+          "name": "provider_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price_cents": {
+          "name": "unit_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_credit_purchase_org_created": {
+          "name": "idx_ai_credit_purchase_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_credit_purchase_org_id_fkey": {
+          "name": "ai_credit_purchase_org_id_fkey",
+          "tableFrom": "ai_credit_purchase",
+          "tableTo": "organization",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_credit_purchase_triggered_by_fkey": {
+          "name": "ai_credit_purchase_triggered_by_fkey",
+          "tableFrom": "ai_credit_purchase",
+          "tableTo": "profile",
+          "columnsFrom": ["triggered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_credit_purchase_provider_order_id_key": {
+          "name": "ai_credit_purchase_provider_order_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["provider_order_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_token_usage": {
+      "name": "ai_token_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "ai_token_usage_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_units": {
+          "name": "cost_units",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_token_usage_org_month": {
+          "name": "idx_ai_token_usage_org_month",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_token_usage_org_id_fkey": {
+          "name": "ai_token_usage_org_id_fkey",
+          "tableFrom": "ai_token_usage",
+          "tableTo": "organization",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_tutor_cap_event": {
+      "name": "ai_tutor_cap_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "ai_tutor_cap_event_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_tutor_cap_event_org_occurred": {
+          "name": "idx_ai_tutor_cap_event_org_occurred",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_tutor_cap_event_user": {
+          "name": "idx_ai_tutor_cap_event_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_tutor_cap_event_org_id_fkey": {
+          "name": "ai_tutor_cap_event_org_id_fkey",
+          "tableFrom": "ai_tutor_cap_event",
+          "tableTo": "organization",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_tutor_cap_event_user_id_fkey": {
+          "name": "ai_tutor_cap_event_user_id_fkey",
+          "tableFrom": "ai_tutor_cap_event",
+          "tableTo": "profile",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_tutor_message_count": {
+      "name": "ai_tutor_message_count",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "ai_tutor_message_count_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cap_hit_at": {
+          "name": "cap_hit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_tutor_message_count_org_period": {
+          "name": "idx_ai_tutor_message_count_org_period",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_tutor_message_count_user": {
+          "name": "idx_ai_tutor_message_count_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_tutor_message_count_org_id_fkey": {
+          "name": "ai_tutor_message_count_org_id_fkey",
+          "tableFrom": "ai_tutor_message_count",
+          "tableTo": "organization",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_tutor_message_count_user_id_fkey": {
+          "name": "ai_tutor_message_count_user_id_fkey",
+          "tableFrom": "ai_tutor_message_count",
+          "tableTo": "profile",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_tutor_message_count_org_user_period_key": {
+          "name": "ai_tutor_message_count_org_user_period_key",
+          "nullsNotDistinct": false,
+          "columns": ["org_id", "user_id", "period_start"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analytics_country_daily": {
+      "name": "analytics_country_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enrollments": {
+          "name": "enrollments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_acntd_org_date": {
+          "name": "idx_acntd_org_date",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analytics_country_daily_org_date_country_unique": {
+          "name": "analytics_country_daily_org_date_country_unique",
+          "nullsNotDistinct": false,
+          "columns": ["org_id", "date", "country"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analytics_course_daily": {
+      "name": "analytics_course_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_visitors": {
+          "name": "unique_visitors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enrollments": {
+          "name": "enrollments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completions": {
+          "name": "completions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_time_to_enroll_seconds": {
+          "name": "avg_time_to_enroll_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_acd_org_date": {
+          "name": "idx_acd_org_date",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_acd_course_date": {
+          "name": "idx_acd_course_date",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analytics_course_daily_course_date_unique": {
+          "name": "analytics_course_daily_course_date_unique",
+          "nullsNotDistinct": false,
+          "columns": ["course_id", "date"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analytics_login_events": {
+      "name": "analytics_login_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logged_in_at": {
+          "name": "logged_in_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "logged_in_date": {
+          "name": "logged_in_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_DATE"
+        }
+      },
+      "indexes": {
+        "idx_analytics_login_events_logged_in_at": {
+          "name": "idx_analytics_login_events_logged_in_at",
+          "columns": [
+            {
+              "expression": "logged_in_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_analytics_login_events_user_id": {
+          "name": "idx_analytics_login_events_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_analytics_login_events_logged_in_date": {
+          "name": "idx_analytics_login_events_logged_in_date",
+          "columns": [
+            {
+              "expression": "logged_in_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analytics_login_events_user_id_fkey": {
+          "name": "analytics_login_events_user_id_fkey",
+          "tableFrom": "analytics_login_events",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analytics_login_events_user_id_date_unique": {
+          "name": "analytics_login_events_user_id_date_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "logged_in_date"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analytics_org_daily": {
+      "name": "analytics_org_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landing_views": {
+          "name": "landing_views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_visitors": {
+          "name": "unique_visitors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "course_page_views": {
+          "name": "course_page_views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enrollments": {
+          "name": "enrollments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completions": {
+          "name": "completions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_aod_org_date": {
+          "name": "idx_aod_org_date",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analytics_org_daily_org_date_unique": {
+          "name": "analytics_org_daily_org_date_unique",
+          "nullsNotDistinct": false,
+          "columns": ["org_id", "date"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analytics_page_event": {
+      "name": "analytics_page_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer_host": {
+          "name": "referrer_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_source": {
+          "name": "utm_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_medium": {
+          "name": "utm_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_campaign": {
+          "name": "utm_campaign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "props": {
+          "name": "props",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_ape_org_occurred": {
+          "name": "idx_ape_org_occurred",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ape_course_occurred": {
+          "name": "idx_ape_course_occurred",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ape_session": {
+          "name": "idx_ape_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ape_event_type": {
+          "name": "idx_ape_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ape_user": {
+          "name": "idx_ape_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apps_poll": {
+      "name": "apps_poll",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "courseId": {
+          "name": "courseId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apps_poll_authorId_fkey": {
+          "name": "apps_poll_authorId_fkey",
+          "tableFrom": "apps_poll",
+          "tableTo": "groupmember",
+          "columnsFrom": ["authorId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "apps_poll_courseId_fkey": {
+          "name": "apps_poll_courseId_fkey",
+          "tableFrom": "apps_poll",
+          "tableTo": "course",
+          "columnsFrom": ["courseId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apps_poll_option": {
+      "name": "apps_poll_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "apps_poll_option_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apps_poll_option_poll_id_fkey": {
+          "name": "apps_poll_option_poll_id_fkey",
+          "tableFrom": "apps_poll_option",
+          "tableTo": "apps_poll",
+          "columnsFrom": ["poll_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apps_poll_submission": {
+      "name": "apps_poll_submission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "apps_poll_submision_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "poll_option_id": {
+          "name": "poll_option_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_by_id": {
+          "name": "selected_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apps_poll_submission_poll_id_fkey": {
+          "name": "apps_poll_submission_poll_id_fkey",
+          "tableFrom": "apps_poll_submission",
+          "tableTo": "apps_poll",
+          "columnsFrom": ["poll_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "apps_poll_submission_poll_option_id_fkey": {
+          "name": "apps_poll_submission_poll_option_id_fkey",
+          "tableFrom": "apps_poll_submission",
+          "tableTo": "apps_poll_option",
+          "columnsFrom": ["poll_option_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "apps_poll_submission_selected_by_id_fkey": {
+          "name": "apps_poll_submission_selected_by_id_fkey",
+          "tableFrom": "apps_poll_submission",
+          "tableTo": "groupmember",
+          "columnsFrom": ["selected_by_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'video'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upload'"
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'s3'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hls_manifest_key": {
+          "name": "hls_manifest_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hls_audio_key": {
+          "name": "hls_audio_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_candidates": {
+          "name": "thumbnail_candidates",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_external": {
+          "name": "is_external",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_assets_organization_id": {
+          "name": "idx_assets_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_assets_organization_status": {
+          "name": "idx_assets_organization_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_assets_organization_kind_status": {
+          "name": "idx_assets_organization_kind_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_assets_organization_created_at": {
+          "name": "idx_assets_organization_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_assets_organization_byte_size": {
+          "name": "idx_assets_organization_byte_size",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "byte_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_organization_id_fkey": {
+          "name": "assets_organization_id_fkey",
+          "tableFrom": "assets",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "assets_created_by_profile_id_fkey": {
+          "name": "assets_created_by_profile_id_fkey",
+          "tableFrom": "assets",
+          "tableTo": "profile",
+          "columnsFrom": ["created_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "assets_org_provider_storage_key_unique": {
+          "name": "assets_org_provider_storage_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["organization_id", "provider", "storage_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_usages": {
+      "name": "asset_usages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_type": {
+          "name": "slot_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lesson_video'"
+        },
+        "slot_key": {
+          "name": "slot_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_asset_usages_org_id": {
+          "name": "idx_asset_usages_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_asset_usages_asset_id": {
+          "name": "idx_asset_usages_asset_id",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_asset_usages_target": {
+          "name": "idx_asset_usages_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "asset_usages_organization_id_fkey": {
+          "name": "asset_usages_organization_id_fkey",
+          "tableFrom": "asset_usages",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "asset_usages_asset_id_fkey": {
+          "name": "asset_usages_asset_id_fkey",
+          "tableFrom": "asset_usages",
+          "tableTo": "assets",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "asset_usages_created_by_profile_id_fkey": {
+          "name": "asset_usages_created_by_profile_id_fkey",
+          "tableFrom": "asset_usages",
+          "tableTo": "profile",
+          "columnsFrom": ["created_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_usages_asset_target_slot_unique": {
+          "name": "asset_usages_asset_target_slot_unique",
+          "nullsNotDistinct": false,
+          "columns": ["asset_id", "target_type", "target_id", "slot_type", "slot_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort": {
+      "name": "cohort",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "COHORT_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cohort_organization_id": {
+          "name": "idx_cohort_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cohort_organization_id_fkey": {
+          "name": "cohort_organization_id_fkey",
+          "tableFrom": "cohort",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cohort_created_by_profile_id_fkey": {
+          "name": "cohort_created_by_profile_id_fkey",
+          "tableFrom": "cohort",
+          "tableTo": "profile",
+          "columnsFrom": ["created_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_course": {
+      "name": "cohort_course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cohort_course_cohort_id": {
+          "name": "idx_cohort_course_cohort_id",
+          "columns": [
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cohort_course_cohort_id_fkey": {
+          "name": "cohort_course_cohort_id_fkey",
+          "tableFrom": "cohort_course",
+          "tableTo": "cohort",
+          "columnsFrom": ["cohort_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cohort_course_course_id_fkey": {
+          "name": "cohort_course_course_id_fkey",
+          "tableFrom": "cohort_course",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cohort_course_cohort_id_course_id_unique": {
+          "name": "cohort_course_cohort_id_course_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["cohort_id", "course_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_goal": {
+      "name": "cohort_goal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "COHORT_GOAL_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_ids": {
+          "name": "course_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "required_count": {
+          "name": "required_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_threshold": {
+          "name": "score_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_pass_rate_threshold": {
+          "name": "team_pass_rate_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_kind": {
+          "name": "deadline_kind",
+          "type": "COHORT_GOAL_DEADLINE_KIND",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "deadline_date": {
+          "name": "deadline_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relative_days": {
+          "name": "relative_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_months": {
+          "name": "recurring_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_days_before": {
+          "name": "reminder_days_before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[7,1]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "COHORT_GOAL_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cohort_goal_cohort_id": {
+          "name": "idx_cohort_goal_cohort_id",
+          "columns": [
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cohort_goal_status": {
+          "name": "idx_cohort_goal_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cohort_goal_cohort_id_fkey": {
+          "name": "cohort_goal_cohort_id_fkey",
+          "tableFrom": "cohort_goal",
+          "tableTo": "cohort",
+          "columnsFrom": ["cohort_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cohort_goal_created_by_profile_id_fkey": {
+          "name": "cohort_goal_created_by_profile_id_fkey",
+          "tableFrom": "cohort_goal",
+          "tableTo": "profile",
+          "columnsFrom": ["created_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_goal_assignment": {
+      "name": "cohort_goal_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_member_id": {
+          "name": "cohort_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "COHORT_GOAL_ASSIGNMENT_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "required_count": {
+          "name": "required_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cohort_goal_assignment_goal_id": {
+          "name": "idx_cohort_goal_assignment_goal_id",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cohort_goal_assignment_cohort_member_id": {
+          "name": "idx_cohort_goal_assignment_cohort_member_id",
+          "columns": [
+            {
+              "expression": "cohort_member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cohort_goal_assignment_due_date": {
+          "name": "idx_cohort_goal_assignment_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cohort_goal_assignment_goal_id_fkey": {
+          "name": "cohort_goal_assignment_goal_id_fkey",
+          "tableFrom": "cohort_goal_assignment",
+          "tableTo": "cohort_goal",
+          "columnsFrom": ["goal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cohort_goal_assignment_cohort_member_id_fkey": {
+          "name": "cohort_goal_assignment_cohort_member_id_fkey",
+          "tableFrom": "cohort_goal_assignment",
+          "tableTo": "cohort_member",
+          "columnsFrom": ["cohort_member_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cohort_goal_assignment_goal_id_cohort_member_id_unique": {
+          "name": "cohort_goal_assignment_goal_id_cohort_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["goal_id", "cohort_member_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_member": {
+      "name": "cohort_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cohort_member_cohort_id": {
+          "name": "idx_cohort_member_cohort_id",
+          "columns": [
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cohort_member_profile_id": {
+          "name": "idx_cohort_member_profile_id",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cohort_member_cohort_id_fkey": {
+          "name": "cohort_member_cohort_id_fkey",
+          "tableFrom": "cohort_member",
+          "tableTo": "cohort",
+          "columnsFrom": ["cohort_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cohort_member_profile_id_fkey": {
+          "name": "cohort_member_profile_id_fkey",
+          "tableFrom": "cohort_member",
+          "tableTo": "profile",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cohort_member_role_id_fkey": {
+          "name": "cohort_member_role_id_fkey",
+          "tableFrom": "cohort_member",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cohort_member_cohort_id_profile_id_unique": {
+          "name": "cohort_member_cohort_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["cohort_id", "profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_newsfeed": {
+      "name": "cohort_newsfeed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"clap\":[],\"smile\":[],\"thumbsup\":[],\"thumbsdown\":[]}'::jsonb"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_cohort_newsfeed_cohort_id": {
+          "name": "idx_cohort_newsfeed_cohort_id",
+          "columns": [
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cohort_newsfeed_author_id_fkey": {
+          "name": "cohort_newsfeed_author_id_fkey",
+          "tableFrom": "cohort_newsfeed",
+          "tableTo": "cohort_member",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cohort_newsfeed_cohort_id_fkey": {
+          "name": "cohort_newsfeed_cohort_id_fkey",
+          "tableFrom": "cohort_newsfeed",
+          "tableTo": "cohort",
+          "columnsFrom": ["cohort_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_newsfeed_comment": {
+      "name": "cohort_newsfeed_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cohort_newsfeed_comment_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cohort_newsfeed_id": {
+          "name": "cohort_newsfeed_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cohort_newsfeed_comment_author_id_fkey": {
+          "name": "cohort_newsfeed_comment_author_id_fkey",
+          "tableFrom": "cohort_newsfeed_comment",
+          "tableTo": "cohort_member",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cohort_newsfeed_comment_cohort_newsfeed_id_fkey": {
+          "name": "cohort_newsfeed_comment_cohort_newsfeed_id_fkey",
+          "tableFrom": "cohort_newsfeed_comment",
+          "tableTo": "cohort_newsfeed",
+          "columnsFrom": ["cohort_newsfeed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_answer": {
+      "name": "community_answer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "votes": {
+          "name": "votes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_answer_author_id_fkey": {
+          "name": "community_answer_author_id_fkey",
+          "tableFrom": "community_answer",
+          "tableTo": "organizationmember",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_answer_author_profile_id_fkey": {
+          "name": "community_answer_author_profile_id_fkey",
+          "tableFrom": "community_answer",
+          "tableTo": "profile",
+          "columnsFrom": ["author_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_answer_question_id_fkey": {
+          "name": "community_answer_question_id_fkey",
+          "tableFrom": "community_answer",
+          "tableTo": "community_question",
+          "columnsFrom": ["question_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_question": {
+      "name": "community_question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "community_question_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "votes": {
+          "name": "votes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_profile_id": {
+          "name": "author_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_question_author_id_fkey": {
+          "name": "community_question_author_id_fkey",
+          "tableFrom": "community_question",
+          "tableTo": "organizationmember",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_question_author_profile_id_fkey": {
+          "name": "community_question_author_profile_id_fkey",
+          "tableFrom": "community_question",
+          "tableTo": "profile",
+          "columnsFrom": ["author_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_question_course_id_fkey": {
+          "name": "community_question_course_id_fkey",
+          "tableFrom": "community_question",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_question_organization_id_fkey": {
+          "name": "community_question_organization_id_fkey",
+          "tableFrom": "community_question",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course": {
+      "name": "course",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overview": {
+          "name": "overview",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Welcome to this amazing course 🚀 '"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_template": {
+          "name": "is_template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"goals\":\"\",\"description\":\"\",\"requirements\":\"\"}'::jsonb"
+        },
+        "cost": {
+          "name": "cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "banner_image": {
+          "name": "banner_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "certificate": {
+          "name": "certificate",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "compliance": {
+          "name": "compliance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "type": {
+          "name": "type",
+          "type": "COURSE_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'SELF_PACED'"
+        },
+        "callout": {
+          "name": "callout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_course_group_id": {
+          "name": "idx_course_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_group_id_fkey": {
+          "name": "course_group_id_fkey",
+          "tableFrom": "course",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "course_slug_key": {
+          "name": "course_slug_key",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_certificate_issue": {
+      "name": "course_certificate_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_completion_record_id": {
+          "name": "course_completion_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cycle_number": {
+          "name": "cycle_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'valid'"
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_course_certificate_issue_course_id": {
+          "name": "idx_course_certificate_issue_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_certificate_issue_profile_id": {
+          "name": "idx_course_certificate_issue_profile_id",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_certificate_issue_status": {
+          "name": "idx_course_certificate_issue_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_certificate_issue_course_id_fkey": {
+          "name": "course_certificate_issue_course_id_fkey",
+          "tableFrom": "course_certificate_issue",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_certificate_issue_profile_id_fkey": {
+          "name": "course_certificate_issue_profile_id_fkey",
+          "tableFrom": "course_certificate_issue",
+          "tableTo": "profile",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_certificate_issue_record_id_fkey": {
+          "name": "course_certificate_issue_record_id_fkey",
+          "tableFrom": "course_certificate_issue",
+          "tableTo": "course_completion_record",
+          "columnsFrom": ["course_completion_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "course_certificate_issue_record_id_key": {
+          "name": "course_certificate_issue_record_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["course_completion_record_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_completion_notification_event": {
+      "name": "course_completion_notification_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_completion_record_id": {
+          "name": "course_completion_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_completion_notification_event_record_id_fkey": {
+          "name": "course_completion_notification_event_record_id_fkey",
+          "tableFrom": "course_completion_notification_event",
+          "tableTo": "course_completion_record",
+          "columnsFrom": ["course_completion_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "course_completion_notification_event_record_channel_type_key": {
+          "name": "course_completion_notification_event_record_channel_type_key",
+          "nullsNotDistinct": false,
+          "columns": ["course_completion_record_id", "channel", "event_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_completion_record": {
+      "name": "course_completion_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_member_id": {
+          "name": "group_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cycle_number": {
+          "name": "cycle_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "time_spent_minutes": {
+          "name": "time_spent_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "waived_by": {
+          "name": "waived_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waiver_reason": {
+          "name": "waiver_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waiver_expires_at": {
+          "name": "waiver_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_course_completion_record_course_id": {
+          "name": "idx_course_completion_record_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_completion_record_profile_id": {
+          "name": "idx_course_completion_record_profile_id",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_completion_record_status": {
+          "name": "idx_course_completion_record_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_completion_record_due_date": {
+          "name": "idx_course_completion_record_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_completion_record_valid_until": {
+          "name": "idx_course_completion_record_valid_until",
+          "columns": [
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_completion_record_course_id_fkey": {
+          "name": "course_completion_record_course_id_fkey",
+          "tableFrom": "course_completion_record",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_completion_record_group_member_id_fkey": {
+          "name": "course_completion_record_group_member_id_fkey",
+          "tableFrom": "course_completion_record",
+          "tableTo": "groupmember",
+          "columnsFrom": ["group_member_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_completion_record_profile_id_fkey": {
+          "name": "course_completion_record_profile_id_fkey",
+          "tableFrom": "course_completion_record",
+          "tableTo": "profile",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_completion_record_waived_by_fkey": {
+          "name": "course_completion_record_waived_by_fkey",
+          "tableFrom": "course_completion_record",
+          "tableTo": "profile",
+          "columnsFrom": ["waived_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "course_completion_record_course_profile_cycle_key": {
+          "name": "course_completion_record_course_profile_cycle_key",
+          "nullsNotDistinct": false,
+          "columns": ["course_id", "profile_id", "cycle_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_import_draft": {
+      "name": "course_import_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "COURSE_IMPORT_SOURCE_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "COURSE_IMPORT_DRAFT_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "LOCALE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "draft": {
+          "name": "draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sourceArtifacts": {
+          "name": "sourceArtifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "published_course_id": {
+          "name": "published_course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_course_import_draft_org_id": {
+          "name": "idx_course_import_draft_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_import_draft_status": {
+          "name": "idx_course_import_draft_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "course_import_draft_org_idempotency_key": {
+          "name": "course_import_draft_org_idempotency_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course_import_draft\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_import_draft_organization_id_organization_id_fk": {
+          "name": "course_import_draft_organization_id_organization_id_fk",
+          "tableFrom": "course_import_draft",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_import_draft_created_by_profile_id_profile_id_fk": {
+          "name": "course_import_draft_created_by_profile_id_profile_id_fk",
+          "tableFrom": "course_import_draft",
+          "tableTo": "profile",
+          "columnsFrom": ["created_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "course_import_draft_published_course_id_course_id_fk": {
+          "name": "course_import_draft_published_course_id_course_id_fk",
+          "tableFrom": "course_import_draft",
+          "tableTo": "course",
+          "columnsFrom": ["published_course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_invite": {
+      "name": "course_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'3'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_by_profile_id": {
+          "name": "revoked_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_revoked": {
+          "name": "is_revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_emails": {
+          "name": "allowed_emails",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_domains": {
+          "name": "allowed_domains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_course_invite_course_id": {
+          "name": "idx_course_invite_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_invite_expires_at": {
+          "name": "idx_course_invite_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_invite_created_by": {
+          "name": "idx_course_invite_created_by",
+          "columns": [
+            {
+              "expression": "created_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_invite_revoked_by": {
+          "name": "idx_course_invite_revoked_by",
+          "columns": [
+            {
+              "expression": "revoked_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_invite_course_id_fkey": {
+          "name": "course_invite_course_id_fkey",
+          "tableFrom": "course_invite",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_invite_created_by_profile_id_fkey": {
+          "name": "course_invite_created_by_profile_id_fkey",
+          "tableFrom": "course_invite",
+          "tableTo": "profile",
+          "columnsFrom": ["created_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "course_invite_revoked_by_profile_id_fkey": {
+          "name": "course_invite_revoked_by_profile_id_fkey",
+          "tableFrom": "course_invite",
+          "tableTo": "profile",
+          "columnsFrom": ["revoked_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "course_invite_role_id_fkey": {
+          "name": "course_invite_role_id_fkey",
+          "tableFrom": "course_invite",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "course_invite_token_hash_key": {
+          "name": "course_invite_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_invite_audit": {
+      "name": "course_invite_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "COURSE_INVITE_EVENT_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_profile_id": {
+          "name": "actor_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_course_invite_audit_invite_id": {
+          "name": "idx_course_invite_audit_invite_id",
+          "columns": [
+            {
+              "expression": "invite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_invite_audit_course_id": {
+          "name": "idx_course_invite_audit_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_invite_audit_event_type": {
+          "name": "idx_course_invite_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_invite_audit_created_at": {
+          "name": "idx_course_invite_audit_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_invite_audit_invite_id_fkey": {
+          "name": "course_invite_audit_invite_id_fkey",
+          "tableFrom": "course_invite_audit",
+          "tableTo": "course_invite",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_invite_audit_course_id_fkey": {
+          "name": "course_invite_audit_course_id_fkey",
+          "tableFrom": "course_invite_audit",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_invite_audit_actor_profile_id_fkey": {
+          "name": "course_invite_audit_actor_profile_id_fkey",
+          "tableFrom": "course_invite_audit",
+          "tableTo": "profile",
+          "columnsFrom": ["actor_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_newsfeed": {
+      "name": "course_newsfeed",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"clap\":[],\"smile\":[],\"thumbsup\":[],\"thumbsdown\":[]}'::jsonb"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_newsfeed_author_id_fkey": {
+          "name": "course_newsfeed_author_id_fkey",
+          "tableFrom": "course_newsfeed",
+          "tableTo": "groupmember",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "course_newsfeed_course_id_fkey": {
+          "name": "course_newsfeed_course_id_fkey",
+          "tableFrom": "course_newsfeed",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_newsfeed_comment": {
+      "name": "course_newsfeed_comment",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "course_newsfeed_comment_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "course_newsfeed_id": {
+          "name": "course_newsfeed_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_newsfeed_comment_author_id_fkey": {
+          "name": "course_newsfeed_comment_author_id_fkey",
+          "tableFrom": "course_newsfeed_comment",
+          "tableTo": "groupmember",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "course_newsfeed_comment_course_newsfeed_id_fkey": {
+          "name": "course_newsfeed_comment_course_newsfeed_id_fkey",
+          "tableFrom": "course_newsfeed_comment",
+          "tableTo": "course_newsfeed",
+          "columnsFrom": ["course_newsfeed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_section": {
+      "name": "course_section",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_section_course_id_course_id_fk": {
+          "name": "course_section_course_id_course_id_fk",
+          "tableFrom": "course_section",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "currency_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dead_letter_job": {
+      "name": "dead_letter_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queue_name": {
+          "name": "queue_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bullmq_job_id": {
+          "name": "bullmq_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "replayed_at": {
+          "name": "replayed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_dead_letter_job_domain_created": {
+          "name": "idx_dead_letter_job_domain_created",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dead_letter_job_org_created": {
+          "name": "idx_dead_letter_job_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercise": {
+      "name": "exercise",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_unlocked": {
+          "name": "is_unlocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "due_by": {
+          "name": "due_by",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_multiple_attempts": {
+          "name": "allow_multiple_attempts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "section_display_mode": {
+          "name": "section_display_mode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'one_question'"
+        },
+        "completion_policy": {
+          "name": "completion_policy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "pass_threshold": {
+          "name": "pass_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_exercise_course_slug": {
+          "name": "idx_exercise_course_slug",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercise_lesson_id_fkey": {
+          "name": "exercise_lesson_id_fkey",
+          "tableFrom": "exercise",
+          "tableTo": "lesson",
+          "columnsFrom": ["lesson_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_course_id_fkey": {
+          "name": "exercise_course_id_fkey",
+          "tableFrom": "exercise",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "exercise_section_id_fkey": {
+          "name": "exercise_section_id_fkey",
+          "tableFrom": "exercise",
+          "tableTo": "course_section",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercise_section": {
+      "name": "exercise_section",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled Section'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "color_theme": {
+          "name": "color_theme",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "after_behavior": {
+          "name": "after_behavior",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"action\":\"continue\"}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_exercise_section_exercise_id": {
+          "name": "idx_exercise_section_exercise_id",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercise_section_exercise_id_fkey": {
+          "name": "exercise_section_exercise_id_fkey",
+          "tableFrom": "exercise_section",
+          "tableTo": "exercise",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercise_template": {
+      "name": "exercise_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "exercise_template_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questionnaire": {
+          "name": "questionnaire",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group": {
+      "name": "group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_group_organization_id": {
+          "name": "idx_group_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_organization_id_fkey": {
+          "name": "group_organization_id_fkey",
+          "tableFrom": "group",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_attendance": {
+      "name": "group_attendance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "group_attendance_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_present": {
+          "name": "is_present",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_attendance_course_id_fkey": {
+          "name": "group_attendance_course_id_fkey",
+          "tableFrom": "group_attendance",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_attendance_student_id_fkey": {
+          "name": "group_attendance_student_id_fkey",
+          "tableFrom": "group_attendance",
+          "tableTo": "groupmember",
+          "columnsFrom": ["student_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groupmember": {
+      "name": "groupmember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "assigned_student_id": {
+          "name": "assigned_student_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_earned_at": {
+          "name": "certificate_earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certification_email_sent_at": {
+          "name": "certification_email_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "groupmember_group_id_fkey": {
+          "name": "groupmember_group_id_fkey",
+          "tableFrom": "groupmember",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groupmember_profile_id_fkey": {
+          "name": "groupmember_profile_id_fkey",
+          "tableFrom": "groupmember",
+          "tableTo": "profile",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "groupmember_role_id_fkey": {
+          "name": "groupmember_role_id_fkey",
+          "tableFrom": "groupmember",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_entries": {
+          "name": "unique_entries",
+          "nullsNotDistinct": false,
+          "columns": ["group_id", "profile_id", "email"]
+        },
+        "unique_group_email": {
+          "name": "unique_group_email",
+          "nullsNotDistinct": false,
+          "columns": ["group_id", "email"]
+        },
+        "unique_group_profile": {
+          "name": "unique_group_profile",
+          "nullsNotDistinct": false,
+          "columns": ["group_id", "profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_step": {
+      "name": "job_step",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_key": {
+          "name": "step_key",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "JOB_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_job_step_run": {
+          "name": "idx_job_step_run",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_step_run_step_unique": {
+          "name": "job_step_run_step_unique",
+          "nullsNotDistinct": false,
+          "columns": ["domain", "run_id", "step_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lesson": {
+      "name": "lesson",
+      "schema": "",
+      "columns": {
+        "note": {
+          "name": "note",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "lesson_at": {
+          "name": "lesson_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "teacher_id": {
+          "name": "teacher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "call_url": {
+          "name": "call_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_unlocked": {
+          "name": "is_unlocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "completion_policy": {
+          "name": "completion_policy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "video_watch_threshold": {
+          "name": "video_watch_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 95
+        },
+        "videos": {
+          "name": "videos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "documents": {
+          "name": "documents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_lesson_course_slug": {
+          "name": "idx_lesson_course_slug",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lesson_section_id_course_section_id_fk": {
+          "name": "lesson_section_id_course_section_id_fk",
+          "tableFrom": "lesson",
+          "tableTo": "course_section",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "lesson_course_id_fkey": {
+          "name": "lesson_course_id_fkey",
+          "tableFrom": "lesson",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lesson_teacher_id_fkey": {
+          "name": "lesson_teacher_id_fkey",
+          "tableFrom": "lesson",
+          "tableTo": "profile",
+          "columnsFrom": ["teacher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lesson_comment": {
+      "name": "lesson_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "lesson_comment_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groupmember_id": {
+          "name": "groupmember_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lesson_comment_groupmember_id_fkey": {
+          "name": "lesson_comment_groupmember_id_fkey",
+          "tableFrom": "lesson_comment",
+          "tableTo": "groupmember",
+          "columnsFrom": ["groupmember_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lesson_comment_lesson_id_fkey": {
+          "name": "lesson_comment_lesson_id_fkey",
+          "tableFrom": "lesson_comment",
+          "tableTo": "lesson",
+          "columnsFrom": ["lesson_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lesson_completion": {
+      "name": "lesson_completion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "lesson_completion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lesson_completion_lesson_id_fkey": {
+          "name": "lesson_completion_lesson_id_fkey",
+          "tableFrom": "lesson_completion",
+          "tableTo": "lesson",
+          "columnsFrom": ["lesson_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lesson_completion_profile_id_fkey": {
+          "name": "lesson_completion_profile_id_fkey",
+          "tableFrom": "lesson_completion",
+          "tableTo": "profile",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_lesson_profile": {
+          "name": "unique_lesson_profile",
+          "nullsNotDistinct": false,
+          "columns": ["lesson_id", "profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lesson_language": {
+      "name": "lesson_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "lesson_language_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "LOCALE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'en'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "public_lesson_language_lesson_id_fkey": {
+          "name": "public_lesson_language_lesson_id_fkey",
+          "tableFrom": "lesson_language",
+          "tableTo": "lesson",
+          "columnsFrom": ["lesson_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lesson_language_history": {
+      "name": "lesson_language_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lesson_language_id": {
+          "name": "lesson_language_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_content": {
+          "name": "old_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_content": {
+          "name": "new_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "public_lesson_language_history_lesson_language_id_fkey": {
+          "name": "public_lesson_language_history_lesson_language_id_fkey",
+          "tableFrom": "lesson_language_history",
+          "tableTo": "lesson_language",
+          "columnsFrom": ["lesson_language_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lesson_video_progress": {
+      "name": "lesson_video_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watched_seconds": {
+          "name": "watched_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "furthest_seconds": {
+          "name": "furthest_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_position_seconds": {
+          "name": "last_position_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lesson_video_progress_lesson_id_fkey": {
+          "name": "lesson_video_progress_lesson_id_fkey",
+          "tableFrom": "lesson_video_progress",
+          "tableTo": "lesson",
+          "columnsFrom": ["lesson_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lesson_video_progress_profile_id_fkey": {
+          "name": "lesson_video_progress_profile_id_fkey",
+          "tableFrom": "lesson_video_progress",
+          "tableTo": "profile",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lesson_video_progress_lesson_profile_asset_unique": {
+          "name": "lesson_video_progress_lesson_profile_asset_unique",
+          "nullsNotDistinct": false,
+          "columns": ["lesson_id", "profile_id", "asset_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_job": {
+      "name": "media_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by_profile_id": {
+          "name": "triggered_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "JOB_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "stage": {
+          "name": "stage",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_percent": {
+          "name": "progress_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "root_job_id": {
+          "name": "root_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_ids": {
+          "name": "job_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_job_asset_id": {
+          "name": "idx_media_job_asset_id",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_job_org_status": {
+          "name": "idx_media_job_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_job_updated_at": {
+          "name": "idx_media_job_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_job_organization_id_fkey": {
+          "name": "media_job_organization_id_fkey",
+          "tableFrom": "media_job",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "media_job_asset_id_fkey": {
+          "name": "media_job_asset_id_fkey",
+          "tableFrom": "media_job",
+          "tableTo": "assets",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "media_job_triggered_by_profile_id_fkey": {
+          "name": "media_job_triggered_by_profile_id_fkey",
+          "tableFrom": "media_job",
+          "tableTo": "profile",
+          "columnsFrom": ["triggered_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_transcript": {
+      "name": "media_transcript",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_job_id": {
+          "name": "media_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai'"
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'whisper-1'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vtt_storage_key": {
+          "name": "vtt_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vtt_bucket": {
+          "name": "vtt_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_transcript_asset": {
+          "name": "idx_media_transcript_asset",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_transcript_organization_id_fkey": {
+          "name": "media_transcript_organization_id_fkey",
+          "tableFrom": "media_transcript",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "media_transcript_asset_id_fkey": {
+          "name": "media_transcript_asset_id_fkey",
+          "tableFrom": "media_transcript",
+          "tableTo": "assets",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "media_transcript_media_job_id_fkey": {
+          "name": "media_transcript_media_job_id_fkey",
+          "tableFrom": "media_transcript",
+          "tableTo": "media_job",
+          "columnsFrom": ["media_job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media_transcript_asset_id_unique": {
+          "name": "media_transcript_asset_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["asset_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.option": {
+      "name": "option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "option_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "option_question_id_fkey": {
+          "name": "option_question_id_fkey",
+          "tableFrom": "option",
+          "tableTo": "question",
+          "columnsFrom": ["question_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siteName": {
+          "name": "siteName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "landingpage": {
+          "name": "landingpage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'blue'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        },
+        "customization": {
+          "name": "customization",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"apps\":{\"poll\":true,\"comments\":true},\"course\":{\"grading\":true,\"newsfeed\":true},\"dashboard\":{\"exercise\":true,\"community\":true,\"bannerText\":\"\",\"bannerImage\":\"\"}}'::json"
+        },
+        "is_restricted": {
+          "name": "is_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customCode": {
+          "name": "customCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customDomain": {
+          "name": "customDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon": {
+          "name": "favicon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isCustomDomainVerified": {
+          "name": "isCustomDomainVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "disable_signup": {
+          "name": "disable_signup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "disable_signup_message": {
+          "name": "disable_signup_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disable_email_password": {
+          "name": "disable_email_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "disable_google_auth": {
+          "name": "disable_google_auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "parent_organization_id": {
+          "name": "parent_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_only_until": {
+          "name": "read_only_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_tutor_settings": {
+          "name": "ai_tutor_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"enabled\":true,\"persona\":\"encouraging\",\"customPersona\":\"\",\"responseLength\":\"medium\",\"welcomeMessage\":\"\",\"disclaimerFooter\":\"I am an AI tutor, not your instructor.\",\"thingsToSay\":\"\",\"thingsNotToSay\":\"\",\"forbiddenTopics\":[],\"groundingScope\":\"course\",\"requireCitations\":true,\"assessmentMode\":\"hint_only\",\"revealSolutionsAfterAttempts\":3,\"codePolicy\":\"hints_only\",\"blockOffTopic\":true,\"profanityFilter\":true,\"escalation\":{\"enabled\":false,\"email\":\"\"}}'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_organization_parent_id": {
+          "name": "idx_organization_parent_id",
+          "columns": [
+            {
+              "expression": "parent_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_parent_organization_id_fkey": {
+          "name": "organization_parent_organization_id_fkey",
+          "tableFrom": "organization",
+          "tableTo": "organization",
+          "columnsFrom": ["parent_organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_siteName_key": {
+          "name": "organization_siteName_key",
+          "nullsNotDistinct": false,
+          "columns": ["siteName"]
+        },
+        "organization_customDomain_key": {
+          "name": "organization_customDomain_key",
+          "nullsNotDistinct": false,
+          "columns": ["customDomain"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_api_key": {
+      "name": "organization_api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "ORGANIZATION_API_KEY_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_prefix": {
+          "name": "secret_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_organization_api_key_org_id": {
+          "name": "idx_organization_api_key_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_api_key_type": {
+          "name": "idx_organization_api_key_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_api_key_secret_hash_unique": {
+          "name": "organization_api_key_secret_hash_unique",
+          "columns": [
+            {
+              "expression": "secret_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_api_key_organization_id_organization_id_fk": {
+          "name": "organization_api_key_organization_id_organization_id_fk",
+          "tableFrom": "organization_api_key",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_api_key_created_by_profile_id_profile_id_fk": {
+          "name": "organization_api_key_created_by_profile_id_profile_id_fk",
+          "tableFrom": "organization_api_key",
+          "tableTo": "profile",
+          "columnsFrom": ["created_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_auth_policy": {
+      "name": "organization_auth_policy",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "force_sso": {
+          "name": "force_sso",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_join_sso_domains": {
+          "name": "auto_join_sso_domains",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "break_glass_enabled": {
+          "name": "break_glass_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_role_id": {
+          "name": "default_role_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'3'"
+        },
+        "role_mapping": {
+          "name": "role_mapping",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_organization_auth_policy_org_id": {
+          "name": "idx_organization_auth_policy_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_auth_policy_organization_id_organization_id_fk": {
+          "name": "organization_auth_policy_organization_id_organization_id_fk",
+          "tableFrom": "organization_auth_policy",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_auth_policy_default_role_id_fkey": {
+          "name": "organization_auth_policy_default_role_id_fkey",
+          "tableFrom": "organization_auth_policy",
+          "tableTo": "role",
+          "columnsFrom": ["default_role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_automation_usage": {
+      "name": "organization_automation_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_api_key_id": {
+          "name": "organization_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "ORGANIZATION_API_KEY_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "AUTOMATION_USAGE_CATEGORY",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_consumed": {
+          "name": "credits_consumed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_org_automation_usage_org_created_at": {
+          "name": "idx_org_automation_usage_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_automation_usage_key_created_at": {
+          "name": "idx_org_automation_usage_key_created_at",
+          "columns": [
+            {
+              "expression": "organization_api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_automation_usage_type_created_at": {
+          "name": "idx_org_automation_usage_type_created_at",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_automation_usage_organization_id_organization_id_fk": {
+          "name": "organization_automation_usage_organization_id_organization_id_fk",
+          "tableFrom": "organization_automation_usage",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_automation_usage_organization_api_key_id_organization_api_key_id_fk": {
+          "name": "organization_automation_usage_organization_api_key_id_organization_api_key_id_fk",
+          "tableFrom": "organization_automation_usage",
+          "tableTo": "organization_api_key",
+          "columnsFrom": ["organization_api_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_contacts": {
+      "name": "organization_contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "organization_contacts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_contacts_organization_id_fkey": {
+          "name": "organization_contacts_organization_id_fkey",
+          "tableFrom": "organization_contacts",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_emaillist": {
+      "name": "organization_emaillist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "organization_emaillist_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_emaillist_organization_id_fkey": {
+          "name": "organization_emaillist_organization_id_fkey",
+          "tableFrom": "organization_emaillist",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_invite": {
+      "name": "organization_invite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "ORGANIZATION_INVITE_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EMAIL'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_by_profile_id": {
+          "name": "accepted_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_profile_id": {
+          "name": "revoked_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_revoked": {
+          "name": "is_revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_organization_invite_organization_id": {
+          "name": "idx_organization_invite_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_invite_email_org": {
+          "name": "idx_organization_invite_email_org",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_invite_expires_at": {
+          "name": "idx_organization_invite_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_invite_created_by": {
+          "name": "idx_organization_invite_created_by",
+          "columns": [
+            {
+              "expression": "created_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_invite_accepted_by": {
+          "name": "idx_organization_invite_accepted_by",
+          "columns": [
+            {
+              "expression": "accepted_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_invite_revoked_by": {
+          "name": "idx_organization_invite_revoked_by",
+          "columns": [
+            {
+              "expression": "revoked_by_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_invite_organization_id_fkey": {
+          "name": "organization_invite_organization_id_fkey",
+          "tableFrom": "organization_invite",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invite_role_id_fkey": {
+          "name": "organization_invite_role_id_fkey",
+          "tableFrom": "organization_invite",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_invite_created_by_profile_id_fkey": {
+          "name": "organization_invite_created_by_profile_id_fkey",
+          "tableFrom": "organization_invite",
+          "tableTo": "profile",
+          "columnsFrom": ["created_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_invite_accepted_by_profile_id_fkey": {
+          "name": "organization_invite_accepted_by_profile_id_fkey",
+          "tableFrom": "organization_invite",
+          "tableTo": "profile",
+          "columnsFrom": ["accepted_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_invite_revoked_by_profile_id_fkey": {
+          "name": "organization_invite_revoked_by_profile_id_fkey",
+          "tableFrom": "organization_invite",
+          "tableTo": "profile",
+          "columnsFrom": ["revoked_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_invite_token_hash_key": {
+          "name": "organization_invite_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_invite_audit": {
+      "name": "organization_invite_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "ORGANIZATION_INVITE_EVENT_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_profile_id": {
+          "name": "actor_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_organization_invite_audit_invite_id": {
+          "name": "idx_organization_invite_audit_invite_id",
+          "columns": [
+            {
+              "expression": "invite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_invite_audit_org_id": {
+          "name": "idx_organization_invite_audit_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_invite_audit_event_type": {
+          "name": "idx_organization_invite_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_invite_audit_created_at": {
+          "name": "idx_organization_invite_audit_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_invite_audit_invite_id_fkey": {
+          "name": "organization_invite_audit_invite_id_fkey",
+          "tableFrom": "organization_invite_audit",
+          "tableTo": "organization_invite",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invite_audit_organization_id_fkey": {
+          "name": "organization_invite_audit_organization_id_fkey",
+          "tableFrom": "organization_invite_audit",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invite_audit_actor_profile_id_fkey": {
+          "name": "organization_invite_audit_actor_profile_id_fkey",
+          "tableFrom": "organization_invite_audit",
+          "tableTo": "profile",
+          "columnsFrom": ["actor_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_plan": {
+      "name": "organization_plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "organization_plan_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "PLAN",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'lmz'"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_organization_plan_org_id": {
+          "name": "idx_organization_plan_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_plan_org_id_fkey": {
+          "name": "organization_plan_org_id_fkey",
+          "tableFrom": "organization_plan",
+          "tableTo": "organization",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_plan_triggered_by_fkey": {
+          "name": "organization_plan_triggered_by_fkey",
+          "tableFrom": "organization_plan",
+          "tableTo": "organizationmember",
+          "columnsFrom": ["triggered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_plan_subscription_id_key": {
+          "name": "organization_plan_subscription_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["subscription_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_sso_config": {
+      "name": "organization_sso_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "better_auth_provider_id": {
+          "name": "better_auth_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "SSO_PROVIDER",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_profile_id": {
+          "name": "updated_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_organization_sso_config_org_id": {
+          "name": "idx_organization_sso_config_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_sso_config_domain": {
+          "name": "idx_organization_sso_config_domain",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_sso_config_provider_id": {
+          "name": "idx_organization_sso_config_provider_id",
+          "columns": [
+            {
+              "expression": "better_auth_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_sso_config_organization_id_organization_id_fk": {
+          "name": "organization_sso_config_organization_id_organization_id_fk",
+          "tableFrom": "organization_sso_config",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_sso_config_created_by_profile_id_profile_id_fk": {
+          "name": "organization_sso_config_created_by_profile_id_profile_id_fk",
+          "tableFrom": "organization_sso_config",
+          "tableTo": "profile",
+          "columnsFrom": ["created_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_sso_config_updated_by_profile_id_profile_id_fk": {
+          "name": "organization_sso_config_updated_by_profile_id_profile_id_fk",
+          "tableFrom": "organization_sso_config",
+          "tableTo": "profile",
+          "columnsFrom": ["updated_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_sso_config_organization_id_unique": {
+          "name": "organization_sso_config_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["organization_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_token_auth": {
+      "name": "organization_token_auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_secret": {
+          "name": "signing_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_organization_token_auth_org_id": {
+          "name": "idx_organization_token_auth_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_token_auth_organization_id_organization_id_fk": {
+          "name": "organization_token_auth_organization_id_organization_id_fk",
+          "tableFrom": "organization_token_auth",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_token_auth_created_by_profile_id_profile_id_fk": {
+          "name": "organization_token_auth_created_by_profile_id_profile_id_fk",
+          "tableFrom": "organization_token_auth",
+          "tableTo": "profile",
+          "columnsFrom": ["created_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_token_auth_organization_id_unique": {
+          "name": "organization_token_auth_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["organization_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizationmember": {
+      "name": "organizationmember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "organizationmember_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_organizationmember_profile_id": {
+          "name": "idx_organizationmember_profile_id",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organizationmember_organization_id": {
+          "name": "idx_organizationmember_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organizationmember_profile_org": {
+          "name": "idx_organizationmember_profile_org",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizationmember_org_profile_unique": {
+          "name": "organizationmember_org_profile_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organizationmember\".\"profile_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizationmember_org_email_unique": {
+          "name": "organizationmember_org_email_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organizationmember\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizationmember_organization_id_fkey": {
+          "name": "organizationmember_organization_id_fkey",
+          "tableFrom": "organizationmember",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organizationmember_profile_id_fkey": {
+          "name": "organizationmember_profile_id_fkey",
+          "tableFrom": "organizationmember",
+          "tableTo": "profile",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organizationmember_role_id_fkey": {
+          "name": "organizationmember_role_id_fkey",
+          "tableFrom": "organizationmember",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizationmember_email_notifications": {
+      "name": "organizationmember_email_notifications",
+      "schema": "",
+      "columns": {
+        "organization_member_id": {
+          "name": "organization_member_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_student": {
+          "name": "new_student",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "new_submission": {
+          "name": "new_submission",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "grading_result": {
+          "name": "grading_result",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "newsfeed": {
+          "name": "newsfeed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "quiz_assigned": {
+          "name": "quiz_assigned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cohort_reminder": {
+          "name": "cohort_reminder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "session": {
+          "name": "session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "course_completion": {
+          "name": "course_completion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizationmember_email_notifications_organization_member_id_fkey": {
+          "name": "organizationmember_email_notifications_organization_member_id_fkey",
+          "tableFrom": "organizationmember_email_notifications",
+          "tableTo": "organizationmember",
+          "columnsFrom": ["organization_member_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fullname": {
+          "name": "fullname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_add_course": {
+          "name": "can_add_course",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_email_verified": {
+          "name": "is_email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "LOCALE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'en'"
+        },
+        "is_restricted": {
+          "name": "is_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_profile_id": {
+          "name": "idx_profile_id",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_profile_email": {
+          "name": "idx_profile_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_id_fkey": {
+          "name": "profile_id_fkey",
+          "tableFrom": "profile",
+          "tableTo": "user",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_username_key": {
+          "name": "profile_username_key",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "profile_email_key": {
+          "name": "profile_email_key",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program": {
+      "name": "program",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "PROGRAM_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_program_organization_id": {
+          "name": "idx_program_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "program_organization_id_fkey": {
+          "name": "program_organization_id_fkey",
+          "tableFrom": "program",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_created_by_profile_id_fkey": {
+          "name": "program_created_by_profile_id_fkey",
+          "tableFrom": "program",
+          "tableTo": "profile",
+          "columnsFrom": ["created_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program_course": {
+      "name": "program_course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_program_course_program_id": {
+          "name": "idx_program_course_program_id",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "program_course_program_id_fkey": {
+          "name": "program_course_program_id_fkey",
+          "tableFrom": "program_course",
+          "tableTo": "program",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_course_course_id_fkey": {
+          "name": "program_course_course_id_fkey",
+          "tableFrom": "program_course",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "program_course_program_id_course_id_unique": {
+          "name": "program_course_program_id_course_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["program_id", "course_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program_goal": {
+      "name": "program_goal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "PROGRAM_GOAL_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_ids": {
+          "name": "course_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "required_count": {
+          "name": "required_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_threshold": {
+          "name": "score_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_pass_rate_threshold": {
+          "name": "team_pass_rate_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_kind": {
+          "name": "deadline_kind",
+          "type": "PROGRAM_GOAL_DEADLINE_KIND",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "deadline_date": {
+          "name": "deadline_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relative_days": {
+          "name": "relative_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_months": {
+          "name": "recurring_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_days_before": {
+          "name": "reminder_days_before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[7,1]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "PROGRAM_GOAL_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by_profile_id": {
+          "name": "created_by_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_program_goal_program_id": {
+          "name": "idx_program_goal_program_id",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_program_goal_status": {
+          "name": "idx_program_goal_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "program_goal_program_id_fkey": {
+          "name": "program_goal_program_id_fkey",
+          "tableFrom": "program_goal",
+          "tableTo": "program",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_goal_created_by_profile_id_fkey": {
+          "name": "program_goal_created_by_profile_id_fkey",
+          "tableFrom": "program_goal",
+          "tableTo": "profile",
+          "columnsFrom": ["created_by_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program_goal_assignment": {
+      "name": "program_goal_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_member_id": {
+          "name": "program_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "PROGRAM_GOAL_ASSIGNMENT_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "required_count": {
+          "name": "required_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_program_goal_assignment_goal_id": {
+          "name": "idx_program_goal_assignment_goal_id",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_program_goal_assignment_program_member_id": {
+          "name": "idx_program_goal_assignment_program_member_id",
+          "columns": [
+            {
+              "expression": "program_member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_program_goal_assignment_due_date": {
+          "name": "idx_program_goal_assignment_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "program_goal_assignment_goal_id_fkey": {
+          "name": "program_goal_assignment_goal_id_fkey",
+          "tableFrom": "program_goal_assignment",
+          "tableTo": "program_goal",
+          "columnsFrom": ["goal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_goal_assignment_program_member_id_fkey": {
+          "name": "program_goal_assignment_program_member_id_fkey",
+          "tableFrom": "program_goal_assignment",
+          "tableTo": "program_member",
+          "columnsFrom": ["program_member_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "program_goal_assignment_goal_id_program_member_id_unique": {
+          "name": "program_goal_assignment_goal_id_program_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["goal_id", "program_member_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program_member": {
+      "name": "program_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_program_member_program_id": {
+          "name": "idx_program_member_program_id",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_program_member_profile_id": {
+          "name": "idx_program_member_profile_id",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "program_member_program_id_fkey": {
+          "name": "program_member_program_id_fkey",
+          "tableFrom": "program_member",
+          "tableTo": "program",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_member_profile_id_fkey": {
+          "name": "program_member_profile_id_fkey",
+          "tableFrom": "program_member",
+          "tableTo": "profile",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_member_role_id_fkey": {
+          "name": "program_member_role_id_fkey",
+          "tableFrom": "program_member",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "program_member_program_id_profile_id_unique": {
+          "name": "program_member_program_id_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["program_id", "profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program_newsfeed": {
+      "name": "program_newsfeed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"clap\":[],\"smile\":[],\"thumbsup\":[],\"thumbsdown\":[]}'::jsonb"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_program_newsfeed_program_id": {
+          "name": "idx_program_newsfeed_program_id",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "program_newsfeed_author_id_fkey": {
+          "name": "program_newsfeed_author_id_fkey",
+          "tableFrom": "program_newsfeed",
+          "tableTo": "program_member",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_newsfeed_program_id_fkey": {
+          "name": "program_newsfeed_program_id_fkey",
+          "tableFrom": "program_newsfeed",
+          "tableTo": "program",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program_newsfeed_comment": {
+      "name": "program_newsfeed_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "program_newsfeed_comment_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_newsfeed_id": {
+          "name": "program_newsfeed_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "program_newsfeed_comment_author_id_fkey": {
+          "name": "program_newsfeed_comment_author_id_fkey",
+          "tableFrom": "program_newsfeed_comment",
+          "tableTo": "program_member",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_newsfeed_comment_program_newsfeed_id_fkey": {
+          "name": "program_newsfeed_comment_program_newsfeed_id_fkey",
+          "tableFrom": "program_newsfeed_comment",
+          "tableTo": "program_newsfeed",
+          "columnsFrom": ["program_newsfeed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question": {
+      "name": "question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "question_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "question_type_id": {
+          "name": "question_type_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercise_section_id": {
+          "name": "exercise_section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "points": {
+          "name": "points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "order": {
+          "name": "order",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_exercise_id_fkey": {
+          "name": "question_exercise_id_fkey",
+          "tableFrom": "question",
+          "tableTo": "exercise",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_exercise_section_id_fkey": {
+          "name": "question_exercise_section_id_fkey",
+          "tableFrom": "question",
+          "tableTo": "exercise_section",
+          "columnsFrom": ["exercise_section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "question_question_type_id_fkey": {
+          "name": "question_question_type_id_fkey",
+          "tableFrom": "question",
+          "tableTo": "question_type",
+          "columnsFrom": ["question_type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answer": {
+      "name": "question_answer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "question_answer_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "answer_data": {
+          "name": "answer_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_answer": {
+          "name": "open_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_member_id": {
+          "name": "group_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answer_group_member_id_fkey": {
+          "name": "question_answer_group_member_id_fkey",
+          "tableFrom": "question_answer",
+          "tableTo": "groupmember",
+          "columnsFrom": ["group_member_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answer_question_id_fkey": {
+          "name": "question_answer_question_id_fkey",
+          "tableFrom": "question_answer",
+          "tableTo": "question",
+          "columnsFrom": ["question_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_answer_submission_id_fkey": {
+          "name": "question_answer_submission_id_fkey",
+          "tableFrom": "question_answer",
+          "tableTo": "submission",
+          "columnsFrom": ["submission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_type": {
+      "name": "question_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "question_type_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "typename": {
+          "name": "typename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz": {
+      "name": "quiz",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timelimit": {
+          "name": "timelimit",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'10s'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'standard'"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_organization_id_fkey": {
+          "name": "quiz_organization_id_fkey",
+          "tableFrom": "quiz",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_play": {
+      "name": "quiz_play",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "play_quiz_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "players": {
+          "name": "players",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "started": {
+          "name": "started",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "currentQuestionId": {
+          "name": "currentQuestionId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "showCurrentQuestionAnswer": {
+          "name": "showCurrentQuestionAnswer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "isLastQuestion": {
+          "name": "isLastQuestion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step": {
+          "name": "step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'CONNECT_TO_PLAY'"
+        },
+        "studentStep": {
+          "name": "studentStep",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'PIN_SETUP'"
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_play_quiz_id_fkey": {
+          "name": "quiz_play_quiz_id_fkey",
+          "tableFrom": "quiz_play",
+          "tableTo": "quiz",
+          "columnsFrom": ["quiz_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "quiz_play_pin_key": {
+          "name": "quiz_play_pin_key",
+          "nullsNotDistinct": false,
+          "columns": ["pin"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "role_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submission": {
+      "name": "submission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1'"
+        },
+        "grading_state": {
+          "name": "grading_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "overall_status": {
+          "name": "overall_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual_required'"
+        },
+        "total": {
+          "name": "total",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submission_course_id_fkey": {
+          "name": "submission_course_id_fkey",
+          "tableFrom": "submission",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "submission_exercise_id_fkey": {
+          "name": "submission_exercise_id_fkey",
+          "tableFrom": "submission",
+          "tableTo": "exercise",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "submission_status_id_fkey": {
+          "name": "submission_status_id_fkey",
+          "tableFrom": "submission",
+          "tableTo": "submissionstatus",
+          "columnsFrom": ["status_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submission_submitted_by_fkey": {
+          "name": "submission_submitted_by_fkey",
+          "tableFrom": "submission",
+          "tableTo": "groupmember",
+          "columnsFrom": ["submitted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissionstatus": {
+      "name": "submissionstatus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "submission_status_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag": {
+      "name": "tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_tag_organization_id": {
+          "name": "idx_tag_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tag_group_id": {
+          "name": "idx_tag_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tag_organization_id_fkey": {
+          "name": "tag_organization_id_fkey",
+          "tableFrom": "tag",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tag_group_id_fkey": {
+          "name": "tag_group_id_fkey",
+          "tableFrom": "tag",
+          "tableTo": "tag_group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tag_org_slug_key": {
+          "name": "tag_org_slug_key",
+          "nullsNotDistinct": false,
+          "columns": ["organization_id", "slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_assignment": {
+      "name": "tag_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_tag_assignment_tag_id": {
+          "name": "idx_tag_assignment_tag_id",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tag_assignment_course_id": {
+          "name": "idx_tag_assignment_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tag_assignment_tag_id_fkey": {
+          "name": "tag_assignment_tag_id_fkey",
+          "tableFrom": "tag_assignment",
+          "tableTo": "tag",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tag_assignment_course_id_fkey": {
+          "name": "tag_assignment_course_id_fkey",
+          "tableFrom": "tag_assignment",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tag_assignment_tag_course_key": {
+          "name": "tag_assignment_tag_course_key",
+          "nullsNotDistinct": false,
+          "columns": ["tag_id", "course_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_group": {
+      "name": "tag_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_tag_group_organization_id": {
+          "name": "idx_tag_group_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tag_group_organization_id_fkey": {
+          "name": "tag_group_organization_id_fkey",
+          "tableFrom": "tag_group",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tag_group_org_slug_key": {
+          "name": "tag_group_org_slug_key",
+          "nullsNotDistinct": false,
+          "columns": ["organization_id", "slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_tenant": {
+      "name": "test_tenant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video_transcripts": {
+      "name": "video_transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "video_transcripts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "muse_svid": {
+          "name": "muse_svid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "downloaded": {
+          "name": "downloaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitinglist": {
+      "name": "waitinglist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "waitinglist_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "constraint_name": {
+          "name": "constraint_name",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget": {
+      "name": "widget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "WIDGET_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "layout_type": {
+          "name": "layout_type",
+          "type": "WIDGET_LAYOUT_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'card_grid'"
+        },
+        "selection_mode": {
+          "name": "selection_mode",
+          "type": "WIDGET_SELECTION_MODE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "has_unpublished_changes": {
+          "name": "has_unpublished_changes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "latest_published_version_id": {
+          "name": "latest_published_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_widget_organization_id": {
+          "name": "idx_widget_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_widget_status": {
+          "name": "idx_widget_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "widget_organization_id_fkey": {
+          "name": "widget_organization_id_fkey",
+          "tableFrom": "widget",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "widget_created_by_user_id_fkey": {
+          "name": "widget_created_by_user_id_fkey",
+          "tableFrom": "widget",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "widget_updated_by_user_id_fkey": {
+          "name": "widget_updated_by_user_id_fkey",
+          "tableFrom": "widget",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "widget_public_key_key": {
+          "name": "widget_public_key_key",
+          "nullsNotDistinct": false,
+          "columns": ["public_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget_course": {
+      "name": "widget_course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "widget_id": {
+          "name": "widget_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_widget_course_widget_id": {
+          "name": "idx_widget_course_widget_id",
+          "columns": [
+            {
+              "expression": "widget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_widget_course_course_id": {
+          "name": "idx_widget_course_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "widget_course_widget_id_fkey": {
+          "name": "widget_course_widget_id_fkey",
+          "tableFrom": "widget_course",
+          "tableTo": "widget",
+          "columnsFrom": ["widget_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "widget_course_course_id_fkey": {
+          "name": "widget_course_course_id_fkey",
+          "tableFrom": "widget_course",
+          "tableTo": "course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "widget_course_widget_course_key": {
+          "name": "widget_course_widget_course_key",
+          "nullsNotDistinct": false,
+          "columns": ["widget_id", "course_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget_version": {
+      "name": "widget_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "widget_id": {
+          "name": "widget_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_snapshot": {
+          "name": "config_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "payload_snapshot": {
+          "name": "payload_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "runtime_manifest": {
+          "name": "runtime_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "rolled_back_from_version_id": {
+          "name": "rolled_back_from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_by_user_id": {
+          "name": "published_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc'::text, now())"
+        }
+      },
+      "indexes": {
+        "idx_widget_version_widget_id": {
+          "name": "idx_widget_version_widget_id",
+          "columns": [
+            {
+              "expression": "widget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "widget_version_widget_id_fkey": {
+          "name": "widget_version_widget_id_fkey",
+          "tableFrom": "widget_version",
+          "tableTo": "widget",
+          "columnsFrom": ["widget_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "widget_version_published_by_user_id_fkey": {
+          "name": "widget_version_published_by_user_id_fkey",
+          "tableFrom": "widget_version",
+          "tableTo": "user",
+          "columnsFrom": ["published_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "widget_version_rolled_back_from_version_id_fkey": {
+          "name": "widget_version_rolled_back_from_version_id_fkey",
+          "tableFrom": "widget_version",
+          "tableTo": "widget_version",
+          "columnsFrom": ["rolled_back_from_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "widget_version_widget_version_key": {
+          "name": "widget_version_widget_version_key",
+          "nullsNotDistinct": false,
+          "columns": ["widget_id", "version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AI_AGENT_RUN_STATUS": {
+      "name": "AI_AGENT_RUN_STATUS",
+      "schema": "public",
+      "values": ["queued", "running", "waiting_for_input", "paused", "completed", "failed", "canceled"]
+    },
+    "public.AUTOMATION_USAGE_CATEGORY": {
+      "name": "AUTOMATION_USAGE_CATEGORY",
+      "schema": "public",
+      "values": ["read", "write", "publish"]
+    },
+    "public.COHORT_GOAL_ASSIGNMENT_STATUS": {
+      "name": "COHORT_GOAL_ASSIGNMENT_STATUS",
+      "schema": "public",
+      "values": ["not_started", "in_progress", "completed", "at_risk", "overdue", "waived"]
+    },
+    "public.COHORT_GOAL_DEADLINE_KIND": {
+      "name": "COHORT_GOAL_DEADLINE_KIND",
+      "schema": "public",
+      "values": ["absolute", "relative_to_join", "recurring", "none"]
+    },
+    "public.COHORT_GOAL_STATUS": {
+      "name": "COHORT_GOAL_STATUS",
+      "schema": "public",
+      "values": ["active", "archived"]
+    },
+    "public.COHORT_GOAL_TYPE": {
+      "name": "COHORT_GOAL_TYPE",
+      "schema": "public",
+      "values": ["complete_all", "n_of_m", "score", "pass_rate", "readiness"]
+    },
+    "public.COHORT_STATUS": {
+      "name": "COHORT_STATUS",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE", "ARCHIVED"]
+    },
+    "public.COURSE_IMPORT_DRAFT_STATUS": {
+      "name": "COURSE_IMPORT_DRAFT_STATUS",
+      "schema": "public",
+      "values": ["DRAFT", "PUBLISHED", "ARCHIVED"]
+    },
+    "public.COURSE_IMPORT_SOURCE_TYPE": {
+      "name": "COURSE_IMPORT_SOURCE_TYPE",
+      "schema": "public",
+      "values": ["prompt", "pdf", "course"]
+    },
+    "public.COURSE_INVITE_EVENT_TYPE": {
+      "name": "COURSE_INVITE_EVENT_TYPE",
+      "schema": "public",
+      "values": ["CREATED", "REVOKED", "PREVIEWED", "ACCEPTED", "EMAIL_SENT", "EMAIL_FAILED", "ABUSE_BLOCKED"]
+    },
+    "public.COURSE_TYPE": {
+      "name": "COURSE_TYPE",
+      "schema": "public",
+      "values": ["SELF_PACED", "LIVE_CLASS", "COMPLIANCE", "PUBLIC"]
+    },
+    "public.JOB_STATUS": {
+      "name": "JOB_STATUS",
+      "schema": "public",
+      "values": ["queued", "running", "completed", "failed", "canceled"]
+    },
+    "public.LOCALE": {
+      "name": "LOCALE",
+      "schema": "public",
+      "values": ["en", "hi", "fr", "pt", "de", "vi", "ru", "es", "pl", "da"]
+    },
+    "public.ORGANIZATION_API_KEY_TYPE": {
+      "name": "ORGANIZATION_API_KEY_TYPE",
+      "schema": "public",
+      "values": ["mcp", "api", "zapier"]
+    },
+    "public.ORGANIZATION_INVITE_EVENT_TYPE": {
+      "name": "ORGANIZATION_INVITE_EVENT_TYPE",
+      "schema": "public",
+      "values": ["CREATED", "REVOKED", "PREVIEWED", "ACCEPTED", "EMAIL_SENT", "EMAIL_FAILED", "ABUSE_BLOCKED"]
+    },
+    "public.ORGANIZATION_INVITE_TYPE": {
+      "name": "ORGANIZATION_INVITE_TYPE",
+      "schema": "public",
+      "values": ["EMAIL", "LINK"]
+    },
+    "public.SSO_PROVIDER": {
+      "name": "SSO_PROVIDER",
+      "schema": "public",
+      "values": ["OKTA", "GOOGLE_WORKSPACE", "AUTH0"]
+    },
+    "public.PLAN": {
+      "name": "PLAN",
+      "schema": "public",
+      "values": ["EARLY_ADOPTER", "ENTERPRISE", "BASIC"]
+    },
+    "public.PROGRAM_GOAL_ASSIGNMENT_STATUS": {
+      "name": "PROGRAM_GOAL_ASSIGNMENT_STATUS",
+      "schema": "public",
+      "values": ["not_started", "in_progress", "completed", "at_risk", "overdue", "waived"]
+    },
+    "public.PROGRAM_GOAL_DEADLINE_KIND": {
+      "name": "PROGRAM_GOAL_DEADLINE_KIND",
+      "schema": "public",
+      "values": ["absolute", "relative_to_join", "recurring", "none"]
+    },
+    "public.PROGRAM_GOAL_STATUS": {
+      "name": "PROGRAM_GOAL_STATUS",
+      "schema": "public",
+      "values": ["active", "archived"]
+    },
+    "public.PROGRAM_GOAL_TYPE": {
+      "name": "PROGRAM_GOAL_TYPE",
+      "schema": "public",
+      "values": ["complete_all", "n_of_m", "score", "pass_rate", "readiness"]
+    },
+    "public.PROGRAM_STATUS": {
+      "name": "PROGRAM_STATUS",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE", "ARCHIVED"]
+    },
+    "public.WIDGET_LAYOUT_TYPE": {
+      "name": "WIDGET_LAYOUT_TYPE",
+      "schema": "public",
+      "values": [
+        "card_grid",
+        "tag_filter",
+        "carousel",
+        "primary_course",
+        "compact_list",
+        "editorial_spotlight",
+        "category_shelf"
+      ]
+    },
+    "public.WIDGET_SELECTION_MODE": {
+      "name": "WIDGET_SELECTION_MODE",
+      "schema": "public",
+      "values": ["manual", "published"]
+    },
+    "public.WIDGET_STATUS": {
+      "name": "WIDGET_STATUS",
+      "schema": "public",
+      "values": ["DRAFT", "PUBLISHED", "ARCHIVED"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.dash_org_stats": {
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_of_courses": {
+          "name": "no_of_courses",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_students": {
+          "name": "enrolled_students",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT gp.organization_id AS org_id, count(DISTINCT course.id) AS no_of_courses, count(DISTINCT gm.profile_id) AS enrolled_students FROM course JOIN \"group\" gp ON gp.id = course.group_id LEFT JOIN groupmember gm ON gm.group_id = gp.id AND gm.role_id = 3 WHERE course.status = 'ACTIVE'::text GROUP BY gp.organization_id",
+      "name": "dash_org_stats",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    },
+    "public.lesson_versions": {
+      "columns": {
+        "old_content": {
+          "name": "old_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_content": {
+          "name": "new_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "LOCALE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT llh.old_content, llh.new_content, llh.\"timestamp\", ll.locale, ll.lesson_id FROM lesson_language_history llh JOIN lesson_language ll ON ll.id = llh.lesson_language_id",
+      "name": "lesson_versions",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1783909129074,
       "tag": "0003_profile_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1783938329367,
+      "tag": "0004_organizationmember_email_notifications",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/queries/notifications/email-preferences-org.ts
+++ b/packages/db/src/queries/notifications/email-preferences-org.ts
@@ -1,0 +1,21 @@
+import { db } from '@db/drizzle';
+import * as schema from '@db/schema';
+import { eq } from 'drizzle-orm';
+import type { EmailNotificationSettings } from '@cio/utils/notifications';
+
+export async function getOrganizationEmailNotificationSettings(
+  orgId: string
+): Promise<EmailNotificationSettings | undefined> {
+  try {
+    const [organization] = await db
+      .select({ settings: schema.organization.settings })
+      .from(schema.organization)
+      .where(eq(schema.organization.id, orgId))
+      .limit(1);
+
+    return organization?.settings?.emailNotifications;
+  } catch (error) {
+    console.error('getOrganizationEmailNotificationSettings error:', error);
+    throw new Error('Failed to get organization email notification settings');
+  }
+}

--- a/packages/db/src/queries/notifications/email-preferences.ts
+++ b/packages/db/src/queries/notifications/email-preferences.ts
@@ -4,54 +4,10 @@ import {
   type PersonalEmailNotificationSettings
 } from '@cio/utils/notifications';
 
-import { getProfileByEmail, getProfileById } from '../auth/profile';
-import { db } from '@db/drizzle';
-import * as schema from '@db/schema';
-import { eq } from 'drizzle-orm';
+import { getOrganizationEmailNotificationSettings } from './email-preferences-org';
+import { getPersonalEmailNotificationSettingsForOrg } from './organizationmember-email-notifications';
+import { getProfileByEmail } from '../auth/profile';
 import type { EmailId } from '@cio/email';
-
-export async function getOrganizationEmailNotificationSettings(
-  orgId: string
-): Promise<EmailNotificationSettings | undefined> {
-  try {
-    const [organization] = await db
-      .select({ settings: schema.organization.settings })
-      .from(schema.organization)
-      .where(eq(schema.organization.id, orgId))
-      .limit(1);
-
-    return organization?.settings?.emailNotifications;
-  } catch (error) {
-    console.error('getOrganizationEmailNotificationSettings error:', error);
-    throw new Error('Failed to get organization email notification settings');
-  }
-}
-
-export async function getProfileEmailNotificationSettingsById(
-  profileId: string
-): Promise<PersonalEmailNotificationSettings | undefined> {
-  try {
-    const profile = await getProfileById(profileId);
-
-    return profile?.settings?.emailNotifications;
-  } catch (error) {
-    console.error('getProfileEmailNotificationSettingsById error:', error);
-    throw new Error('Failed to get profile email notification settings');
-  }
-}
-
-export async function getProfileEmailNotificationSettingsByEmail(
-  email: string
-): Promise<PersonalEmailNotificationSettings | undefined> {
-  try {
-    const profile = await getProfileByEmail(email);
-
-    return profile?.settings?.emailNotifications;
-  } catch (error) {
-    console.error('getProfileEmailNotificationSettingsByEmail error:', error);
-    throw new Error('Failed to get profile email notification settings');
-  }
-}
 
 export async function shouldSendEmail(input: {
   emailId: EmailId;
@@ -67,7 +23,7 @@ export async function shouldSendEmail(input: {
  */
 export class EmailPreferenceLookupCache {
   private orgSettingsById = new Map<string, EmailNotificationSettings | undefined>();
-  private profileSettingsById = new Map<string, PersonalEmailNotificationSettings | undefined>();
+  private personalSettingsByOrgMember = new Map<string, PersonalEmailNotificationSettings | undefined>();
   private profileIdByEmail = new Map<string, string | undefined>();
 
   async shouldSend(input: {
@@ -84,7 +40,8 @@ export class EmailPreferenceLookupCache {
       profileId = await this.getProfileIdByEmail(input.recipientEmail);
     }
 
-    const personalSettings = profileId ? await this.getProfileSettings(profileId) : undefined;
+    const personalSettings =
+      profileId && input.organizationId ? await this.getPersonalSettings(profileId, input.organizationId) : undefined;
 
     return resolveEmailDelivery(input.emailId, orgSettings, personalSettings);
   }
@@ -107,12 +64,17 @@ export class EmailPreferenceLookupCache {
     return this.profileIdByEmail.get(email);
   }
 
-  private async getProfileSettings(profileId: string): Promise<PersonalEmailNotificationSettings | undefined> {
-    if (!this.profileSettingsById.has(profileId)) {
-      const settings = await getProfileEmailNotificationSettingsById(profileId);
-      this.profileSettingsById.set(profileId, settings);
+  private async getPersonalSettings(
+    profileId: string,
+    organizationId: string
+  ): Promise<PersonalEmailNotificationSettings | undefined> {
+    const cacheKey = `${profileId}:${organizationId}`;
+
+    if (!this.personalSettingsByOrgMember.has(cacheKey)) {
+      const settings = await getPersonalEmailNotificationSettingsForOrg(profileId, organizationId);
+      this.personalSettingsByOrgMember.set(cacheKey, settings);
     }
 
-    return this.profileSettingsById.get(profileId);
+    return this.personalSettingsByOrgMember.get(cacheKey);
   }
 }

--- a/packages/db/src/queries/notifications/index.ts
+++ b/packages/db/src/queries/notifications/index.ts
@@ -1,1 +1,3 @@
 export * from './email-preferences';
+export * from './email-preferences-org';
+export * from './organizationmember-email-notifications';

--- a/packages/db/src/queries/notifications/organizationmember-email-notifications.ts
+++ b/packages/db/src/queries/notifications/organizationmember-email-notifications.ts
@@ -1,0 +1,120 @@
+import {
+  DEFAULT_MEMBER_EMAIL_NOTIFICATION_ROW,
+  memberEmailNotificationRowToApiResponse,
+  memberEmailNotificationRowToPersonalSettings,
+  personalSettingsToMemberEmailNotificationRow,
+  type MemberEmailNotificationRow
+} from '@cio/utils/notifications';
+import type { PersonalEmailNotificationSettings } from '@cio/utils/notifications';
+import type { TMemberEmailNotificationPreferencesUpdate } from '@cio/utils/validation/notifications';
+
+import { getOrganizationMemberIdByOrgAndProfile } from '../organization/organization';
+import { db } from '@db/drizzle';
+import * as schema from '@db/schema';
+import { eq } from 'drizzle-orm';
+
+function rowFromRecord(
+  record: typeof schema.organizationmemberEmailNotifications.$inferSelect | undefined
+): MemberEmailNotificationRow | null {
+  if (!record) {
+    return null;
+  }
+
+  return {
+    newStudent: record.newStudent,
+    newSubmission: record.newSubmission,
+    gradingResult: record.gradingResult,
+    newsfeed: record.newsfeed,
+    quizAssigned: record.quizAssigned,
+    cohortReminder: record.cohortReminder,
+    session: record.session,
+    courseCompletion: record.courseCompletion
+  };
+}
+
+export async function getOrganizationMemberEmailNotifications(
+  profileId: string,
+  organizationId: string
+): Promise<MemberEmailNotificationRow | null> {
+  try {
+    const organizationMemberId = await getOrganizationMemberIdByOrgAndProfile(organizationId, profileId);
+
+    if (!organizationMemberId) {
+      return null;
+    }
+
+    const [record] = await db
+      .select()
+      .from(schema.organizationmemberEmailNotifications)
+      .where(eq(schema.organizationmemberEmailNotifications.organizationMemberId, organizationMemberId))
+      .limit(1);
+
+    return rowFromRecord(record);
+  } catch (error) {
+    console.error('getOrganizationMemberEmailNotifications error:', error);
+    throw new Error('Failed to get organization member email notification preferences');
+  }
+}
+
+export async function getOrganizationMemberEmailNotificationsForApi(profileId: string, organizationId: string) {
+  const row = await getOrganizationMemberEmailNotifications(profileId, organizationId);
+
+  return memberEmailNotificationRowToApiResponse(row);
+}
+
+export async function getPersonalEmailNotificationSettingsForOrg(
+  profileId: string,
+  organizationId: string
+): Promise<PersonalEmailNotificationSettings | undefined> {
+  const row = await getOrganizationMemberEmailNotifications(profileId, organizationId);
+
+  return memberEmailNotificationRowToPersonalSettings(row);
+}
+
+export async function upsertOrganizationMemberEmailNotifications(
+  profileId: string,
+  organizationId: string,
+  preferences: TMemberEmailNotificationPreferencesUpdate
+): Promise<MemberEmailNotificationRow> {
+  try {
+    const organizationMemberId = await getOrganizationMemberIdByOrgAndProfile(organizationId, profileId);
+
+    if (!organizationMemberId) {
+      throw new Error('Organization member not found');
+    }
+
+    const existing = await getOrganizationMemberEmailNotifications(profileId, organizationId);
+    const merged = personalSettingsToMemberEmailNotificationRow({
+      ...(existing ?? DEFAULT_MEMBER_EMAIL_NOTIFICATION_ROW),
+      ...preferences
+    });
+    const updatedAt = new Date().toISOString();
+
+    const [record] = await db
+      .insert(schema.organizationmemberEmailNotifications)
+      .values({
+        organizationMemberId,
+        ...merged,
+        updatedAt
+      })
+      .onConflictDoUpdate({
+        target: schema.organizationmemberEmailNotifications.organizationMemberId,
+        set: {
+          ...merged,
+          updatedAt
+        }
+      })
+      .returning();
+
+    const row = rowFromRecord(record);
+
+    if (!row) {
+      throw new Error('Failed to upsert organization member email notification preferences');
+    }
+
+    return row;
+  } catch (error) {
+    console.error('upsertOrganizationMemberEmailNotifications error:', error);
+    throw new Error('Failed to update organization member email notification preferences');
+  }
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -410,18 +410,7 @@ export const profile = pgTable(
     verifiedAt: timestamp('verified_at', { withTimezone: true, mode: 'string' }),
     locale: locale().default('en'),
     isRestricted: boolean('is_restricted').default(false).notNull(),
-    settings: jsonb().default({}).$type<{
-      emailNotifications?: {
-        newStudent?: boolean;
-        newSubmission?: boolean;
-        gradingResult?: boolean;
-        newsfeed?: boolean;
-        quizAssigned?: boolean;
-        cohortReminder?: boolean;
-        session?: boolean;
-        courseCompletion?: boolean;
-      };
-    }>()
+    settings: jsonb().default({}).$type<Record<string, unknown>>()
   },
   (table) => [
     foreignKey({
@@ -1857,6 +1846,30 @@ export const organizationmember = pgTable(
     uniqueIndex('organizationmember_org_email_unique')
       .on(table.organizationId, table.email)
       .where(sql`${table.email} IS NOT NULL`)
+  ]
+);
+
+export const organizationmemberEmailNotifications = pgTable(
+  'organizationmember_email_notifications',
+  {
+    organizationMemberId: bigint('organization_member_id', { mode: 'number' }).primaryKey().notNull(),
+    newStudent: boolean('new_student').default(true).notNull(),
+    newSubmission: boolean('new_submission').default(true).notNull(),
+    gradingResult: boolean('grading_result').default(true).notNull(),
+    newsfeed: boolean('newsfeed').default(true).notNull(),
+    quizAssigned: boolean('quiz_assigned').default(true).notNull(),
+    cohortReminder: boolean('cohort_reminder').default(true).notNull(),
+    session: boolean('session').default(true).notNull(),
+    courseCompletion: boolean('course_completion').default(true).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' }).defaultNow().notNull()
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.organizationMemberId],
+      foreignColumns: [organizationmember.id],
+      name: 'organizationmember_email_notifications_organization_member_id_fkey'
+    }).onDelete('cascade')
   ]
 );
 

--- a/packages/db/src/scripts/backfill-member-email-notifications-from-profile.ts
+++ b/packages/db/src/scripts/backfill-member-email-notifications-from-profile.ts
@@ -1,0 +1,111 @@
+/**
+ * Copies legacy profile.settings.emailNotifications into
+ * organizationmember_email_notifications (one row per membership), then
+ * removes the old jsonb key from profile.settings.
+ *
+ * Usage:
+ *   pnpm db:backfill-member-email-notifications           # dry run (default)
+ *   pnpm db:backfill-member-email-notifications -- --execute # apply updates
+ */
+import 'dotenv/config';
+
+import postgres from 'postgres';
+
+const connectionString = process.env.DATABASE_URL ?? process.env.PRIVATE_DATABASE_URL ?? '';
+const shouldExecute = process.argv.includes('--execute');
+
+if (!connectionString) {
+  console.error('DATABASE_URL or PRIVATE_DATABASE_URL environment variable is required');
+  process.exit(1);
+}
+
+const AFFECTED_MEMBERSHIPS_SQL = `
+  SELECT
+    om.id AS organization_member_id,
+    p.id AS profile_id,
+    om.organization_id,
+    p.settings->'emailNotifications' AS legacy_preferences
+  FROM organizationmember om
+  INNER JOIN profile p ON p.id = om.profile_id
+  WHERE p.settings ? 'emailNotifications'
+`;
+
+async function main() {
+  const sql = postgres(connectionString);
+
+  try {
+    const affected = await sql.unsafe(AFFECTED_MEMBERSHIPS_SQL);
+    console.log(`Found ${affected.length} organization membership(s) with legacy profile email preferences.`);
+
+    if (affected.length === 0) {
+      console.log('Nothing to do.');
+      return;
+    }
+
+    if (!shouldExecute) {
+      console.log('Dry run only. Re-run with --execute to apply updates.');
+      console.log('Sample (up to 10):');
+      for (const row of affected.slice(0, 10)) {
+        console.log(`  member=${row.organization_member_id}  profile=${row.profile_id}  org=${row.organization_id}`);
+      }
+      return;
+    }
+
+    const inserted = await sql`
+      INSERT INTO organizationmember_email_notifications (
+        organization_member_id,
+        new_student,
+        new_submission,
+        grading_result,
+        newsfeed,
+        quiz_assigned,
+        cohort_reminder,
+        session,
+        course_completion
+      )
+      SELECT
+        om.id,
+        COALESCE((p.settings->'emailNotifications'->>'newStudent')::boolean, true),
+        COALESCE((p.settings->'emailNotifications'->>'newSubmission')::boolean, true),
+        COALESCE((p.settings->'emailNotifications'->>'gradingResult')::boolean, true),
+        COALESCE((p.settings->'emailNotifications'->>'newsfeed')::boolean, true),
+        COALESCE((p.settings->'emailNotifications'->>'quizAssigned')::boolean, true),
+        COALESCE((p.settings->'emailNotifications'->>'cohortReminder')::boolean, true),
+        COALESCE((p.settings->'emailNotifications'->>'session')::boolean, true),
+        COALESCE((p.settings->'emailNotifications'->>'courseCompletion')::boolean, true)
+      FROM organizationmember om
+      INNER JOIN profile p ON p.id = om.profile_id
+      WHERE p.settings ? 'emailNotifications'
+      ON CONFLICT (organization_member_id) DO NOTHING
+      RETURNING organization_member_id
+    `;
+
+    const clearedProfiles = await sql`
+      UPDATE profile
+      SET settings = settings - 'emailNotifications'
+      WHERE settings ? 'emailNotifications'
+      RETURNING id
+    `;
+
+    const remaining = await sql.unsafe(`SELECT COUNT(*)::int AS count FROM (${AFFECTED_MEMBERSHIPS_SQL}) AS affected`);
+    const remainingCount = remaining[0]?.count ?? 0;
+
+    console.log(`Inserted ${inserted.length} organizationmember_email_notifications row(s).`);
+    console.log(`Cleared legacy preferences from ${clearedProfiles.length} profile(s).`);
+    console.log(`Remaining memberships with legacy profile preferences: ${remainingCount}`);
+
+    if (remainingCount > 0) {
+      console.warn('Some rows were not migrated — inspect manually before retrying.');
+      process.exit(1);
+    }
+
+    console.log('Backfill complete.');
+  } catch (error) {
+    console.error('backfill-member-email-notifications-from-profile error:', error);
+    throw error;
+  } finally {
+    await sql.end();
+  }
+}
+
+main();

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -141,6 +141,8 @@ export type TNewLessonLanguageHistory = typeof schema.lessonLanguageHistory.$inf
 
 export type TOrganizationmember = typeof schema.organizationmember.$inferSelect;
 export type TNewOrganizationmember = typeof schema.organizationmember.$inferInsert;
+export type TOrganizationmemberEmailNotifications = typeof schema.organizationmemberEmailNotifications.$inferSelect;
+export type TNewOrganizationmemberEmailNotifications = typeof schema.organizationmemberEmailNotifications.$inferInsert;
 
 export type TQuestion = typeof schema.question.$inferSelect;
 export type TNewQuestion = typeof schema.question.$inferInsert;

--- a/packages/utils/src/notifications/index.ts
+++ b/packages/utils/src/notifications/index.ts
@@ -1,1 +1,2 @@
 export * from './email-toggles';
+export * from './member-email-notifications';

--- a/packages/utils/src/notifications/member-email-notifications.ts
+++ b/packages/utils/src/notifications/member-email-notifications.ts
@@ -1,0 +1,61 @@
+import type { PersonalEmailNotificationSettings, PersonalEmailNotificationToggleKey } from './email-toggles';
+import { PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS } from './email-toggles';
+
+export type MemberEmailNotificationRow = {
+  newStudent: boolean;
+  newSubmission: boolean;
+  gradingResult: boolean;
+  newsfeed: boolean;
+  quizAssigned: boolean;
+  cohortReminder: boolean;
+  session: boolean;
+  courseCompletion: boolean;
+};
+
+export const DEFAULT_MEMBER_EMAIL_NOTIFICATION_ROW: MemberEmailNotificationRow = {
+  newStudent: true,
+  newSubmission: true,
+  gradingResult: true,
+  newsfeed: true,
+  quizAssigned: true,
+  cohortReminder: true,
+  session: true,
+  courseCompletion: true
+};
+
+export function memberEmailNotificationRowToPersonalSettings(
+  row: MemberEmailNotificationRow | null | undefined
+): PersonalEmailNotificationSettings | undefined {
+  if (!row) {
+    return undefined;
+  }
+
+  const settings: Partial<Record<PersonalEmailNotificationToggleKey, boolean>> = {};
+
+  for (const key of PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS) {
+    if (row[key] === false) {
+      settings[key] = false;
+    }
+  }
+
+  return settings;
+}
+
+export function personalSettingsToMemberEmailNotificationRow(
+  preferences: Partial<PersonalEmailNotificationSettings> | MemberEmailNotificationRow
+): MemberEmailNotificationRow {
+  return {
+    newStudent: preferences.newStudent ?? true,
+    newSubmission: preferences.newSubmission ?? true,
+    gradingResult: preferences.gradingResult ?? true,
+    newsfeed: preferences.newsfeed ?? true,
+    quizAssigned: preferences.quizAssigned ?? true,
+    cohortReminder: preferences.cohortReminder ?? true,
+    session: preferences.session ?? true,
+    courseCompletion: preferences.courseCompletion ?? true
+  };
+}
+
+export function memberEmailNotificationRowToApiResponse(row: MemberEmailNotificationRow | null | undefined) {
+  return personalSettingsToMemberEmailNotificationRow(row ?? DEFAULT_MEMBER_EMAIL_NOTIFICATION_ROW);
+}

--- a/packages/utils/src/validation/account/account.ts
+++ b/packages/utils/src/validation/account/account.ts
@@ -1,22 +1,10 @@
 import * as z from 'zod';
 
-const ZEmailNotificationToggleFields = {
-  newStudent: z.boolean().optional(),
-  newSubmission: z.boolean().optional(),
-  gradingResult: z.boolean().optional(),
-  newsfeed: z.boolean().optional(),
-  quizAssigned: z.boolean().optional(),
-  cohortReminder: z.boolean().optional(),
-  session: z.boolean().optional(),
-  courseCompletion: z.boolean().optional()
-};
-
 export const ZUpdateProfile = z.object({
   fullname: z.string().min(3).optional(),
   username: z.string().min(3).optional(),
   locale: z.enum(['en', 'hi', 'fr', 'pt', 'de', 'vi', 'ru', 'es', 'pl', 'da']).optional(),
-  avatarUrl: z.url().optional(),
-  emailNotifications: z.object(ZEmailNotificationToggleFields).optional()
+  avatarUrl: z.url().optional()
 });
 
 export type TUpdateProfile = z.infer<typeof ZUpdateProfile>;

--- a/packages/utils/src/validation/notifications/email-notifications.ts
+++ b/packages/utils/src/validation/notifications/email-notifications.ts
@@ -1,0 +1,20 @@
+import * as z from 'zod';
+
+export const ZPersonalEmailNotificationToggleFields = {
+  newStudent: z.boolean(),
+  newSubmission: z.boolean(),
+  gradingResult: z.boolean(),
+  newsfeed: z.boolean(),
+  quizAssigned: z.boolean(),
+  cohortReminder: z.boolean(),
+  session: z.boolean(),
+  courseCompletion: z.boolean()
+};
+
+export const ZMemberEmailNotificationPreferences = z.object(ZPersonalEmailNotificationToggleFields);
+
+export type TMemberEmailNotificationPreferences = z.infer<typeof ZMemberEmailNotificationPreferences>;
+
+export const ZMemberEmailNotificationPreferencesUpdate = z.object(ZPersonalEmailNotificationToggleFields).partial();
+
+export type TMemberEmailNotificationPreferencesUpdate = z.infer<typeof ZMemberEmailNotificationPreferencesUpdate>;

--- a/packages/utils/src/validation/notifications/index.ts
+++ b/packages/utils/src/validation/notifications/index.ts
@@ -1,0 +1,1 @@
+export * from './email-notifications';


### PR DESCRIPTION
## Commits

- c35456b82 docs: add token auth guide (#752)
- b7711ffae feat(dashboard): show course progress in student sidebar (#761)
- f3d1a885b feat(notifications): per-org member email preferences table (#751)
- 968177027 fix(dashboard): show locked notice instead of teacher empty state on lessons (#760)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release PR bundles four improvements: a per-org member email-preferences table (migrating data out of `profile.settings` JSONB), a course-progress indicator in the student sidebar, a fix that shows the locked-content notice instead of the teacher empty state when a lesson is locked, and a token-auth documentation page.

- **Email preferences migration** – adds `organizationmember_email_notifications`, a DB migration, a backfill script, new GET/PUT API routes, and updates the dashboard notifications settings page to read/write via the new endpoint instead of the profile store.
- **Course progress** – new `ContentProgress` utilities, `CourseProgressCard` and `CourseProgressPopover` components, and per-section completion percentages in the content tree sidebar.
- **Lesson lock fix** – refactors `lesson.svelte` to use `getStudentContentLockReason`, correctly gates the teacher \"add content\" empty state behind `$isOrgStudent !== true`, and adds a loading spinner while course state resolves.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the not-found error being swallowed in the upsert path; all other changes are well-structured.

The upsert function throws 'Organization member not found' inside its own try block, which the catch immediately overwrites with a generic message. The service layer checks for that exact string to return a 404, so a PUT request for a non-member will always produce a 500 instead. The rest of the PR — schema, migration, backfill script, dashboard components, lesson-lock fix — is clean.

packages/db/src/queries/notifications/organizationmember-email-notifications.ts — the upsert error-handling path; apps/api/src/services/notification/member-email-notifications.ts depends on the error message that never reaches it.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/queries/notifications/organizationmember-email-notifications.ts | New query module for the per-org-member email notifications table; error from the not-found guard is swallowed by the outer catch, breaking the 404 signal the service layer depends on. |
| apps/api/src/services/notification/member-email-notifications.ts | Thin service layer wrapping upsert; 404 detection via error message string match fails in practice due to the upstream error-swallowing bug. |
| apps/api/src/routes/organization/member-email-notifications.ts | New GET/PUT router for per-org member email preferences; auth + org-member middleware applied correctly to both endpoints. |
| packages/db/src/schema.ts | Adds organizationmemberEmailNotifications table; widens profile.settings JSONB type to Record<string, unknown>, consistent with the migration to the new table. |
| packages/db/src/queries/notifications/email-preferences.ts | Migrates the EmailPreferenceLookupCache to use the new per-org member table; cache key correctly scoped to profileId:organizationId. |
| packages/db/src/scripts/backfill-member-email-notifications-from-profile.ts | Dry-run-by-default backfill script that copies legacy profile.settings.emailNotifications into the new table and clears the old key; follows the repo's established one-time script conventions. |
| apps/dashboard/src/lib/features/course/pages/lesson.svelte | Fixes the regression where the teacher add-content empty state was shown to locked students; introduces a loading spinner while course state resolves. |
| apps/dashboard/src/lib/features/settings/pages/notifications.svelte | Refactors personal notification prefs from profile-store-backed to a live GET/PUT against the new per-org endpoint; adds savedPersonalToggles to correctly track dirty state. |
| packages/utils/src/notifications/member-email-notifications.ts | Utility helpers for converting between DB row, API response, and PersonalEmailNotificationSettings types; logic is consistent and defaults are all true. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Dashboard (notifications.svelte)
    participant API as GET/PUT /organization/member/email-notifications
    participant SVC as MemberEmailNotificationsService
    participant DB as organizationmember_email_notifications
    participant Cache as EmailPreferenceLookupCache

    UI->>API: GET (fetch preferences)
    API->>SVC: getMemberEmailNotificationPreferences(userId, orgId)
    SVC->>DB: "SELECT WHERE organization_member_id = ?"
    DB-->>SVC: "row | null"
    SVC-->>API: defaults if null, else row
    API-->>UI: "{ success, data }"

    UI->>API: PUT (update preferences)
    API->>SVC: updateMemberEmailNotificationPreferences(userId, orgId, prefs)
    SVC->>DB: INSERT ... ON CONFLICT DO UPDATE
    DB-->>SVC: updated row
    SVC-->>API: MemberEmailNotificationRow
    API-->>UI: "{ success, data }"

    Note over Cache,DB: Email send path
    Cache->>DB: getPersonalEmailNotificationSettingsForOrg(profileId, orgId)
    DB-->>Cache: "PersonalEmailNotificationSettings | undefined"
    Cache->>Cache: "cache key = profileId:orgId"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Dashboard (notifications.svelte)
    participant API as GET/PUT /organization/member/email-notifications
    participant SVC as MemberEmailNotificationsService
    participant DB as organizationmember_email_notifications
    participant Cache as EmailPreferenceLookupCache

    UI->>API: GET (fetch preferences)
    API->>SVC: getMemberEmailNotificationPreferences(userId, orgId)
    SVC->>DB: "SELECT WHERE organization_member_id = ?"
    DB-->>SVC: "row | null"
    SVC-->>API: defaults if null, else row
    API-->>UI: "{ success, data }"

    UI->>API: PUT (update preferences)
    API->>SVC: updateMemberEmailNotificationPreferences(userId, orgId, prefs)
    SVC->>DB: INSERT ... ON CONFLICT DO UPDATE
    DB-->>SVC: updated row
    SVC-->>API: MemberEmailNotificationRow
    API-->>UI: "{ success, data }"

    Note over Cache,DB: Email send path
    Cache->>DB: getPersonalEmailNotificationSettingsForOrg(profileId, orgId)
    DB-->>Cache: "PersonalEmailNotificationSettings | undefined"
    Cache->>Cache: "cache key = profileId:orgId"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: add token auth guide (#752)"](https://github.com/classroomio/classroomio/commit/c35456b82110a918679cddf943f3fa06b53b3a4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44740642)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->