### PR TITLE
fix(dashboard): show lesson lock notice for org-site learners

### DIFF
--- a/apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte
+++ b/apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte
@@ -7,7 +7,7 @@
   import { Button } from '@cio/ui/base/button';
   import * as Tooltip from '@cio/ui/base/tooltip';
   import { PercentRingProgress } from '@cio/ui/custom/percent-ring-progress';
-  import { isOrgStudent } from '$lib/utils/store/app';
+  import { isCourseLearnerView } from '$lib/utils/store/app';
   import { getStudentContentLockReason } from '$features/ai-assistant/utils/content-ask-ai-bar';
   import { t } from '$lib/utils/functions/translations';
   import { courseApi, lessonApi } from '$features/course/api';
@@ -52,6 +52,16 @@
 
   function goToContent(target: CourseContentItem | null) {
     if (!target) return;
+
+    if ($isCourseLearnerView) {
+      const targetType = target.type === ContentType.Lesson ? ContentType.Lesson : ContentType.Exercise;
+      const lockReason = getStudentContentLockReason(courseApi.course, target.id, targetType);
+
+      if (lockReason) {
+        return;
+      }
+    }
+
     const courseIdResolved = courseApi.course?.id;
     if (!courseIdResolved) return;
     const path = getContentRoute(courseIdResolved, target);
@@ -73,7 +83,7 @@
   const contentLockReason = $derived(
     lessonId ? getStudentContentLockReason(courseApi.course, lessonId, ContentType.Lesson) : null
   );
-  const isLessonLocked = $derived($isOrgStudent === true && contentLockReason !== null);
+  const isLessonLocked = $derived($isCourseLearnerView && contentLockReason !== null);
   const isVideoWatchLesson = $derived.by(() => {
     if (!lessonId) return false;
 
@@ -107,7 +117,7 @@
     isMarkingComplete || isLessonLocked || isLessonComplete || isVideoWatchLesson
   );
   const showWatchProgress = $derived(
-    !!lessonId && $isOrgStudent && isVideoWatchLesson && !showVideoWatchCompleteState && !isLessonLocked
+    !!lessonId && $isCourseLearnerView && isVideoWatchLesson && !showVideoWatchCompleteState && !isLessonLocked
   );
 
   const watchProgressTooltip = $derived(

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-content-tree.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-content-tree.svelte
@@ -14,7 +14,7 @@
   import { IconButton } from '@cio/ui/custom/icon-button';
   import { RadioIcon } from '@cio/ui/custom/moving-icons';
   import CourseContentIcon from '$features/course/components/course-content-icon.svelte';
-  import { isOrgStudent } from '$lib/utils/store/app';
+  import { isCourseLearnerView } from '$lib/utils/store/app';
 
   interface Props {
     path: string;
@@ -99,7 +99,7 @@
                       {#snippet child({ props })}
                         {@const isContentLocked = (contentItem.isUnlocked ?? true) === false}
                         {@const isLockedForStudent =
-                          $isOrgStudent === true && (isContentLocked || contentItem.accessible === false)}
+                          $isCourseLearnerView && (isContentLocked || contentItem.accessible === false)}
                         <a
                           href={resolve(getContentRoute(id, contentItem), {})}
                           aria-disabled={isLockedForStudent}
@@ -151,8 +151,7 @@
         <Sidebar.MenuSubButton isActive={(path || page.url.pathname).includes(contentItem.id)}>
           {#snippet child({ props })}
             {@const isContentLocked = (contentItem.isUnlocked ?? true) === false}
-            {@const isLockedForStudent =
-              $isOrgStudent === true && (isContentLocked || contentItem.accessible === false)}
+            {@const isLockedForStudent = $isCourseLearnerView && (isContentLocked || contentItem.accessible === false)}
             <a
               href={resolve(getContentRoute(id, contentItem), {})}
               aria-disabled={isLockedForStudent}

--- a/apps/dashboard/src/lib/features/course/pages/lesson.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/lesson.svelte
@@ -16,7 +16,7 @@
 
   import MODES from '$lib/utils/constants/mode';
   import { profile } from '$lib/utils/store/user';
-  import { isOrgStudent, isStudentExperience } from '$lib/utils/store/app';
+  import { isCourseLearnerView, isStudentExperience } from '$lib/utils/store/app';
   import { getStudentContentLockReason } from '$features/ai-assistant/utils/content-ask-ai-bar';
   import { currentOrg } from '$lib/utils/store/org';
   import { snackbar } from '$features/ui/snackbar/store';
@@ -86,9 +86,8 @@
   );
   const lessonTitle = $derived(currentLessonContentItem?.title || lessonApi.lesson?.title || 'Lesson');
   const contentLockReason = $derived(getStudentContentLockReason(courseApi.course, lessonId, ContentType.Lesson));
-  const isLessonLockedForStudent = $derived($isOrgStudent === true && contentLockReason !== null);
   const isStudentLessonStateReady = $derived.by(() => {
-    if ($isOrgStudent !== true) {
+    if (!$isCourseLearnerView) {
       return true;
     }
 
@@ -466,7 +465,7 @@
 <Page.Body>
   {#snippet child()}
     <div class={`overflow-x-hidden pb-6 ${mode === MODES.edit ? 'lg:w-full xl:w-11/12' : 'mx-auto w-full max-w-3xl'}`}>
-      {#if isLiveSessionLesson && mode === MODES.view && !isLessonLockedForStudent}
+      {#if isLiveSessionLesson && mode === MODES.view && !($isCourseLearnerView && contentLockReason)}
         <div class="mb-4">
           <LiveSessionCard
             title={lessonTitle}
@@ -477,12 +476,39 @@
         </div>
       {/if}
 
-      {#if $isOrgStudent === true && !isStudentLessonStateReady}
-        <div class="flex justify-center py-16">
-          <Spinner />
-        </div>
-      {:else if isLessonLockedForStudent && contentLockReason}
-        <StudentContentLockedNotice reason={contentLockReason} contentType={ContentType.Lesson} />
+      {#if $isCourseLearnerView}
+        {#if !isStudentLessonStateReady}
+          <div class="flex justify-center py-16">
+            <Spinner />
+          </div>
+        {:else if contentLockReason}
+          <StudentContentLockedNotice reason={contentLockReason} contentType={ContentType.Lesson} />
+        {:else if lessonApi.lesson && !isMaterialsEmpty}
+          {#key lessonId}
+            <div class="mb-20 flex w-full flex-col" in:fade={{ delay: 500 }} out:fade>
+              {#if !hasLessonVideos}
+                <LessonMaterialActions showSummarize {lessonId} alignWithNote />
+              {/if}
+
+              {#each viewModeComponents as Component, index (index)}
+                <Component {mode} {lessonId} {courseId} />
+              {/each}
+
+              {#if $currentOrg.customization?.apps?.comments}
+                <hr class="my-2" />
+
+                <Comments {lessonId} />
+              {/if}
+            </div>
+          {/key}
+        {:else}
+          <Empty
+            title={$t('course.navItem.lessons.materials.no_content')}
+            icon={VideoIcon}
+            variant="page"
+            class="text-center"
+          />
+        {/if}
       {:else if mode === MODES.edit}
         <UnderlineTabs.Root
           bind:value={currentTabValue}
@@ -558,13 +584,6 @@
             {/if}
           </div>
         {/key}
-      {:else if $isOrgStudent === true}
-        <Empty
-          title={$t('course.navItem.lessons.materials.no_content')}
-          icon={VideoIcon}
-          variant="page"
-          class="text-center"
-        />
       {:else}
         <Empty
           title={$t('course.navItem.lessons.materials.body_heading')}

--- a/apps/dashboard/src/lib/utils/store/app.ts
+++ b/apps/dashboard/src/lib/utils/store/app.ts
@@ -33,6 +33,19 @@ export const isStudentExperience = derived([globalStore, isOrgStudent], ([$gs, $
 });
 
 /**
+ * True when course lesson/exercise pages should render the learner UI
+ * (locked notices, student empty states, no teacher authoring CTAs).
+ * Cloud org-site visitors always get the learner view; on the app host
+ * only org-role students do.
+ */
+export const isCourseLearnerView = derived(
+  [isStudentExperience, isOrgStudent],
+  ([$isStudentExperience, $isOrgStudent]) => {
+    return $isStudentExperience || $isOrgStudent === true;
+  }
+);
+
+/**
  * The root path for navigation: '/lms' for students, '/org/{siteName}' for admin/teacher
  */
 export const basePath = derived([isStudentExperience, currentOrgPath], ([$isStudent, $orgPath]) =>

--- a/apps/dashboard/src/routes/(app)/courses/[id]/+layout.svelte
+++ b/apps/dashboard/src/routes/(app)/courses/[id]/+layout.svelte
@@ -25,7 +25,7 @@
   import { page } from '$app/state';
   import { profile } from '$lib/utils/store/user';
   import { isOrgAdmin } from '$lib/utils/store/org';
-  import { isOrgStudent } from '$lib/utils/store/app';
+  import { isCourseLearnerView } from '$lib/utils/store/app';
   import { t } from '$lib/utils/functions/translations';
   import { ContentType } from '@cio/utils/constants/content';
   import type { CourseMember } from '$features/course/utils/types';
@@ -104,7 +104,7 @@
   const showContentAskAiBar = $derived(
     isCourseReady &&
       isLessonOrExercisePage &&
-      !($isOrgStudent && isContentLockedForStudent) &&
+      !($isCourseLearnerView && isContentLockedForStudent) &&
       sidePanel.activePanelId !== AI_ASSISTANT_PANEL_ID
   );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #760. The first lesson-lock fix gated checks on `$isOrgStudent === true`, which still misses learners on **org sites** (subdomain/custom domain) where `isStudentExperience` is `true` but org role may be unset or not `STUDENT`.

Those students saw the teacher empty state ("No note, video or slide added…" + Get Started) on locked lessons even though the sidebar showed a padlock.

## Fix

- Add `isCourseLearnerView` = `isStudentExperience || isOrgStudent === true`
- Restructure lesson page like exercise page: learner branch always shows locked notice / student empty states
- Apply to sidebar lock blocking, nav actions, and AI bar
- Block prev/next navigation into locked content for learners

## Test plan

- [ ] On org site / custom domain as student, open teacher-locked empty lesson → "This content is locked"
- [ ] Progression-locked lesson → "Complete previous content first"
- [ ] Teacher on same lesson → teacher empty state with Get Started
- [ ] Prev/next does not navigate into locked items for learners
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-033e3d1f-cc26-4a2e-93f4-1e6c23962126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-033e3d1f-cc26-4a2e-93f4-1e6c23962126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the lesson-lock fix from #760 to cover org-site learners (subdomain/custom domain), where `isStudentExperience` is `true` but `isOrgStudent` may be unset. A new `isCourseLearnerView` derived store (`isStudentExperience || isOrgStudent === true`) replaces the narrower `$isOrgStudent === true` guards across the lesson page, sidebar, nav actions, and AI bar.

- **`app.ts`**: Adds `isCourseLearnerView` store with a clear JSDoc explaining the intent; `isStudentExperience` and `isOrgStudent` are its two inputs.
- **`lesson.svelte`**: Restructures the page body so the full learner branch (spinner → locked notice → content → empty state) lives under a single `{#if $isCourseLearnerView}` block, mirroring the exercise page.
- **`content-navigation-actions.svelte`**, **`course-content-tree.svelte`**, **`+layout.svelte`**: Import swapped and all gating expressions updated — except one missed usage of `$isOrgStudent` inside `markLessonComplete` (see inline comment).

<h3>Confidence Score: 3/5</h3>

The org-site locking logic is sound but the component has a broken import that will prevent it from compiling.

The new `isCourseLearnerView` store is well-reasoned and four of five usages were correctly migrated. However, `$isOrgStudent` inside `markLessonComplete` lost its import — the Svelte compiler requires the backing store to be in scope for reactive `$store` subscription syntax, so this file will either fail to compile or throw at runtime when a student marks a lesson complete.

`content-navigation-actions.svelte` — `isOrgStudent` must be re-added to the import (or the `allComplete` check updated to use `$isCourseLearnerView`) before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/utils/store/app.ts | Adds `isCourseLearnerView` derived store combining `isStudentExperience || isOrgStudent === true`. Logic is clear and well-documented. |
| apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte | Import of `isOrgStudent` was removed but `$isOrgStudent` is still referenced inside `markLessonComplete`, causing a compile/runtime error. Three other usages were correctly migrated to `$isCourseLearnerView`. |
| apps/dashboard/src/lib/features/course/pages/lesson.svelte | Restructured to put the entire learner UI branch under `$isCourseLearnerView`; correctly shows locked notice, spinner, content, and student empty state. |
| apps/dashboard/src/lib/features/course/components/sidebar/course-content-tree.svelte | Both `isLockedForStudent` derivations correctly migrated from `$isOrgStudent === true` to `$isCourseLearnerView`. |
| apps/dashboard/src/routes/(app)/courses/[id]/+layout.svelte | AI bar `showContentAskAiBar` guard updated from `$isOrgStudent` to `$isCourseLearnerView`. Clean change. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte`, line 147-152 ([link](https://github.com/classroomio/classroomio/blob/9ffed337707698bf828c048cf5a24def4641c5c1/apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte#L147-L152)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing import breaks `markLessonComplete`**

   The PR replaced the `isOrgStudent` import with `isCourseLearnerView`, but left `$isOrgStudent` referenced inside `markLessonComplete`. Because `isOrgStudent` is no longer in scope, the Svelte compiler will reject this file, which would prevent the entire component from rendering. Even if the build were somehow lenient, calling `markLessonComplete` would throw a ReferenceError at runtime and students could never trigger the course-completion modal.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): use learner view for les..."](https://github.com/classroomio/classroomio/commit/9ffed337707698bf828c048cf5a24def4641c5c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44752042)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->