### PR TITLE
fix(api): use admin app URL for teacher auto-enroll email links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,7 +442,8 @@ Rule of thumb: if the recipient is being addressed **as a ClassroomIO customer**
 
 ### Email link URLs
 
-Links embedded in transactional emails must use the correct dashboard host:
+Links embedded in transactional emails must use the correct dashboard host. Templates only receive pre-built URLs — callers build them in API services before `enqueueTransactionalEmail`. See `packages/email/README.md` § Email link URLs.
+
 
 - **Teacher/tutor/admin dashboard actions** (course management, grading, team invites, auto-enroll): build URLs with `getAppBaseUrl()` from `@cio/core/config/dashboard-url`. This resolves to the admin app (`app.classroomio.com` in cloud, or `DASHBOARD_ORIGIN` / localhost in dev). Do **not** pass org `customDomain` or tenant `siteName` — staff sign in on the admin app, not the org public site.
 - **Student/learner-facing links** (course enroll, org audience invites, login): build URLs with `getDashboardBaseUrl(org)` so links land on the org's public site (verified custom domain, tenant subdomain, or platform fallback).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,6 +440,13 @@ Every transactional email in `packages/email/src/emails` is one of two kinds —
 
 Rule of thumb: if the recipient is being addressed **as a ClassroomIO customer** (account/billing/limits), it's a system email → ClassroomIO branding. If they're addressed **as a member of a specific org**, it's org-branded.
 
+### Email link URLs
+
+Links embedded in transactional emails must use the correct dashboard host:
+
+- **Teacher/tutor/admin dashboard actions** (course management, grading, team invites, auto-enroll): build URLs with `getAppBaseUrl()` from `@cio/core/config/dashboard-url`. This resolves to the admin app (`app.classroomio.com` in cloud, or `DASHBOARD_ORIGIN` / localhost in dev). Do **not** pass org `customDomain` or tenant `siteName` — staff sign in on the admin app, not the org public site.
+- **Student/learner-facing links** (course enroll, org audience invites, login): build URLs with `getDashboardBaseUrl(org)` so links land on the org's public site (verified custom domain, tenant subdomain, or platform fallback).
+
 ## Best Practices Summary
 
 ### ✅ DO

--- a/apps/api/src/services/course/payment-request.ts
+++ b/apps/api/src/services/course/payment-request.ts
@@ -5,7 +5,7 @@ import { getCourseWithOrgData } from '@cio/db/queries/course';
 import { buildEmailFromName, buildEmailBranding } from '@cio/email';
 import { enqueueTransactionalEmail } from '@api/services/jobs';
 import { trackServerEvent, SERVER_EVENTS } from '@cio/analytics';
