### PR TITLE
feat(course): auto-enrol button for paid course join requests

### DIFF
--- a/apps/api/src/services/course/payment-request.ts
+++ b/apps/api/src/services/course/payment-request.ts
@@ -5,6 +5,7 @@ import { getCourseWithOrgData } from '@cio/db/queries/course';
 import { buildEmailFromName, buildEmailBranding } from '@cio/email';
 import { enqueueTransactionalEmail } from '@api/services/jobs';
 import { trackServerEvent, SERVER_EVENTS } from '@cio/analytics';
+import { getDashboardBaseUrl } from '@cio/core/config/dashboard-url';
 
 export interface PaymentRequestData {
   courseId: string;
@@ -47,6 +48,15 @@ export async function createPaymentRequest(data: PaymentRequestData) {
 
     const teacherEmail = teacherResult[0].email;
 
+    const dashboardOrg = {
+      siteName: course.orgSiteName,
+      customDomain: course.orgCustomDomain,
+      isCustomDomainVerified: course.orgIsCustomDomainVerified
+    };
+    const dashboardBaseUrl = getDashboardBaseUrl(dashboardOrg);
+    const courseUrl = `${dashboardBaseUrl}/courses/${data.courseId}`;
+    const autoEnrollUrl = `${dashboardBaseUrl}/courses/${data.courseId}/people?grantAccess=${encodeURIComponent(data.studentEmail)}`;
+
     try {
       await enqueueTransactionalEmail('teacherStudentBuyRequest', {
         to: teacherEmail,
@@ -54,6 +64,8 @@ export async function createPaymentRequest(data: PaymentRequestData) {
           courseName,
           studentEmail: data.studentEmail,
           studentFullname: data.studentFullname,
+          courseUrl,
+          autoEnrollUrl,
           branding
         },
         from: buildEmailFromName('ClassroomIO'),

--- a/apps/dashboard/src/lib/features/course/components/people/grant-access-modal.svelte
+++ b/apps/dashboard/src/lib/features/course/components/people/grant-access-modal.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
+  import * as Dialog from '@cio/ui/base/dialog';
+  import { Button } from '@cio/ui/base/button';
+  import { t } from '$lib/utils/functions/translations';
+  import { courseApi } from '$features/course/api';
+  import { orgApi } from '$features/org/api/org.svelte';
+  import { profile } from '$lib/utils/store/user';
+  import { isStudentLimitReached } from '$lib/utils/store/org';
+  import { UpgradeBanner } from '$features/ui';
+
+  const GRANT_ACCESS_PARAM = 'grantAccess';
+
+  let courseId = $derived(courseApi.course?.id ?? '');
+  const studentEmail = $derived(new URLSearchParams(page.url.search).get(GRANT_ACCESS_PARAM)?.trim() ?? '');
+  const isOpen = $derived(Boolean(studentEmail));
+
+  let isSubmitting = $state(false);
+
+  function closeModal() {
+    const nextParams = new URLSearchParams(page.url.search);
+    nextParams.delete(GRANT_ACCESS_PARAM);
+    const query = nextParams.toString();
+
+    goto(resolve(`${page.url.pathname}${query ? `?${query}` : ''}`, {}));
+  }
+
+  async function handleSendInvite() {
+    if (!courseId || !studentEmail || $isStudentLimitReached) {
+      return;
+    }
+
+    isSubmitting = true;
+
+    try {
+      const response = await orgApi.importAudienceMembers({
+        recipientCsv: studentEmail,
+        courseIds: [courseId],
+        sendEmail: true
+      });
+
+      if (!response) {
+        return;
+      }
+
+      await courseApi.refreshCourse(courseId, $profile.id);
+      closeModal();
+    } finally {
+      isSubmitting = false;
+    }
+  }
+</script>
+
+<Dialog.Root
+  open={isOpen}
+  onOpenChange={(open) => {
+    if (!open) closeModal();
+  }}
+>
+  <Dialog.Content class="max-w-md">
+    <Dialog.Header>
+      <Dialog.Title>{$t('course.navItem.people.grant_access_modal.title')}</Dialog.Title>
+      <Dialog.Description>
+        {$t('course.navItem.people.grant_access_modal.description', { email: studentEmail })}
+      </Dialog.Description>
+    </Dialog.Header>
+
+    {#if $isStudentLimitReached}
+      <UpgradeBanner removeParams={[GRANT_ACCESS_PARAM]}>
+        {$t('course.navItem.people.invite_modal.student_limit_reached')}
+      </UpgradeBanner>
+    {/if}
+
+    <div class="flex justify-end gap-2">
+      <Button type="button" variant="outline" onclick={closeModal} disabled={isSubmitting}>
+        {$t('course.navItem.people.grant_access_modal.cancel')}
+      </Button>
+      <Button
+        type="button"
+        variant="secondary"
+        onclick={handleSendInvite}
+        loading={isSubmitting}
+        disabled={$isStudentLimitReached || !studentEmail}
+      >
+        {$t('course.navItem.people.grant_access_modal.send_invite')}
+      </Button>
+    </div>
+  </Dialog.Content>
+</Dialog.Root>

--- a/apps/dashboard/src/lib/features/course/pages/people.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/people.svelte
@@ -11,6 +11,7 @@
   import * as Avatar from '@cio/ui/base/avatar';
   import { ComingSoon, RoleBasedSecurity, UpgradeBanner } from '$features/ui';
   import InvitationModal from '$features/course/components/people/invitation-modal.svelte';
+  import GrantAccessModal from '$features/course/components/people/grant-access-modal.svelte';
   import DeleteConfirmation from '$features/course/components/people/delete-confirmation.svelte';
   import { isStudentLimitReached } from '$lib/utils/store/org';
 
@@ -101,6 +102,7 @@
 </script>
 
 <InvitationModal />
+<GrantAccessModal />
 
 {#if $isStudentLimitReached}
   <UpgradeBanner className="mb-2">{$t('course.navItem.people.invite_modal.student_limit_reached')}</UpgradeBanner>

--- a/apps/dashboard/src/lib/utils/translations/da.json
+++ b/apps/dashboard/src/lib/utils/translations/da.json
@@ -1199,10 +1199,10 @@
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
           "grant_access_modal": {
-            "title": "Give student access",
-            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
-            "cancel": "Cancel",
-            "send_invite": "Send invite"
+            "title": "Giv studerende adgang",
+            "description": "Giv {email} adgang til dette kursus. Vi sender en invitationsmail, så vedkommende kan tilslutte sig din organisation og tilmelde sig kurset.",
+            "cancel": "Annuller",
+            "send_invite": "Send invitation"
           },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",

--- a/apps/dashboard/src/lib/utils/translations/da.json
+++ b/apps/dashboard/src/lib/utils/translations/da.json
@@ -1202,7 +1202,7 @@
             "title": "Giv studerende adgang",
             "description": "Giv {email} adgang til dette kursus. Vi sender en invitationsmail, så vedkommende kan tilslutte sig din organisation og tilmelde sig kurset.",
             "cancel": "Annuller",
-            "send_invite": "Send invitation"
+            "send_invite": "Send invitationen"
           },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",

--- a/apps/dashboard/src/lib/utils/translations/da.json
+++ b/apps/dashboard/src/lib/utils/translations/da.json
@@ -1198,6 +1198,12 @@
           "no_matching_existing_students": "No organization students match your search.",
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
+          "grant_access_modal": {
+            "title": "Give student access",
+            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
+            "cancel": "Cancel",
+            "send_invite": "Send invite"
+          },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",
           "invite_new_students": "Invite Students",

--- a/apps/dashboard/src/lib/utils/translations/de.json
+++ b/apps/dashboard/src/lib/utils/translations/de.json
@@ -1199,10 +1199,10 @@
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
           "grant_access_modal": {
-            "title": "Give student access",
-            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
-            "cancel": "Cancel",
-            "send_invite": "Send invite"
+            "title": "Schülerzugang gewähren",
+            "description": "Gewähren Sie {email} Zugang zu diesem Kurs. Wir senden eine Einladungs-E-Mail, damit die Person Ihrer Organisation beitreten und in diesem Kurs eingeschrieben werden kann.",
+            "cancel": "Abbrechen",
+            "send_invite": "Einladung senden"
           },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",

--- a/apps/dashboard/src/lib/utils/translations/de.json
+++ b/apps/dashboard/src/lib/utils/translations/de.json
@@ -1198,6 +1198,12 @@
           "no_matching_existing_students": "No organization students match your search.",
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
+          "grant_access_modal": {
+            "title": "Give student access",
+            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
+            "cancel": "Cancel",
+            "send_invite": "Send invite"
+          },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",
           "invite_new_students": "Invite Students",

--- a/apps/dashboard/src/lib/utils/translations/en.json
+++ b/apps/dashboard/src/lib/utils/translations/en.json
@@ -3230,6 +3230,12 @@
           "no_matching_existing_students": "No organization students match your search.",
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
+          "grant_access_modal": {
+            "title": "Give student access",
+            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
+            "cancel": "Cancel",
+            "send_invite": "Send invite"
+          },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",
           "invite_new_students": "Invite Students",

--- a/apps/dashboard/src/lib/utils/translations/es.json
+++ b/apps/dashboard/src/lib/utils/translations/es.json
@@ -1199,10 +1199,10 @@
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
           "grant_access_modal": {
-            "title": "Give student access",
-            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
-            "cancel": "Cancel",
-            "send_invite": "Send invite"
+            "title": "Dar acceso al estudiante",
+            "description": "Da acceso a {email} a este curso. Le enviaremos un correo de invitación para unirse a tu organización e inscribirse en este curso.",
+            "cancel": "Cancelar",
+            "send_invite": "Enviar invitación"
           },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",

--- a/apps/dashboard/src/lib/utils/translations/es.json
+++ b/apps/dashboard/src/lib/utils/translations/es.json
@@ -1198,6 +1198,12 @@
           "no_matching_existing_students": "No organization students match your search.",
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
+          "grant_access_modal": {
+            "title": "Give student access",
+            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
+            "cancel": "Cancel",
+            "send_invite": "Send invite"
+          },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",
           "invite_new_students": "Invite Students",

--- a/apps/dashboard/src/lib/utils/translations/fr.json
+++ b/apps/dashboard/src/lib/utils/translations/fr.json
@@ -1199,10 +1199,10 @@
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
           "grant_access_modal": {
-            "title": "Give student access",
-            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
-            "cancel": "Cancel",
-            "send_invite": "Send invite"
+            "title": "Accorder l'accès à l'étudiant",
+            "description": "Accordez à {email} l'accès à ce cours. Nous lui enverrons un e-mail d'invitation pour rejoindre votre organisation et s'inscrire à ce cours.",
+            "cancel": "Annuler",
+            "send_invite": "Envoyer l'invitation"
           },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",

--- a/apps/dashboard/src/lib/utils/translations/fr.json
+++ b/apps/dashboard/src/lib/utils/translations/fr.json
@@ -1198,6 +1198,12 @@
           "no_matching_existing_students": "No organization students match your search.",
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
+          "grant_access_modal": {
+            "title": "Give student access",
+            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
+            "cancel": "Cancel",
+            "send_invite": "Send invite"
+          },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",
           "invite_new_students": "Invite Students",

--- a/apps/dashboard/src/lib/utils/translations/hi.json
+++ b/apps/dashboard/src/lib/utils/translations/hi.json
@@ -1199,10 +1199,10 @@
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
           "grant_access_modal": {
-            "title": "Give student access",
-            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
-            "cancel": "Cancel",
-            "send_invite": "Send invite"
+            "title": "छात्र को एक्सेस दें",
+            "description": "{email} को इस कोर्स का एक्सेस दें। हम उन्हें आपके संगठन में शामिल होने और इस कोर्स में नामांकन के लिए आमंत्रण ईमेल भेजेंगे।",
+            "cancel": "रद्द करें",
+            "send_invite": "निमंत्रण भेजें"
           },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",

--- a/apps/dashboard/src/lib/utils/translations/hi.json
+++ b/apps/dashboard/src/lib/utils/translations/hi.json
@@ -1198,6 +1198,12 @@
           "no_matching_existing_students": "No organization students match your search.",
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
+          "grant_access_modal": {
+            "title": "Give student access",
+            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
+            "cancel": "Cancel",
+            "send_invite": "Send invite"
+          },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",
           "invite_new_students": "Invite Students",

--- a/apps/dashboard/src/lib/utils/translations/pl.json
+++ b/apps/dashboard/src/lib/utils/translations/pl.json
@@ -1199,10 +1199,10 @@
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
           "grant_access_modal": {
-            "title": "Give student access",
-            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
-            "cancel": "Cancel",
-            "send_invite": "Send invite"
+            "title": "Udostępnij dostęp studentowi",
+            "description": "Przyznaj {email} dostęp do tego kursu. Wyślemy zaproszenie e-mailem, aby dołączył do Twojej organizacji i zapisał się na ten kurs.",
+            "cancel": "Anuluj",
+            "send_invite": "Wyślij zaproszenie"
           },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",

--- a/apps/dashboard/src/lib/utils/translations/pl.json
+++ b/apps/dashboard/src/lib/utils/translations/pl.json
@@ -1198,6 +1198,12 @@
           "no_matching_existing_students": "No organization students match your search.",
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
+          "grant_access_modal": {
+            "title": "Give student access",
+            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
+            "cancel": "Cancel",
+            "send_invite": "Send invite"
+          },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",
           "invite_new_students": "Invite Students",

--- a/apps/dashboard/src/lib/utils/translations/pt.json
+++ b/apps/dashboard/src/lib/utils/translations/pt.json
@@ -1199,10 +1199,10 @@
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
           "grant_access_modal": {
-            "title": "Give student access",
-            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
-            "cancel": "Cancel",
-            "send_invite": "Send invite"
+            "title": "Conceder acesso ao aluno",
+            "description": "Conceda acesso a {email} a este curso. Enviaremos um e-mail de convite para que a pessoa entre na sua organização e se inscreva neste curso.",
+            "cancel": "Cancelar",
+            "send_invite": "Enviar convite"
           },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",

--- a/apps/dashboard/src/lib/utils/translations/pt.json
+++ b/apps/dashboard/src/lib/utils/translations/pt.json
@@ -1198,6 +1198,12 @@
           "no_matching_existing_students": "No organization students match your search.",
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
+          "grant_access_modal": {
+            "title": "Give student access",
+            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
+            "cancel": "Cancel",
+            "send_invite": "Send invite"
+          },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",
           "invite_new_students": "Invite Students",

--- a/apps/dashboard/src/lib/utils/translations/ru.json
+++ b/apps/dashboard/src/lib/utils/translations/ru.json
@@ -1199,10 +1199,10 @@
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
           "grant_access_modal": {
-            "title": "Give student access",
-            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
-            "cancel": "Cancel",
-            "send_invite": "Send invite"
+            "title": "Предоставить доступ студенту",
+            "description": "Предоставьте {email} доступ к этому курсу. Мы отправим приглашение по электронной почте, чтобы присоединиться к вашей организации и записаться на курс.",
+            "cancel": "Отмена",
+            "send_invite": "Отправить приглашение"
           },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",

--- a/apps/dashboard/src/lib/utils/translations/ru.json
+++ b/apps/dashboard/src/lib/utils/translations/ru.json
@@ -1198,6 +1198,12 @@
           "no_matching_existing_students": "No organization students match your search.",
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
+          "grant_access_modal": {
+            "title": "Give student access",
+            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
+            "cancel": "Cancel",
+            "send_invite": "Send invite"
+          },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",
           "invite_new_students": "Invite Students",

--- a/apps/dashboard/src/lib/utils/translations/vi.json
+++ b/apps/dashboard/src/lib/utils/translations/vi.json
@@ -1199,10 +1199,10 @@
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
           "grant_access_modal": {
-            "title": "Give student access",
-            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
-            "cancel": "Cancel",
-            "send_invite": "Send invite"
+            "title": "Cấp quyền truy cập cho học viên",
+            "description": "Cấp cho {email} quyền truy cập khóa học này. Chúng tôi sẽ gửi email mời để tham gia tổ chức của bạn và đăng ký khóa học.",
+            "cancel": "Hủy",
+            "send_invite": "Gửi lời mời"
           },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",

--- a/apps/dashboard/src/lib/utils/translations/vi.json
+++ b/apps/dashboard/src/lib/utils/translations/vi.json
@@ -1198,6 +1198,12 @@
           "no_matching_existing_students": "No organization students match your search.",
           "notify_existing_students": "Send course access email",
           "grant_access": "Grant Access",
+          "grant_access_modal": {
+            "title": "Give student access",
+            "description": "Give {email} access to this course. We'll send them an invite email to join your organization and enroll in this course.",
+            "cancel": "Cancel",
+            "send_invite": "Send invite"
+          },
           "invite_new_students_title": "Invite new students",
           "invite_new_students_description": "Invite new people into your organization and pre-assign them to this course. They will create an account, accept the invite, and get access.",
           "invite_new_students": "Invite Students",

--- a/packages/email/src/emails/teacher-student-buy-request.ts
+++ b/packages/email/src/emails/teacher-student-buy-request.ts
@@ -11,6 +11,8 @@ export const teacherStudentBuyRequestEmail = defineEmail({
     courseName: z.string().min(1),
     studentEmail: z.string().email(),
     studentFullname: z.string().min(1),
+    courseUrl: z.url(),
+    autoEnrollUrl: z.url(),
     branding: ZEmailBranding
   }),
   render: (fields) => {
@@ -22,6 +24,19 @@ export const teacherStudentBuyRequestEmail = defineEmail({
         Name: ${fields.studentFullname}<br />
         Email: ${fields.studentEmail}
       </p>
+      <p style="font-weight: bold; margin-top: 24px;">How to give this student access</p>
+      <ol style="padding-left: 20px; line-height: 1.6;">
+        <li>Open the course: <a href="${fields.courseUrl}">${fields.courseUrl}</a></li>
+        <li>Click <strong>People</strong> on the sidebar</li>
+        <li>Click <strong>Add</strong></li>
+        <li>Under <strong>Invite new students</strong>, enter <strong>${fields.studentEmail}</strong></li>
+        <li>Click <strong>Invite Students</strong></li>
+      </ol>
+      <p style="font-weight: bold; margin-top: 24px;">Or automatically enroll them</p>
+      <p>Use the button below to open the course and send this student an invite in one step.</p>
+      <div>
+        <a class="button" href="${fields.autoEnrollUrl}">Auto Enrol this Student</a>
+      </div>
     `;
 
     return getDefaultTemplate(content, fields.branding);

--- a/packages/email/src/emails/teacher-student-buy-request.ts
+++ b/packages/email/src/emails/teacher-student-buy-request.ts
@@ -35,7 +35,7 @@ export const teacherStudentBuyRequestEmail = defineEmail({
       <p style="font-weight: bold; margin-top: 24px;">Or automatically enroll them</p>
       <p>Use the button below to open the course and send this student an invite in one step.</p>
       <div>
-        <a class="button" href="${fields.autoEnrollUrl}">Auto Enrol this Student</a>
+        <a class="button" href="${fields.autoEnrollUrl}">Auto Enrol Student</a>
       </div>
     `;
 

--- a/packages/email/src/emails/teacher-student-buy-request.ts
+++ b/packages/email/src/emails/teacher-student-buy-request.ts
@@ -35,7 +35,7 @@ export const teacherStudentBuyRequestEmail = defineEmail({
       <p style="font-weight: bold; margin-top: 24px;">Or automatically enroll them</p>
       <p>Use the button below to open the course and send this student an invite in one step.</p>
       <div>
-        <a class="button" href="${fields.autoEnrollUrl}">Auto Enrol Student</a>
+        <a class="button" href="${fields.autoEnrollUrl}">Auto Enroll Student</a>
       </div>
     `;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a student requests to join a paid course, the teacher notification email now includes step-by-step instructions for granting access manually, plus an **Auto Enrol this Student** button.

Clicking the button opens the course People page (with login redirect if needed) and shows a confirmation modal to invite the student by email — the same org audience import flow used by **Invite new students** in the Add people modal.

## Changes

### Email (`teacherStudentBuyRequest`)
- Manual instructions: open course → People → Add → invite email → Invite Students
- **Auto Enrol this Student** CTA linking to `/courses/{courseId}/people?grantAccess={studentEmail}`

### API (`createPaymentRequest`)
- Builds `courseUrl` and `autoEnrollUrl` using `getDashboardBaseUrl` for the org

### Dashboard
- New `grant-access-modal.svelte` on the course People page
- Reads `?grantAccess=` query param, shows modal with Cancel / Send invite
- **Send invite** calls `orgApi.importAudienceMembers` with the student email and refreshes course members

## Test plan

- [ ] Submit a paid course payment request as a student
- [ ] Verify teacher email includes manual steps and Auto Enrol button
- [ ] Click Auto Enrol while logged out → login → land on People page with modal open
- [ ] Click **Send invite** → student receives org invite email with course access
- [ ] Click **Cancel** → modal closes and query param is cleared

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e14eba1e-4236-43c2-875b-99f9f11330b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e14eba1e-4236-43c2-875b-99f9f11330b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an "Auto Enrol" flow for paid course join requests: the teacher notification email now includes step-by-step manual instructions and a CTA linking to `/courses/{id}/people?grantAccess={email}`. A new `grant-access-modal.svelte` reads that query param on the People page and invokes the existing `orgApi.importAudienceMembers` to send the invite.

- **API (`payment-request.ts`)**: Constructs `courseUrl` and `autoEnrollUrl` using `getDashboardBaseUrl` and passes them to the existing `teacherStudentBuyRequest` email template via correctly named local variables.
- **Email template**: Adds inline instructions and a `<a class="button">` CTA; both URLs are Zod-validated (`z.url()`) before being rendered.
- **Dashboard modal**: New `grant-access-modal.svelte` reads the query param reactively, guards on `isStudentLimitReached`, calls `importAudienceMembers`, refreshes the course member list on success, and clears the param via `closeModal`.
- **Translations**: All nine locales include properly localised strings for the new modal keys.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is well-scoped, uses existing validated patterns, and introduces no new error paths.

The API layer correctly builds URLs from database-sourced org data and assigns them to named locals before embedding in the email fields object. Both new URLs are Zod-validated as z.url() before rendering. The modal reads the query param reactively, guards on student-limit state, and delegates error feedback to the existing orgApi.execute snackbar layer. All nine locale files include properly localised strings for the new modal keys. No logic errors or unsafe data handling found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/services/course/payment-request.ts | Adds courseUrl and autoEnrollUrl construction via getDashboardBaseUrl; both are assigned to local variables before use in the email fields object, consistent with code style rules. Clean change. |
| packages/email/src/emails/teacher-student-buy-request.ts | Adds courseUrl and autoEnrollUrl to schema as z.url(), renders manual instructions and Auto Enrol CTA in the email body. Schema validation ensures URLs are well-formed before rendering. |
| apps/dashboard/src/lib/features/course/components/people/grant-access-modal.svelte | New component that reactively reads ?grantAccess= param, shows confirmation dialog, calls importAudienceMembers on confirm, and clears the param on close. Error feedback is delegated to the orgApi execute wrapper's snackbar. Logic is sound. |
| apps/dashboard/src/lib/features/course/pages/people.svelte | Adds GrantAccessModal component alongside the existing InvitationModal; minimal, clean integration. |
| apps/dashboard/src/lib/utils/translations/en.json | Adds grant_access_modal keys (title, description, cancel, send_invite) in English; keys are consistent across all locale files. |
| apps/dashboard/src/lib/utils/translations/da.json | Adds grant_access_modal translations in Danish; all four new string values use Danish vocabulary. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Student
    participant API as API (payment-request.ts)
    participant Email as Email (teacherStudentBuyRequest)
    participant Teacher
    participant Dashboard as Dashboard (people.svelte)
    participant Modal as GrantAccessModal
    participant OrgAPI as orgApi.importAudienceMembers

    Student->>API: "POST /payment-request {courseId, studentEmail}"
    API->>API: getCourseWithOrgData(courseId)
    API->>API: getDashboardBaseUrl(org) → courseUrl, autoEnrollUrl
    API->>Email: enqueueTransactionalEmail(teacherStudentBuyRequest)
    Email->>Teacher: Email with manual steps + Auto Enrol button (autoEnrollUrl)
    Teacher->>Dashboard: "Click Auto Enrol → /courses/{id}/people?grantAccess={email}"
    Dashboard->>Modal: "Mount GrantAccessModal (isOpen=true because grantAccess param set)"
    Teacher->>Modal: Click Send Invite
    Modal->>OrgAPI: "importAudienceMembers({recipientCsv: email, courseIds: [id]})"
    OrgAPI-->>Modal: response
    Modal->>Dashboard: courseApi.refreshCourse()
    Modal->>Dashboard: closeModal() — removes grantAccess param via goto()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Student
    participant API as API (payment-request.ts)
    participant Email as Email (teacherStudentBuyRequest)
    participant Teacher
    participant Dashboard as Dashboard (people.svelte)
    participant Modal as GrantAccessModal
    participant OrgAPI as orgApi.importAudienceMembers

    Student->>API: "POST /payment-request {courseId, studentEmail}"
    API->>API: getCourseWithOrgData(courseId)
    API->>API: getDashboardBaseUrl(org) → courseUrl, autoEnrollUrl
    API->>Email: enqueueTransactionalEmail(teacherStudentBuyRequest)
    Email->>Teacher: Email with manual steps + Auto Enrol button (autoEnrollUrl)
    Teacher->>Dashboard: "Click Auto Enrol → /courses/{id}/people?grantAccess={email}"
    Dashboard->>Modal: "Mount GrantAccessModal (isOpen=true because grantAccess param set)"
    Teacher->>Modal: Click Send Invite
    Modal->>OrgAPI: "importAudienceMembers({recipientCsv: email, courseIds: [id]})"
    OrgAPI-->>Modal: response
    Modal->>Dashboard: courseApi.refreshCourse()
    Modal->>Dashboard: closeModal() — removes grantAccess param via goto()
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(i18n): localize Danish grant-access ..."](https://github.com/classroomio/classroomio/commit/437cf68f0eba1a4c2efdcae8d5f3baa0b6814225) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45429751)</sub>

**Context used:**

- Rule used - When reviewing changes to translation files (e.g.,... ([source](https://app.greptile.com/classroomio/github/classroomio/classroomio/-/custom-context?memory=bb9d3cef-509f-4814-9e69-d82ecdd91bf9))

<!-- /greptile_comment -->