### PR TITLE
fix(dashboard): course landing page editor section and currency bugs

### DIFF
--- a/apps/dashboard/src/lib/features/ui/course-landing-page/components/editor/pricing-form.svelte
+++ b/apps/dashboard/src/lib/features/ui/course-landing-page/components/editor/pricing-form.svelte
@@ -48,7 +48,7 @@
       <Select.Trigger class="w-full">
         <p>{course.currency === 'NGN' ? 'NGN' : 'USD'}</p>
       </Select.Trigger>
-      <Select.Content>
+      <Select.Content class="z-menu-elevated">
         <Select.Item value="NGN">NGN</Select.Item>
         <Select.Item value="USD">USD</Select.Item>
       </Select.Content>

--- a/apps/dashboard/src/lib/utils/functions/getCurrencyFormatter.ts
+++ b/apps/dashboard/src/lib/utils/functions/getCurrencyFormatter.ts
@@ -1,8 +1,2 @@
-export default (currency: string | undefined) => {
-  const locale = currency == 'NGN' ? 'en-NG' : 'en-US';
-  return new Intl.NumberFormat(locale, {
-    style: 'currency',
-    currency: currency,
-    minimumFractionDigits: 2
-  });
-};
+export { getCurrencyFormatter } from '@cio/utils/functions';
+export { getCurrencyFormatter as default } from '@cio/utils/functions';

