### PR TITLE
fix(db): preserve not-found error in member email notification upsert

### DIFF
--- a/packages/db/src/queries/notifications/organizationmember-email-notifications.ts
+++ b/packages/db/src/queries/notifications/organizationmember-email-notifications.ts
@@ -32,6 +32,18 @@ function rowFromRecord(
   };
 }
 
+async function getEmailNotificationsByMemberId(
+  organizationMemberId: number
+): Promise<MemberEmailNotificationRow | null> {
+  const [record] = await db
+    .select()
+    .from(schema.organizationmemberEmailNotifications)
+    .where(eq(schema.organizationmemberEmailNotifications.organizationMemberId, organizationMemberId))
+    .limit(1);
+
+  return rowFromRecord(record);
+}
+
 export async function getOrganizationMemberEmailNotifications(
   profileId: string,
   organizationId: string
@@ -43,13 +55,7 @@ export async function getOrganizationMemberEmailNotifications(
       return null;
     }
 
-    const [record] = await db
-      .select()
-      .from(schema.organizationmemberEmailNotifications)
-      .where(eq(schema.organizationmemberEmailNotifications.organizationMemberId, organizationMemberId))
-      .limit(1);
-
-    return rowFromRecord(record);
+    return getEmailNotificationsByMemberId(organizationMemberId);
   } catch (error) {
     console.error('getOrganizationMemberEmailNotifications error:', error);
     throw new Error('Failed to get organization member email notification preferences');
@@ -83,7 +89,7 @@ export async function upsertOrganizationMemberEmailNotifications(
       throw new Error('Organization member not found');
     }
 
-    const existing = await getOrganizationMemberEmailNotifications(profileId, organizationId);
+    const existing = await getEmailNotificationsByMemberId(organizationMemberId);
     const merged = personalSettingsToMemberEmailNotificationRow({
       ...(existing ?? DEFAULT_MEMBER_EMAIL_NOTIFICATION_ROW),
       ...preferences
@@ -114,6 +120,10 @@ export async function upsertOrganizationMemberEmailNotifications(
 
     return row;
   } catch (error) {
+    if (error instanceof Error && error.message === 'Organization member not found') {
+      throw error;
+    }
+
     console.error('upsertOrganizationMemberEmailNotifications error:', error);
     throw new Error('Failed to update organization member email notification preferences');
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses Greptile review on #762 (email notification query layer from #751).

## Changes

- **P1:** `upsertOrganizationMemberEmailNotifications` re-throws `Organization member not found` instead of replacing it with a generic error, so the API service can return **404** (not 500) when the user is not an org member.
- **P2:** Upsert resolves `organizationMemberId` once and loads existing prefs via `getEmailNotificationsByMemberId`, avoiding a duplicate `getOrganizationMemberIdByOrgAndProfile` call through `getOrganizationMemberEmailNotifications`.

## Testing

- Format check passes
- Change is limited to `packages/db/src/queries/notifications/organizationmember-email-notifications.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-beb6f5b0-5fe5-43dc-8785-f50e46082324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-beb6f5b0-5fe5-43dc-8785-f50e46082324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two issues in the email notification upsert path: re-throwing `Organization member not found` so the API can return 404 instead of 500, and eliminating a redundant `getOrganizationMemberIdByOrgAndProfile` call by using a new private `getEmailNotificationsByMemberId` helper.

- The "not found" sentinel is now preserved through the catch block via an `error.message` string comparison; both the throw site and the guard use the same literal, which is fragile if either is later renamed.
- The private helper correctly queries by `organizationMemberId` with `.limit(1)` and returns `null` on a missing row, keeping the merge/default logic intact.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core behavioral fix is correct and the only concern is a maintenance hazard in the error string coupling.

Both the throw site and the catch guard reference the same bare string 'Organization member not found'. The fix works today, but if one side is ever renamed without updating the other, the not-found error silently collapses back into the generic 500 wrapper, reverting the fix invisibly.

packages/db/src/queries/notifications/organizationmember-email-notifications.ts — the string literal used at both the throw and catch sites.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/src/queries/notifications/organizationmember-email-notifications.ts | Adds private getEmailNotificationsByMemberId helper to avoid a redundant member-ID lookup in the upsert path, and re-throws the not-found error so callers can distinguish 404 from 500; the catch guard uses a bare string literal that is fragile to rename. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant API as API Service
    participant Upsert as upsertOrganizationMemberEmailNotifications
    participant OrgQ as getOrganizationMemberIdByOrgAndProfile
    participant NotifQ as getEmailNotificationsByMemberId
    participant DB as Database

    API->>Upsert: profileId, organizationId, preferences
    Upsert->>OrgQ: organizationId, profileId
    OrgQ->>DB: SELECT organizationMemberId
    DB-->>OrgQ: "id | null"
    OrgQ-->>Upsert: organizationMemberId

    alt member not found
        Upsert-->>API: throw Error(ORG_MEMBER_NOT_FOUND_MSG) → 404
    else member found
        Upsert->>NotifQ: organizationMemberId
        NotifQ->>DB: SELECT existing prefs
        DB-->>NotifQ: "record | undefined"
        NotifQ-->>Upsert: "MemberEmailNotificationRow | null"
        Upsert->>DB: INSERT ... ON CONFLICT DO UPDATE
        DB-->>Upsert: updated record
        Upsert-->>API: MemberEmailNotificationRow
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant API as API Service
    participant Upsert as upsertOrganizationMemberEmailNotifications
    participant OrgQ as getOrganizationMemberIdByOrgAndProfile
    participant NotifQ as getEmailNotificationsByMemberId
    participant DB as Database

    API->>Upsert: profileId, organizationId, preferences
    Upsert->>OrgQ: organizationId, profileId
    OrgQ->>DB: SELECT organizationMemberId
    DB-->>OrgQ: "id | null"
    OrgQ-->>Upsert: organizationMemberId

    alt member not found
        Upsert-->>API: throw Error(ORG_MEMBER_NOT_FOUND_MSG) → 404
    else member found
        Upsert->>NotifQ: organizationMemberId
        NotifQ->>DB: SELECT existing prefs
        DB-->>NotifQ: "record | undefined"
        NotifQ-->>Upsert: "MemberEmailNotificationRow | null"
        Upsert->>DB: INSERT ... ON CONFLICT DO UPDATE
        DB-->>Upsert: updated record
        Upsert-->>API: MemberEmailNotificationRow
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/db/src/queries/notifications/organizationmember-email-notifications.ts`, line 88-90 ([link](https://github.com/classroomio/classroomio/blob/76950a867490b39edcb8ddea3787aaa9fe0c6805/packages/db/src/queries/notifications/organizationmember-email-notifications.ts#L88-L90)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Fragile string-literal sentinel for error re-throw. The catch guard on line 123 and the throw on line 89 share a bare string `'Organization member not found'`. If either is renamed or reworded in isolation the error will silently collapse into the generic 500 wrapper again, exactly reversing this fix. Defining the message as a module-level constant used in both places prevents that drift.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(db): preserve not-found error and de..."](https://github.com/classroomio/classroomio/commit/76950a867490b39edcb8ddea3787aaa9fe0c6805) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44763426)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->