-import { getDashboardBaseUrl } from '@cio/core/config/dashboard-url';
+import { getAppBaseUrl } from '@cio/core/config/dashboard-url';
 
 export interface PaymentRequestData {
   courseId: string;
@@ -48,14 +48,9 @@ export async function createPaymentRequest(data: PaymentRequestData) {
 
     const teacherEmail = teacherResult[0].email;
 
-    const dashboardOrg = {
-      siteName: course.orgSiteName,
-      customDomain: course.orgCustomDomain,
-      isCustomDomainVerified: course.orgIsCustomDomainVerified
-    };
-    const dashboardBaseUrl = getDashboardBaseUrl(dashboardOrg);
-    const courseUrl = `${dashboardBaseUrl}/courses/${data.courseId}`;
-    const autoEnrollUrl = `${dashboardBaseUrl}/courses/${data.courseId}/people?grantAccess=${encodeURIComponent(data.studentEmail)}`;
+    const appBaseUrl = getAppBaseUrl();
+    const courseUrl = `${appBaseUrl}/courses/${data.courseId}`;
+    const autoEnrollUrl = `${appBaseUrl}/courses/${data.courseId}/people?grantAccess=${encodeURIComponent(data.studentEmail)}`;
 
     try {
       await enqueueTransactionalEmail('teacherStudentBuyRequest', {

--- a/apps/api/src/services/jobs/email-jobs.ts
+++ b/apps/api/src/services/jobs/email-jobs.ts
@@ -59,6 +59,11 @@ function recipientKey(base: string | undefined, recipient: string, total: number
  * against the template's Zod schema up front so bad payloads fail in the
  * domain handler instead of silently inside the worker.
  *
+ * **Link fields** (`courseUrl`, `autoEnrollUrl`, `loginUrl`, `inviteUrl`, etc.)
+ * must be built by the caller before enqueueing. Use `getAppBaseUrl()` for
+ * teacher/tutor/admin dashboard links and `getDashboardBaseUrl(org)` for
+ * student/learner links — see `packages/email/README.md` § Email link URLs.
+ *
  * BullMQ tracks send state, retries, and failure history — no DB ledger is
  * written. Final failures are recorded in `dead_letter_job` by the worker
  * for operator triage.

--- a/packages/core/src/config/dashboard-url.ts
+++ b/packages/core/src/config/dashboard-url.ts
@@ -3,6 +3,21 @@ import { TENANT_ROOT_DOMAIN, BRAND_ROOT_DOMAIN } from '@cio/utils/constants/doma
 import { env } from './env';
 
 /**
+ * Dashboard host helpers for links embedded in emails and other outbound URLs.
+ *
+ * Email templates only receive pre-built URLs in their `fields` — callers in
+ * `apps/api` (or other services) choose the host here before enqueueing mail.
+ *
+ * - **Student/learner links** (course enroll, audience invites, login):
+ *   `getDashboardBaseUrl(org)` — org custom domain, tenant subdomain, or fallback.
+ * - **Teacher/tutor/admin dashboard actions** (course management, grading, team
+ *   invites, auto-enroll): `getAppBaseUrl()` — admin app (`app.classroomio.com`
+ *   in cloud). Do not pass org `customDomain` or tenant `siteName`.
+ *
+ * See `packages/email/README.md` and `AGENTS.md` § Email link URLs.
+ */
+
+/**
  * Minimal org shape consumed by `getDashboardBaseUrl`. Accepts the three
  * fields that decide which host the org's URLs live on. All optional so
  * callers without an org context can still ask for a sensible default.
@@ -14,8 +29,10 @@ export type DashboardOrg = {
 };
 
 /**
- * Returns the base URL for the dashboard app, used for invite links, login
- * URLs, course URLs, and email-embedded links.
+ * Returns the learner-facing dashboard base URL for an org.
+ *
+ * Use for **student/learner email links** (course enroll, audience invites,
+ * login) so links land on the org's public site.
  *
  * Resolution order (highest precedence first):
  *  1. Org's verified `customDomain`  → `https://<customDomain>`
@@ -26,6 +43,8 @@ export type DashboardOrg = {
  *
  * `customDomain` wins over `DASHBOARD_ORIGIN` because per-org BYOD must
  * override the platform-wide self-hosted dashboard host for that org's URLs.
+ *
+ * For teacher/tutor/admin dashboard actions in email, use `getAppBaseUrl()`.
  */
 export function getDashboardBaseUrl(org?: DashboardOrg): string {
   if (org?.customDomain && org.isCustomDomainVerified) {
@@ -49,7 +68,12 @@ export function getDashboardBaseUrl(org?: DashboardOrg): string {
 
 /**
  * Returns the admin dashboard origin (`app.classroomio.com` in cloud).
- * Use for team-member invite links (admin/tutor) — not student-facing URLs.
+ *
+ * Use for **teacher/tutor/admin email links** — course management, grading,
+ * team invites, auto-enroll, and any other staff dashboard action. Staff sign
+ * in on the admin app, not the org public site.
+ *
+ * Do not use for student/learner-facing links; use `getDashboardBaseUrl(org)`.
  */
 export function getAppBaseUrl(): string {
   return getDashboardBaseUrl();

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -46,6 +46,29 @@ await send('forgotPassword', {
 });
 ```
 
+## Email link URLs
+
+Email templates receive fully-built URLs in their `fields` — templates do **not** choose the host. Callers in `apps/api` (or other services) must build links before calling `enqueueTransactionalEmail` or `send`.
+
+Import helpers from `@cio/core/config/dashboard-url`:
+
+| Recipient | Helper | Use for |
+| --- | --- | --- |
+| Teacher, tutor, admin | `getAppBaseUrl()` | Course management, grading, team invites, auto-enroll |
+| Student, learner | `getDashboardBaseUrl(org)` | Course enroll, audience invites, login |
+
+```typescript
+import { getAppBaseUrl, getDashboardBaseUrl } from '@cio/core/config/dashboard-url';
+
+// Staff dashboard action (admin app — not org custom domain)
+const autoEnrollUrl = `${getAppBaseUrl()}/courses/${courseId}/people?grantAccess=${encodeURIComponent(email)}`;
+
+// Learner-facing invite (org public site)
+const inviteUrl = `${getDashboardBaseUrl(org)}/invite/${encodeURIComponent(token)}`;
+```
+
+See also `AGENTS.md` § Email link URLs.
+
 ## Creating Email Templates
 
 ### Basic Example


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes teacher auto-enroll email links to use the admin app (`app.classroomio.com`) instead of the org's custom/tenant domain, and documents the staff vs learner URL rule where developers actually wire emails.

## Changes

- **`payment-request.ts`**: Use `getAppBaseUrl()` for `courseUrl` and `autoEnrollUrl` in teacher buy-request emails
- **`dashboard-url.ts`**: Module-level docs + corrected JSDoc on `getDashboardBaseUrl` / `getAppBaseUrl` (previously claimed all email links use `getDashboardBaseUrl`)
- **`packages/email/README.md`**: New "Email link URLs" section with table and examples (callers build URLs before enqueueing)
- **`email-jobs.ts`**: JSDoc on `enqueueTransactionalEmail` pointing to the URL rules
- **`AGENTS.md`**: Cross-reference to email README

## Verification

- `pnpm --filter @cio/api^... build && pnpm --filter @cio/api build`
- `pnpm format:check`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e14eba1e-4236-43c2-875b-99f9f11330b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e14eba1e-4236-43c2-875b-99f9f11330b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where teacher auto-enroll and course management links in `payment-request.ts` were built using the org's learner-facing URL (custom domain / tenant subdomain) instead of the admin app (`app.classroomio.com`). It also adds consistent documentation across four locations — `dashboard-url.ts`, `email-jobs.ts`, `packages/email/README.md`, and `AGENTS.md` — establishing the staff-vs-learner URL rule for future callers.

- **`payment-request.ts`**: Swaps `getDashboardBaseUrl(dashboardOrg)` for `getAppBaseUrl()` and removes the now-unused intermediate `dashboardOrg` object; teachers receive links that land on the admin dashboard rather than the org's public site.
- **Documentation**: Module-level and per-function JSDoc on `dashboard-url.ts`, a `enqueueTransactionalEmail` JSDoc note, a new README table with examples, and an `AGENTS.md` subsection all reinforce the same rule at every point a developer touches email link construction.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted one-function swap in a single service file, with the rest of the diff being documentation only.

The core fix is straightforward: getAppBaseUrl() is a well-tested alias for getDashboardBaseUrl() called with no org, which resolves to app.classroomio.com in cloud production and DASHBOARD_ORIGIN / localhost in self-hosted / development — exactly the right host for teacher-facing admin links. The removed dashboardOrg intermediate was the only path by which a custom domain or tenant subdomain could contaminate a staff email link. No logic was changed in the four documentation files.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/services/course/payment-request.ts | Replaces getDashboardBaseUrl(dashboardOrg) with getAppBaseUrl() for courseUrl and autoEnrollUrl, correctly routing teacher-facing links to the admin app instead of the org's learner-facing custom/tenant domain; also removes the now-unused dashboardOrg intermediate object. |
| packages/core/src/config/dashboard-url.ts | Documentation-only change: adds a module-level JSDoc block and improves per-function JSDoc to clarify when to use getDashboardBaseUrl (learner links) vs getAppBaseUrl (staff/admin links). No logic changes. |
| apps/api/src/services/jobs/email-jobs.ts | Documentation-only change: adds a JSDoc note on enqueueTransactionalEmail directing callers to use the correct URL helper for link fields. No logic changes. |
| packages/email/README.md | Adds a new 'Email link URLs' section with a reference table and code examples documenting the getAppBaseUrl vs getDashboardBaseUrl rule for email callers. |
| AGENTS.md | Adds an 'Email link URLs' subsection cross-referencing the README rule and spelling out the staff-vs-learner URL choice at the point where developers wire emails. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Student
    participant API as apps/api payment-request.ts
    participant URLHelper as dashboard-url.ts
    participant Queue as BullMQ / email-jobs.ts
    participant Teacher

    Student->>API: POST /payment-request (courseId, studentEmail)
    API->>API: getCourseWithOrgData(courseId)
    API->>API: getCourseTeachers(groupId)
    Note over API,URLHelper: Before fix: getDashboardBaseUrl(org) → org custom domain
    API->>URLHelper: getAppBaseUrl()
    URLHelper-->>API: https://app.classroomio.com (admin app)
    API->>API: "build courseUrl & autoEnrollUrl with admin base"
    API->>Queue: "enqueueTransactionalEmail(teacherStudentBuyRequest, { courseUrl, autoEnrollUrl })"
    Queue-->>Teacher: Email with admin-app links ✓
    API->>Queue: "enqueueTransactionalEmail(studentProvePayment, { … })"
    Queue-->>Student: Confirmation email
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Student
    participant API as apps/api payment-request.ts
    participant URLHelper as dashboard-url.ts
    participant Queue as BullMQ / email-jobs.ts
    participant Teacher

    Student->>API: POST /payment-request (courseId, studentEmail)
    API->>API: getCourseWithOrgData(courseId)
    API->>API: getCourseTeachers(groupId)
    Note over API,URLHelper: Before fix: getDashboardBaseUrl(org) → org custom domain
    API->>URLHelper: getAppBaseUrl()
    URLHelper-->>API: https://app.classroomio.com (admin app)
    API->>API: "build courseUrl & autoEnrollUrl with admin base"
    API->>Queue: "enqueueTransactionalEmail(teacherStudentBuyRequest, { courseUrl, autoEnrollUrl })"
    Queue-->>Teacher: Email with admin-app links ✓
    API->>Queue: "enqueueTransactionalEmail(studentProvePayment, { … })"
    Queue-->>Student: Confirmation email
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: surface email link URL rules where..."](https://github.com/classroomio/classroomio/commit/b6b8e42443e8436021784c88267a389ec257fd17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45438209)</sub>

<!-- /greptile_comment -->