### PR TITLE
fix(dashboard): lesson nav build error and add CI build check

### DIFF
--- a/.github/workflows/package-build-check.yml
+++ b/.github/workflows/package-build-check.yml
@@ -1,0 +1,53 @@
+name: Package build check
+
+on:
+  pull_request:
+    paths:
+      - 'apps/dashboard/**'
+      - 'apps/api/**'
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - 'turbo.json'
+      - '.nvmrc'
+      - '.github/workflows/package-build-check.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/dashboard/**'
+      - 'apps/api/**'
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - 'turbo.json'
+      - '.nvmrc'
+      - '.github/workflows/package-build-check.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Prepare dashboard env
+        run: cp apps/dashboard/.env.example apps/dashboard/.env
+
+      - name: Build dashboard
+        run: pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build
+
+      - name: Build API
+        run: pnpm --filter @cio/api^... build && pnpm --filter @cio/api build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,29 @@ When a task requires factual information (API specifications, context window siz
 - Commit messages must follow the Conventional Commits 1.0.0 spec: https://www.conventionalcommits.org/en/v1.0.0/
 - Never include agent-provider attribution in commits or commit trailers. Do not add `Co-authored-by` lines for Cursor, Claude, Codex, or any other tool.
 
+## Verification before commit/PR
+
+Before committing or opening/updating a PR, run the build checks that match the areas you changed. Use Node 20 (the repo's `.nvmrc` version):
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH"
+```
+
+- **Dashboard changes** (`apps/dashboard/**`, or shared packages consumed by the dashboard):
+
+  ```bash
+  test -f apps/dashboard/.env || cp apps/dashboard/.env.example apps/dashboard/.env
+  pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build
+  ```
+
+- **API changes** (`apps/api/**`, or shared packages consumed by the API):
+
+  ```bash
+  pnpm --filter @cio/api^... build && pnpm --filter @cio/api build
+  ```
+
+Also run `pnpm format:check` (see Translation, Formatting, and Git Workflow above). Do not commit if any verification step fails.
+
 ## Naming Convention
 
 - Use kebab-case for files (e.g. `user-profile.svelte`, `org.svelte.ts`).

--- a/apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte
+++ b/apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte
@@ -7,8 +7,10 @@
   import { Button } from '@cio/ui/base/button';
   import * as Tooltip from '@cio/ui/base/tooltip';
   import { PercentRingProgress } from '@cio/ui/custom/percent-ring-progress';
+  import { get } from 'svelte/store';
   import { isCourseLearnerView } from '$lib/utils/store/app';
   import { getStudentContentLockReason } from '$features/ai-assistant/utils/content-ask-ai-bar';
+  import { getStudentContentLockTitleKey } from '$features/course/utils/content-lock-utils';
   import { t } from '$lib/utils/functions/translations';
   import { courseApi, lessonApi } from '$features/course/api';
   import { getOrderedNavigableContent, getContentRoute } from '$features/course/utils/content';
@@ -50,16 +52,21 @@
     };
   });
 
+  function getNavigableLockReason(target: CourseContentItem | null) {
+    if (!target) return null;
+
+    const targetType = target.type === ContentType.Lesson ? ContentType.Lesson : ContentType.Exercise;
+    return getStudentContentLockReason(courseApi.course, target.id, targetType);
+  }
+
   function goToContent(target: CourseContentItem | null) {
     if (!target) return;
 
-    if ($isCourseLearnerView) {
-      const targetType = target.type === ContentType.Lesson ? ContentType.Lesson : ContentType.Exercise;
-      const lockReason = getStudentContentLockReason(courseApi.course, target.id, targetType);
+    const lockReason = getNavigableLockReason(target);
 
-      if (lockReason) {
-        return;
-      }
+    if (get(isCourseLearnerView) && lockReason) {
+      snackbar.error(getStudentContentLockTitleKey(lockReason));
+      return;
     }
 
     const courseIdResolved = courseApi.course?.id;
@@ -71,6 +78,20 @@
 
   const isPrevDisabled = $derived(!prevNextContent.prev);
   const isNextDisabled = $derived(!prevNextContent.next);
+  const prevNavLockReason = $derived($isCourseLearnerView ? getNavigableLockReason(prevNextContent.prev) : null);
+  const nextNavLockReason = $derived($isCourseLearnerView ? getNavigableLockReason(prevNextContent.next) : null);
+  const isPrevNavBlocked = $derived(Boolean(prevNavLockReason));
+  const isNextNavBlocked = $derived(Boolean(nextNavLockReason));
+  const prevNavTooltip = $derived(
+    prevNavLockReason
+      ? $t(getStudentContentLockTitleKey(prevNavLockReason))
+      : $t('course.navItem.lessons.prev_shortcut')
+  );
+  const nextNavTooltip = $derived(
+    nextNavLockReason
+      ? $t(getStudentContentLockTitleKey(nextNavLockReason))
+      : $t('course.navItem.lessons.next_shortcut')
+  );
   const isLessonComplete = $derived.by(() => {
     if (!lessonId) return false;
     const lesson = lessonItems.find((l) => l.id === lessonId);
@@ -145,7 +166,7 @@
       updateCourseContentCompletion(currentLessonId, isComplete);
 
       const allComplete =
-        $isOrgStudent &&
+        get(isCourseLearnerView) &&
         isComplete &&
         navigableContentItems.length > 0 &&
         navigableContentItems.every((item) => item.isComplete);
@@ -231,14 +252,14 @@
             size="icon-sm"
             variant="outline"
             onclick={() => goToContent(prevNextContent.prev)}
-            disabled={isPrevDisabled}
+            disabled={isPrevDisabled || isPrevNavBlocked}
             aria-label={$t('course.navItem.lessons.prev')}
           >
             <ChevronLeftIcon size={14} />
           </Button>
         </Tooltip.Trigger>
         <Tooltip.Content side="bottom" sideOffset={4}>
-          {$t('course.navItem.lessons.prev_shortcut')}
+          {prevNavTooltip}
         </Tooltip.Content>
       </Tooltip.Root>
 
@@ -248,14 +269,14 @@
             size="icon-sm"
             variant="outline"
             onclick={() => goToContent(prevNextContent.next)}
-            disabled={isNextDisabled}
+            disabled={isNextDisabled || isNextNavBlocked}
             aria-label={$t('course.navItem.lessons.next')}
           >
             <ChevronRightIcon size={14} />
           </Button>
         </Tooltip.Trigger>
         <Tooltip.Content side="bottom" sideOffset={4}>
-          {$t('course.navItem.lessons.next_shortcut')}
+          {nextNavTooltip}
         </Tooltip.Content>
       </Tooltip.Root>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the production build error introduced in #764 where `content-navigation-actions.svelte` referenced `$isOrgStudent` after its import was removed.

Also adds agent/CI guardrails so similar build failures are caught before merge.

## Changes

### Lesson navigation build fix
- Replace `$isOrgStudent` with `get(isCourseLearnerView)` for the course-completion modal gate
- Disable prev/next navigation when the adjacent lesson is locked for the learner
- Show lock-reason tooltips on blocked navigation arrows
- Show a snackbar when blocked navigation is attempted (including keyboard shortcuts)

### Verification guardrails
- **AGENTS.md** — new "Verification before commit/PR" section with Node 20, dashboard/API build commands, and `pnpm format:check`
- **`.github/workflows/package-build-check.yml`** — runs dashboard and API builds on PRs that touch `apps/dashboard`, `apps/api`, `packages/`, or lockfile changes

## Testing

```bash
export PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH"
test -f apps/dashboard/.env || cp apps/dashboard/.env.example apps/dashboard/.env
pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build
pnpm format:check
```

Dashboard build passes locally with the nav fix applied.

Fixes the Render build failure from illegal `$isOrgStudent` reference.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-033e3d1f-cc26-4a2e-93f4-1e6c23962126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-033e3d1f-cc26-4a2e-93f4-1e6c23962126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a production build error from #764 where `$isOrgStudent` was referenced in `content-navigation-actions.svelte` after its import was removed. It also adds UX improvements for locked-content navigation and a new CI workflow to catch similar build failures before merge.

- **Build fix**: replaces the removed `$isOrgStudent` with `get(isCourseLearnerView)` in imperative function bodies and `$isCourseLearnerView` in reactive `$derived` expressions — the correct Svelte 5 pattern for each context.
- **Lock-aware nav**: prev/next buttons are now visually disabled when the adjacent item is locked for a learner, with lock-reason tooltips; keyboard shortcuts (`ArrowLeft`/`ArrowRight`) still fire but route through `goToContent`, which shows a snackbar and short-circuits navigation.
- **CI guardrail**: new `package-build-check.yml` runs dashboard and API builds on PRs touching `apps/`, `packages/`, or lockfile changes, and the same commands are documented in `AGENTS.md` for local verification.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the Svelte component fix is minimal and correct, the CI workflow uses pinned actions, and no logic paths are left unguarded.

The core fix is a straightforward substitution of the correct reactive and imperative store-access patterns in Svelte 5. The lock-aware navigation additions are self-contained and degrade gracefully (null-guarded helper, boolean derived values). The CI workflow follows standard GitHub Actions conventions with no risky steps.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte | Replaces removed $isOrgStudent with get(isCourseLearnerView) in imperative contexts and $isCourseLearnerView in reactive $derived blocks; adds per-button lock awareness, lock-reason tooltips, and snackbar feedback when learners try to navigate to locked content |
| .github/workflows/package-build-check.yml | New CI workflow that builds dashboard and API on PRs touching those paths; uses pinned v4 actions, pnpm cache, and .env.example setup step |
| AGENTS.md | Documents build verification steps for agents/contributors, matching the new CI workflow commands |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Arrow key / button click] --> B{target exists?}
    B -- No --> Z[no-op]
    B -- Yes --> C[getNavigableLockReason]
    C --> D{isCourseLearnerView\n&& lockReason?}
    D -- Yes --> E[snackbar.error with lock title key]
    E --> Z
    D -- No --> F[resolve route via getContentRoute]
    F --> G[goto route]

    H["$derived: prevNavLockReason\n($isCourseLearnerView ? lock : null)"] --> I{lockReason set?}
    I -- Yes --> J[disabled button + lock tooltip]
    I -- No --> K[normal button + shortcut tooltip]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Arrow key / button click] --> B{target exists?}
    B -- No --> Z[no-op]
    B -- Yes --> C[getNavigableLockReason]
    C --> D{isCourseLearnerView\n&& lockReason?}
    D -- Yes --> E[snackbar.error with lock title key]
    E --> Z
    D -- No --> F[resolve route via getContentRoute]
    F --> G[goto route]

    H["$derived: prevNavLockReason\n($isCourseLearnerView ? lock : null)"] --> I{lockReason set?}
    I -- Yes --> J[disabled button + lock tooltip]
    I -- No --> K[normal button + shortcut tooltip]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["ci: add package build check and AGENTS.m..."](https://github.com/classroomio/classroomio/commit/7e6f85d74a5e8dc2e467e89c097e3646f0fce9a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44759902)</sub>

<!-- /greptile_comment -->