--- a/apps/dashboard/src/routes/(app)/courses/[id]/landingpage/+page.svelte
+++ b/apps/dashboard/src/routes/(app)/courses/[id]/landingpage/+page.svelte
@@ -44,10 +44,13 @@
   };
 
   setLandingPageEditContext({
-    selectedKey: () => selectedSectionKey,
-    selectKey: (key) => (selectedSectionKey = key),
-    labelFor: (key) => t.get(`course.navItem.landing_page.editor.title.${key}` as never) || key,
-    iconFor: (key) => sectionIcons[key] ?? HeaderIcon
+    selectedKey: () => (selectedSectionKey === 'header' ? 'hero' : selectedSectionKey),
+    selectKey: (key) => (selectedSectionKey = key === 'hero' ? 'header' : key),
+    labelFor: (key) => {
+      const sectionKey = key === 'hero' ? 'header' : key;
+      return t.get(`course.navItem.landing_page.editor.title.${sectionKey}` as never) || key;
+    },
+    iconFor: (key) => sectionIcons[key === 'hero' ? 'header' : key] ?? HeaderIcon
   });
 
   function syncCourseStore(_courseData: Course) {

--- a/packages/ui/src/custom/org-landing-page/course-pricing.svelte
+++ b/packages/ui/src/custom/org-landing-page/course-pricing.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import type { CoursePricing, CourseLandingPageLabels, OrgLandingPageTheme } from './types';
   import { courseLandingTokens } from './course-landing-page.tokens';
-  import { calcCourseDiscount, getCourseCurrencyFormatter } from './landing-page-utils';
+  import { calcCourseDiscount } from './landing-page-utils';
+  import { getCurrencyFormatter } from '@cio/utils/functions';
   import EditableLandingSection from './editable-section.svelte';
   import LandingButton from './landing-button.svelte';
   import CheckIcon from '@lucide/svelte/icons/check';
@@ -20,7 +21,7 @@
 
   const isFree = $derived(!pricing.cost || pricing.cost <= 0);
 
-  const currencyFormatter = $derived(getCourseCurrencyFormatter(pricing.currency ?? 'USD'));
+  const currencyFormatter = $derived(getCurrencyFormatter(pricing.currency ?? 'USD'));
 
   const discountedAmount = $derived(
     pricing.showDiscount && pricing.discount && pricing.cost

--- a/packages/ui/src/custom/org-landing-page/course-pricing.svelte
+++ b/packages/ui/src/custom/org-landing-page/course-pricing.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { CoursePricing, CourseLandingPageLabels, OrgLandingPageTheme } from './types';
   import { courseLandingTokens } from './course-landing-page.tokens';
+  import { calcCourseDiscount, getCourseCurrencyFormatter } from './landing-page-utils';
   import EditableLandingSection from './editable-section.svelte';
   import LandingButton from './landing-button.svelte';
   import CheckIcon from '@lucide/svelte/icons/check';
@@ -19,17 +20,17 @@
 
   const isFree = $derived(!pricing.cost || pricing.cost <= 0);
 
-  const currencySymbol = $derived(
-    pricing.currency === 'USD' ? '$' : pricing.currency === 'EUR' ? '€' : pricing.currency === 'GBP' ? '£' : ''
-  );
+  const currencyFormatter = $derived(getCourseCurrencyFormatter(pricing.currency ?? 'USD'));
 
   const discountedAmount = $derived(
     pricing.showDiscount && pricing.discount && pricing.cost
-      ? pricing.cost - (pricing.cost * pricing.discount) / 100
+      ? calcCourseDiscount(pricing.discount, pricing.cost, true)
       : null
   );
 
   const displayAmount = $derived(discountedAmount ?? pricing.cost ?? 0);
+  const formattedDisplayAmount = $derived(currencyFormatter.format(displayAmount));
+  const formattedOriginalAmount = $derived(currencyFormatter.format(pricing.cost ?? 0));
 </script>
 
 <EditableLandingSection sectionKey="pricing">
@@ -42,14 +43,9 @@
             <span class={t.pricingAmount}>{labels?.freeLabel ?? 'Free'}</span>
           {:else}
             <div class="ui:flex ui:items-baseline ui:gap-3">
-              <span class={t.pricingAmount}>
-                {currencySymbol}{displayAmount.toFixed(0)}
-                <span class={t.pricingCurrency}>{currencySymbol ? '' : pricing.currency}</span>
-              </span>
+              <span class={t.pricingAmount}>{formattedDisplayAmount}</span>
               {#if discountedAmount !== null}
-                <span class={t.pricingDiscount}>
-                  {currencySymbol}{(pricing.cost ?? 0).toFixed(0)}
-                </span>
+                <span class={t.pricingDiscount}>{formattedOriginalAmount}</span>
               {/if}
             </div>
             {#if pricing.discount && pricing.showDiscount}

--- a/packages/ui/src/custom/org-landing-page/editable-section.svelte
+++ b/packages/ui/src/custom/org-landing-page/editable-section.svelte
@@ -42,23 +42,22 @@
     onclick={handleClick}
     onkeydown={handleKeydown}
     class={cn(
-      'ui:relative ui:outline-none ui:cursor-pointer ui:transition-shadow',
-      selected
-        ? 'ui:ring-2 ui:ring-primary ui:ring-inset'
-        : 'ui:hover:ring-2 ui:hover:ring-primary/40 ui:hover:ring-inset',
+      'group ui:relative ui:outline-none ui:cursor-pointer ui:border-y-2 ui:border-dashed ui:transition-colors',
+      selected ? 'ui:border-primary' : 'ui:border-transparent ui:hover:border-primary/40',
       className
     )}
   >
-    {#if selected}
-      <div
-        class="ui:absolute ui:top-0 ui:left-0 ui:z-30 ui:-translate-y-full ui:flex ui:items-center ui:gap-1.5 ui:rounded-t-md ui:bg-primary ui:px-2 ui:py-1 ui:text-xs ui:font-medium ui:text-primary-foreground ui:shadow-sm ui:pointer-events-none"
-      >
-        {#if Icon}
-          <Icon size={14} class="ui:size-3.5" />
-        {/if}
-        <span>{ctx.labelFor(sectionKey)}</span>
-      </div>
-    {/if}
+    <div
+      class={cn(
+        'ui:absolute ui:top-0 ui:left-0 ui:z-30 ui:-translate-y-full ui:flex ui:items-center ui:gap-1.5 ui:rounded-t-md ui:bg-primary ui:px-2 ui:py-1 ui:text-xs ui:font-medium ui:text-primary-foreground ui:shadow-sm ui:pointer-events-none ui:transition-opacity',
+        selected ? 'ui:opacity-100' : 'ui:opacity-0 ui:group-hover:opacity-100'
+      )}
+    >
+      {#if Icon}
+        <Icon size={14} class="ui:size-3.5" />
+      {/if}
+      <span>{ctx.labelFor(sectionKey)}</span>
+    </div>
     {@render children()}
   </div>
 {/if}

--- a/packages/ui/src/custom/org-landing-page/editable-section.svelte
+++ b/packages/ui/src/custom/org-landing-page/editable-section.svelte
@@ -42,7 +42,7 @@
     onclick={handleClick}
     onkeydown={handleKeydown}
     class={cn(
-      'group ui:relative ui:outline-none ui:cursor-pointer ui:border-y-2 ui:border-dashed ui:transition-colors',
+      'ui:group ui:relative ui:outline-none ui:cursor-pointer ui:border-y-2 ui:border-dashed ui:transition-colors',
       selected ? 'ui:border-primary' : 'ui:border-transparent ui:hover:border-primary/40',
       className
     )}

--- a/packages/ui/src/custom/org-landing-page/landing-page-utils.ts
+++ b/packages/ui/src/custom/org-landing-page/landing-page-utils.ts
@@ -65,17 +65,6 @@ export function formatExerciseCountLabel(count: number) {
   return `${count} exercises`;
 }
 
-/** Mirrors dashboard `getCurrencyFormatter` for landing-page course pricing. */
-export function getCourseCurrencyFormatter(currency = 'USD') {
-  const locale = currency === 'NGN' ? 'en-NG' : 'en-US';
-
-  return new Intl.NumberFormat(locale, {
-    style: 'currency',
-    currency,
-    minimumFractionDigits: 2
-  });
-}
-
 /** Mirrors dashboard `calcCourseDiscount` for landing-page course cards. */
 export function calcCourseDiscount(percent = 0, cost: number, showDiscount: boolean) {
   if (!percent || !showDiscount) return cost;

--- a/packages/ui/src/custom/org-landing-page/landing-page-utils.ts
+++ b/packages/ui/src/custom/org-landing-page/landing-page-utils.ts
@@ -65,6 +65,21 @@ export function formatExerciseCountLabel(count: number) {
   return `${count} exercises`;
 }
 
+/** Mirrors dashboard `getCurrencyFormatter` for landing-page course pricing. */
+export function getCourseCurrencyFormatter(currency = 'USD') {
+  const locale = currency === 'NGN' ? 'en-NG' : 'en-US';
+
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2
+  });
+}
+
+export function formatCourseCurrency(amount: number, currency = 'USD') {
+  return getCourseCurrencyFormatter(currency).format(amount);
+}
+
 /** Mirrors dashboard `calcCourseDiscount` for landing-page course cards. */
 export function calcCourseDiscount(percent = 0, cost: number, showDiscount: boolean) {
   if (!percent || !showDiscount) return cost;

--- a/packages/ui/src/custom/org-landing-page/landing-page-utils.ts
+++ b/packages/ui/src/custom/org-landing-page/landing-page-utils.ts
@@ -76,10 +76,6 @@ export function getCourseCurrencyFormatter(currency = 'USD') {
   });
 }
 
-export function formatCourseCurrency(amount: number, currency = 'USD') {
-  return getCourseCurrencyFormatter(currency).format(amount);
-}
-
 /** Mirrors dashboard `calcCourseDiscount` for landing-page course cards. */
 export function calcCourseDiscount(percent = 0, cost: number, showDiscount: boolean) {
   if (!percent || !showDiscount) return cost;

--- a/packages/utils/src/functions/currency.ts
+++ b/packages/utils/src/functions/currency.ts
@@ -1,0 +1,11 @@
+/** Locale-aware currency formatter for course prices (NGN and USD). */
+export function getCurrencyFormatter(currency: string | undefined = 'USD') {
+  const normalizedCurrency = currency === 'NGN' ? 'NGN' : 'USD';
+  const locale = normalizedCurrency === 'NGN' ? 'en-NG' : 'en-US';
+
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: normalizedCurrency,
+    minimumFractionDigits: 2
+  });
+}

--- a/packages/utils/src/functions/index.ts
+++ b/packages/utils/src/functions/index.ts
@@ -1,4 +1,5 @@
 export * from './array';
+export * from './currency';
 export * from './fileValidation';
 export * from './sanitize';
 export * from './slug';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes bugs in the course landing page editor:

1. **Currency dropdown not selectable** — Raised select z-index with `z-menu-elevated` so the dropdown appears above the full-screen editor shell.
2. **Missing section boundary affordances** — Dashed top/bottom borders and section title badge on hover and when active.
3. **No price formatting** — Pricing preview now uses `Intl.NumberFormat` (e.g. `₦10.00`, `$10.00`) instead of raw values like `10 NGN`.
4. **Hero/header key mismatch** — Course editor maps `hero` ↔ `header` so clicking the hero opens the Header form.

## Changes

- `pricing-form.svelte` — `Select.Content class="z-menu-elevated"`
- `editable-section.svelte` — dashed borders + hover title badge
- `course-pricing.svelte` — `getCourseCurrencyFormatter` for formatted prices
- `landing-page-utils.ts` — shared currency formatter utility
- `courses/[id]/landingpage/+page.svelte` — hero/header key mapping

## Test plan

- [ ] Open course landing page editor → Pricing section
- [ ] Confirm currency dropdown opens and NGN/USD can be selected
- [ ] Confirm price displays as `₦10.00` (NGN) or `$10.00` (USD), not `10 NGN`
- [ ] Confirm active/hovered sections show dashed borders and title badge
- [ ] Click hero in preview and confirm Header form opens

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e14eba1e-4236-43c2-875b-99f9f11330b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e14eba1e-4236-43c2-875b-99f9f11330b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes four independent bugs in the course landing page editor: the currency dropdown being obscured by the full-screen editor shell, missing hover/active affordances on editable sections, raw price display lacking locale formatting, and the hero section click not opening the Header form.

- **`pricing-form.svelte`**: Adds `z-menu-elevated` so the Select dropdown appears above the full-screen overlay.
- **`editable-section.svelte`**: Switches from ring outline to dashed border; section badge is always present in the DOM using `ui:group` + `ui:group-hover:opacity-100`, which correctly uses the Tailwind `ui:` prefix.
- **`course-pricing.svelte` + `currency.ts`**: Replaces manual symbol strings and `.toFixed(0)` with `Intl.NumberFormat` via a new shared `getCurrencyFormatter` utility, producing properly formatted strings like `₦10.00` / `$10.00`. Currency schema is restricted to `['NGN', 'USD']`, so the helper's normalization to those two codes is exhaustive.
- **`+page.svelte`**: Hero↔header key mapping is applied consistently across all four context callbacks (`selectedKey`, `selectKey`, `labelFor`, `iconFor`).

<h3>Confidence Score: 5/5</h3>

All four fixes are narrow and targeted; no shared state, migrations, or auth paths are touched.

Each change addresses a clearly scoped UI bug. The currency utility's hardcoding to NGN/USD is safe because the schema already enforces that enum. The getCurrencyFormatter re-export preserves the existing default-import contract. No regressions were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/ui/course-landing-page/components/editor/pricing-form.svelte | Adds z-menu-elevated to Select.Content to fix the currency dropdown appearing below the full-screen editor overlay. |
| packages/utils/src/functions/currency.ts | New shared getCurrencyFormatter utility; safely defaults to USD for undefined and normalizes non-NGN to USD, consistent with the schema-level enum restriction to ['NGN','USD']. |
| apps/dashboard/src/lib/utils/functions/getCurrencyFormatter.ts | Replaced inline implementation with re-exports (named + default) from @cio/utils/functions, keeping backward-compatibility for all existing callers using the default import. |
| apps/dashboard/src/routes/(app)/courses/[id]/landingpage/+page.svelte | Adds hero-header key translation in all four context callbacks so clicking the hero section opens the Header form and shows the correct label/icon. |
| packages/ui/src/custom/org-landing-page/course-pricing.svelte | Replaces manual currency symbol logic and .toFixed(0) with Intl.NumberFormat via getCurrencyFormatter; also switches to the shared calcCourseDiscount helper. |
| packages/ui/src/custom/org-landing-page/editable-section.svelte | Replaces ring outline with dashed border; section-title badge is now always in the DOM (opacity-0 until hovered/selected) using ui:group + ui:group-hover:opacity-100, which is correctly prefixed. |
| packages/utils/src/functions/index.ts | Exports the new currency.ts module from the utils package barrel file. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Preview as Landing Preview
    participant Ctx as Edit Context
    participant Editor as Editor Sidebar

    Note over Ctx: selectedSectionKey state

    Preview->>Ctx: selectKey('hero')
    Ctx->>Ctx: "selectedSectionKey = 'header'"
    Ctx->>Editor: open Header form

    Editor->>Ctx: selectedKey()
    Ctx-->>Editor: 'hero' (mapped from 'header')
    Editor->>Preview: "highlight hero section (selected=true)"

    Preview->>Ctx: labelFor('hero')
    Ctx->>Ctx: "sectionKey = 'header'"
    Ctx-->>Preview: t('...editor.title.header')

    Preview->>Ctx: iconFor('hero')
    Ctx-->>Preview: "sectionIcons['header'] = HeaderIcon"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Preview as Landing Preview
    participant Ctx as Edit Context
    participant Editor as Editor Sidebar

    Note over Ctx: selectedSectionKey state

    Preview->>Ctx: selectKey('hero')
    Ctx->>Ctx: "selectedSectionKey = 'header'"
    Ctx->>Editor: open Header form

    Editor->>Ctx: selectedKey()
    Ctx-->>Editor: 'hero' (mapped from 'header')
    Editor->>Preview: "highlight hero section (selected=true)"

    Preview->>Ctx: labelFor('hero')
    Ctx->>Ctx: "sectionKey = 'header'"
    Ctx-->>Preview: t('...editor.title.header')

    Preview->>Ctx: iconFor('hero')
    Ctx-->>Preview: "sectionIcons['header'] = HeaderIcon"
```

</a>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into cursor/course-l..."](https://github.com/classroomio/classroomio/commit/3e612bd7bd40c73444d16db5286bebd753318bd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45429671)</sub>

<!-- /greptile_comment -->