### PR TITLE
fix(dashboard): stop ERR_CONTENT_DECODING_FAILED on auth/proxy

### DIFF
--- a/apps/dashboard/src/lib/utils/csp-domains.js
+++ b/apps/dashboard/src/lib/utils/csp-domains.js
@@ -7,6 +7,7 @@ const saasDefaults = {
     'https://assets.cdn.clsrio.com',
     'https://embed.classroomio.com',
     'https://cdnjs.cloudflare.com',
+    'https://cdn.userjot.com',
     'https://*.posthog.com',
     'https://*.senja.io',
     'https://umami.hz.oncws.com',

--- a/apps/dashboard/src/lib/utils/csp.test.ts
+++ b/apps/dashboard/src/lib/utils/csp.test.ts
@@ -1,0 +1,22 @@
+import { parseCspDomains } from './csp';
+
+describe('parseCspDomains', () => {
+  it('returns an empty list for missing or blank input', () => {
+    expect(parseCspDomains(undefined)).toEqual([]);
+    expect(parseCspDomains('')).toEqual([]);
+    expect(parseCspDomains('   ')).toEqual([]);
+    expect(parseCspDomains(', ,')).toEqual([]);
+  });
+
+  it('preserves special CSP source tokens and quoted self', () => {
+    expect(parseCspDomains("data:, blob:, self, 'self'")).toEqual(['data:', 'blob:', "'self'", "'self'"]);
+  });
+
+  it('keeps explicit http(s) URLs and prefixes bare domains', () => {
+    expect(parseCspDomains(' https://cdn.example.com , http://localhost:9000 , fonts.gstatic.com ')).toEqual([
+      'https://cdn.example.com',
+      'http://localhost:9000',
+      'https://fonts.gstatic.com'
+    ]);
+  });
+});

--- a/apps/dashboard/src/lib/utils/csp.ts
+++ b/apps/dashboard/src/lib/utils/csp.ts
@@ -4,7 +4,20 @@ function parseCspDomains(value: string | undefined): string[] {
     .split(',')
     .map((d) => d.trim())
     .filter(Boolean)
-    .map((d) => (d.startsWith('http://') || d.startsWith('https://') ? d : `https://${d}`));
+    .map((d) => {
+      if (
+        d === 'data:' ||
+        d === 'blob:' ||
+        d === "'self'" ||
+        d === 'self' ||
+        d.startsWith('http://') ||
+        d.startsWith('https://')
+      ) {
+        return d === 'self' ? "'self'" : d;
+      }
+
+      return `https://${d}`;
+    });
 }
 
 function buildCspExtensions(): Record<string, string[]> {

--- a/apps/dashboard/src/lib/utils/csp.ts
+++ b/apps/dashboard/src/lib/utils/csp.ts
@@ -1,22 +1,24 @@
-function parseCspDomains(value: string | undefined): string[] {
+/** Normalize a comma-separated CSP domain/env list into valid CSP source values. */
+export function parseCspDomains(value: string | undefined): string[] {
   if (!value) return [];
+
   return value
     .split(',')
-    .map((d) => d.trim())
+    .map((domain) => domain.trim())
     .filter(Boolean)
-    .map((d) => {
+    .map((domain) => {
       if (
-        d === 'data:' ||
-        d === 'blob:' ||
-        d === "'self'" ||
-        d === 'self' ||
-        d.startsWith('http://') ||
-        d.startsWith('https://')
+        domain === 'data:' ||
+        domain === 'blob:' ||
+        domain === "'self'" ||
+        domain === 'self' ||
+        domain.startsWith('http://') ||
+        domain.startsWith('https://')
       ) {
-        return d === 'self' ? "'self'" : d;
+        return domain === 'self' ? "'self'" : domain;
       }
 
-      return `https://${d}`;
+      return `https://${domain}`;
     });
 }
 

--- a/apps/dashboard/src/lib/utils/proxy-api-request.test.ts
+++ b/apps/dashboard/src/lib/utils/proxy-api-request.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { buildProxiedApiResponse, proxyRequestToApi, shouldForwardToApi } from './proxy-api-request';
+
+describe('shouldForwardToApi', () => {
+  it('forwards /proxy and /api/auth paths', () => {
+    expect(shouldForwardToApi('/proxy')).toBe(true);
+    expect(shouldForwardToApi('/proxy/account')).toBe(true);
+    expect(shouldForwardToApi('/api/auth')).toBe(true);
+    expect(shouldForwardToApi('/api/auth/get-session')).toBe(true);
+  });
+
+  it('does not forward unrelated paths', () => {
+    expect(shouldForwardToApi('/login')).toBe(false);
+    expect(shouldForwardToApi('/api/csp-report')).toBe(false);
+  });
+});
+
+describe('buildProxiedApiResponse', () => {
+  it('strips content-encoding and content-length so the browser does not re-decode', async () => {
+    const upstream = new Response('{"user":null}', {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        'content-encoding': 'gzip',
+        'content-length': '13',
+        'transfer-encoding': 'chunked',
+        'set-cookie': 'session=abc; Path=/'
+      }
+    });
+
+    const proxied = buildProxiedApiResponse(upstream);
+
+    expect(proxied.status).toBe(200);
+    expect(proxied.headers.get('content-type')).toBe('application/json');
+    expect(proxied.headers.get('set-cookie')).toBe('session=abc; Path=/');
+    expect(proxied.headers.get('content-encoding')).toBeNull();
+    expect(proxied.headers.get('content-length')).toBeNull();
+    expect(proxied.headers.get('transfer-encoding')).toBeNull();
+    expect(await proxied.text()).toBe('{"user":null}');
+  });
+});
+
+describe('proxyRequestToApi', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('returns 502 when PRIVATE_SERVER_URL is missing', async () => {
+    vi.stubEnv('PRIVATE_SERVER_URL', '');
+
+    const response = await proxyRequestToApi(new Request('https://app.example/api/auth/get-session'));
+
+    expect(response.status).toBe(502);
+    expect(await response.text()).toBe('API upstream not configured');
+  });
+
+  it('requests identity encoding and returns a stripped response', async () => {
+    vi.stubEnv('PRIVATE_SERVER_URL', 'http://api.internal:3081');
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"session":null}', {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          'content-encoding': 'gzip',
+          'content-length': '16'
+        }
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await proxyRequestToApi(
+      new Request('https://dashboard.example/api/auth/get-session', {
+        headers: {
+          accept: 'application/json',
+          'accept-encoding': 'gzip, deflate, br',
+          cookie: 'better-auth.session_token=test'
+        }
+      })
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [upstreamUrl, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(String(upstreamUrl)).toBe('http://api.internal:3081/api/auth/get-session');
+    expect(init.method).toBe('GET');
+
+    const upstreamHeaders = new Headers(init.headers);
+    expect(upstreamHeaders.get('accept-encoding')).toBe('identity');
+    expect(upstreamHeaders.get('host')).toBe('api.internal:3081');
+    expect(upstreamHeaders.get('x-forwarded-host')).toBe('dashboard.example');
+    expect(upstreamHeaders.get('cookie')).toBe('better-auth.session_token=test');
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-encoding')).toBeNull();
+    expect(response.headers.get('content-length')).toBeNull();
+    expect(await response.text()).toBe('{"session":null}');
+  });
+});

--- a/apps/dashboard/src/lib/utils/proxy-api-request.test.ts
+++ b/apps/dashboard/src/lib/utils/proxy-api-request.test.ts
@@ -1,5 +1,3 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-
 import { buildProxiedApiResponse, proxyRequestToApi, shouldForwardToApi } from './proxy-api-request';
 
 describe('shouldForwardToApi', () => {
@@ -24,8 +22,7 @@ describe('buildProxiedApiResponse', () => {
         'content-type': 'application/json',
         'content-encoding': 'gzip',
         'content-length': '13',
-        'transfer-encoding': 'chunked',
-        'set-cookie': 'session=abc; Path=/'
+        'transfer-encoding': 'chunked'
       }
     });
 
@@ -33,23 +30,59 @@ describe('buildProxiedApiResponse', () => {
 
     expect(proxied.status).toBe(200);
     expect(proxied.headers.get('content-type')).toBe('application/json');
-    expect(proxied.headers.get('set-cookie')).toBe('session=abc; Path=/');
     expect(proxied.headers.get('content-encoding')).toBeNull();
     expect(proxied.headers.get('content-length')).toBeNull();
     expect(proxied.headers.get('transfer-encoding')).toBeNull();
     expect(await proxied.text()).toBe('{"user":null}');
   });
+
+  it('preserves multiple Set-Cookie headers without collapsing Expires commas', async () => {
+    const upstreamHeaders = new Headers({
+      'content-type': 'application/json',
+      'content-encoding': 'gzip'
+    });
+    upstreamHeaders.append(
+      'set-cookie',
+      'better-auth.session_token=abc; Path=/; HttpOnly; Expires=Wed, 21 Oct 2026 07:28:00 GMT'
+    );
+    upstreamHeaders.append(
+      'set-cookie',
+      'better-auth.csrf_token=xyz; Path=/; HttpOnly; Expires=Thu, 22 Oct 2026 07:28:00 GMT'
+    );
+
+    const proxied = buildProxiedApiResponse(
+      new Response('{"ok":true}', {
+        status: 200,
+        headers: upstreamHeaders
+      })
+    );
+
+    expect(proxied.headers.getSetCookie()).toEqual([
+      'better-auth.session_token=abc; Path=/; HttpOnly; Expires=Wed, 21 Oct 2026 07:28:00 GMT',
+      'better-auth.csrf_token=xyz; Path=/; HttpOnly; Expires=Thu, 22 Oct 2026 07:28:00 GMT'
+    ]);
+    expect(proxied.headers.get('content-encoding')).toBeNull();
+    expect(await proxied.text()).toBe('{"ok":true}');
+  });
 });
 
 describe('proxyRequestToApi', () => {
+  const originalPrivateServerUrl = process.env.PRIVATE_SERVER_URL;
+  const originalFetch = global.fetch;
+
   afterEach(() => {
-    vi.unstubAllGlobals();
-    vi.unstubAllEnvs();
-    vi.restoreAllMocks();
+    if (originalPrivateServerUrl === undefined) {
+      delete process.env.PRIVATE_SERVER_URL;
+    } else {
+      process.env.PRIVATE_SERVER_URL = originalPrivateServerUrl;
+    }
+
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
   });
 
   it('returns 502 when PRIVATE_SERVER_URL is missing', async () => {
-    vi.stubEnv('PRIVATE_SERVER_URL', '');
+    delete process.env.PRIVATE_SERVER_URL;
 
     const response = await proxyRequestToApi(new Request('https://app.example/api/auth/get-session'));
 
@@ -58,9 +91,9 @@ describe('proxyRequestToApi', () => {
   });
 
   it('requests identity encoding and returns a stripped response', async () => {
-    vi.stubEnv('PRIVATE_SERVER_URL', 'http://api.internal:3081');
+    process.env.PRIVATE_SERVER_URL = 'http://api.internal:3081';
 
-    const fetchMock = vi.fn().mockResolvedValue(
+    const fetchMock = jest.fn().mockResolvedValue(
       new Response('{"session":null}', {
         status: 200,
         headers: {
@@ -70,7 +103,7 @@ describe('proxyRequestToApi', () => {
         }
       })
     );
-    vi.stubGlobal('fetch', fetchMock);
+    global.fetch = fetchMock as typeof fetch;
 
     const response = await proxyRequestToApi(
       new Request('https://dashboard.example/api/auth/get-session', {
@@ -82,7 +115,7 @@ describe('proxyRequestToApi', () => {
       })
     );
 
-    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     const [upstreamUrl, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
     expect(String(upstreamUrl)).toBe('http://api.internal:3081/api/auth/get-session');
     expect(init.method).toBe('GET');

--- a/apps/dashboard/src/lib/utils/proxy-api-request.ts
+++ b/apps/dashboard/src/lib/utils/proxy-api-request.ts
@@ -10,6 +10,9 @@
 const PROXY_PREFIX = '/proxy';
 const AUTH_PREFIX = '/api/auth';
 
+/** Hop-by-hop / encoding headers that must not be forwarded after Node fetch decompresses. */
+const RESPONSE_HEADERS_TO_STRIP = ['content-encoding', 'content-length', 'transfer-encoding'] as const;
+
 export function shouldForwardToApi(pathname: string): boolean {
   return (
     pathname === PROXY_PREFIX ||
@@ -57,6 +60,28 @@ function resolveBrowserForwardedHost(request: Request, url: URL): string {
   return raw;
 }
 
+/**
+ * Node's `fetch` always decompresses gzip/br bodies while often leaving
+ * `Content-Encoding` on the Response. Returning that Response to the browser
+ * (adapter-node) causes `net::ERR_CONTENT_DECODING_FAILED` on auth/proxy calls.
+ *
+ * Ask the upstream for an identity body and strip encoding length headers so
+ * the client receives a plain payload that matches the headers.
+ */
+export function buildProxiedApiResponse(upstream: Response): Response {
+  const headers = new Headers(upstream.headers);
+
+  for (const headerName of RESPONSE_HEADERS_TO_STRIP) {
+    headers.delete(headerName);
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers
+  });
+}
+
 export async function proxyRequestToApi(request: Request): Promise<Response> {
   const url = new URL(request.url);
   const apiBase = resolveApiUpstreamBase();
@@ -74,6 +99,9 @@ export async function proxyRequestToApi(request: Request): Promise<Response> {
   upstreamHeaders.set('host', upstreamUrl.host);
   upstreamHeaders.set('x-forwarded-host', originalHost);
   upstreamHeaders.set('x-forwarded-proto', url.protocol.replace(':', ''));
+  // Prevent compressed upstream responses: Node decompresses automatically but
+  // can leave Content-Encoding set, which breaks the browser.
+  upstreamHeaders.set('accept-encoding', 'identity');
 
   const forwardedFor = request.headers.get('cf-connecting-ip') ?? request.headers.get('x-forwarded-for');
   if (forwardedFor) {
@@ -90,5 +118,7 @@ export async function proxyRequestToApi(request: Request): Promise<Response> {
     init.body = await request.arrayBuffer();
   }
 
-  return fetch(upstreamUrl, init);
+  const upstreamResponse = await fetch(upstreamUrl, init);
+
+  return buildProxiedApiResponse(upstreamResponse);
 }

--- a/apps/dashboard/src/lib/utils/proxy-api-request.ts
+++ b/apps/dashboard/src/lib/utils/proxy-api-request.ts
@@ -60,6 +60,10 @@ function resolveBrowserForwardedHost(request: Request, url: URL): string {
   return raw;
 }
 
+function isStrippedResponseHeader(name: string): boolean {
+  return (RESPONSE_HEADERS_TO_STRIP as readonly string[]).includes(name);
+}
+
 /**
  * Node's `fetch` always decompresses gzip/br bodies while often leaving
  * `Content-Encoding` on the Response. Returning that Response to the browser
@@ -67,12 +71,30 @@ function resolveBrowserForwardedHost(request: Request, url: URL): string {
  *
  * Ask the upstream for an identity body and strip encoding length headers so
  * the client receives a plain payload that matches the headers.
+ *
+ * Set-Cookie must be copied via `getSetCookie()` + `append` — never through
+ * `Headers.get('set-cookie')` / a naive `new Headers(upstream.headers)` path
+ * that can collapse multiple cookies into one comma-joined value (Expires
+ * attributes contain commas, so browsers may drop session/CSRF cookies).
  */
 export function buildProxiedApiResponse(upstream: Response): Response {
-  const headers = new Headers(upstream.headers);
+  const headers = new Headers();
 
-  for (const headerName of RESPONSE_HEADERS_TO_STRIP) {
-    headers.delete(headerName);
+  for (const [name, value] of upstream.headers.entries()) {
+    if (name === 'set-cookie' || isStrippedResponseHeader(name)) {
+      continue;
+    }
+
+    headers.set(name, value);
+  }
+
+  const setCookies =
+    typeof upstream.headers.getSetCookie === 'function'
+      ? upstream.headers.getSetCookie()
+      : [...upstream.headers.entries()].filter(([name]) => name === 'set-cookie').map(([, value]) => value);
+
+  for (const cookie of setCookies) {
+    headers.append('set-cookie', cookie);
   }
 
   return new Response(upstream.body, {

--- a/apps/dashboard/src/lib/utils/services/userjot/index.ts
+++ b/apps/dashboard/src/lib/utils/services/userjot/index.ts
@@ -1,4 +1,5 @@
 import { dev } from '$app/environment';
+import { PUBLIC_IS_SELFHOSTED } from '$env/static/public';
 import { get } from 'svelte/store';
 import { globalStore } from '$lib/utils/store/app';
 
@@ -8,6 +9,7 @@ let isInitialized = false;
 
 function isWidgetAllowed(): boolean {
   if (dev) return false;
+  if (PUBLIC_IS_SELFHOSTED === 'true') return false;
   if (get(globalStore).isOrgSite) return false;
 
   return true;
@@ -30,7 +32,9 @@ function ensureSdkLoaded(): void {
   script.type = 'module';
   script.async = true;
   script.src = 'https://cdn.userjot.com/sdk/v2/uj.js';
-  const nonce = document.querySelector('script[nonce]')?.getAttribute('nonce');
+  // Browsers hide the nonce attribute in the DOM; read via the IDL property.
+  const nonceSource = document.querySelector('script[nonce]') as HTMLScriptElement | null;
+  const nonce = nonceSource?.nonce || nonceSource?.getAttribute('nonce');
   if (nonce) script.setAttribute('nonce', nonce);
   document.head.appendChild(script);
 }

--- a/apps/dashboard/svelte.config.js
+++ b/apps/dashboard/svelte.config.js
@@ -38,7 +38,8 @@ const config = {
         'script-src': ['self', ...csp.scriptSrc, 'unsafe-hashes', 'unsafe-eval'],
         'style-src': ['self', 'unsafe-inline', ...csp.styleSrc],
         'style-src-elem': ['self', 'unsafe-inline', ...csp.styleSrc],
-        'font-src': ['self', ...csp.fontSrc],
+        // data: covers inlined woff2 (e.g. PDF.js / icon fonts); file fonts use 'self'
+        'font-src': ['self', 'data:', ...csp.fontSrc],
         'img-src': ['self', 'data:', ...csp.mediaSrc, 'blob:', 'http://localhost:9000'],
         'media-src': [
           'self',
@@ -70,7 +71,7 @@ const config = {
         'script-src': ['self', ...csp.scriptSrc, 'unsafe-hashes', 'unsafe-eval'],
         'style-src': ['self', 'unsafe-inline', ...csp.styleSrc],
         'style-src-elem': ['self', 'unsafe-inline', ...csp.styleSrc],
-        'font-src': ['self', ...csp.fontSrc],
+        'font-src': ['self', 'data:', ...csp.fontSrc],
         'img-src': ['self', 'data:', ...csp.mediaSrc, 'blob:', 'http://localhost:9000'],
         'media-src': [
           'self',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes self-hosted dashboard auth/proxy failures where the browser reports:

`GET /api/auth/get-session net::ERR_CONTENT_DECODING_FAILED 200 (OK)`

Root cause: the dashboard `hooks.server.ts` proxy (`proxyRequestToApi`) forwards browser `Accept-Encoding` to the API. Node's `fetch` decompresses the body but can leave `Content-Encoding: gzip` on the Response. Returning that Response to the browser makes Chrome try to gunzip already-plain JSON → decoding failure (login/session broken).

### Changes
- Request `Accept-Encoding: identity` from the API upstream
- Strip `content-encoding`, `content-length`, and `transfer-encoding` from proxied responses
- Copy `Set-Cookie` via `getSetCookie()` + `append` so multi-cookie auth responses are not collapsed
- Allow `data:` in CSP `font-src` (inlined fonts were blocked)
- Disable UserJot on self-hosted; allow `cdn.userjot.com` in SaaS CSP defaults
- Preserve special CSP schemes (`data:`, `blob:`) when parsing runtime env domain lists
- Jest coverage for proxy decoding/cookies and CSP domain normalization

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Redeploy dashboard with this change on Railway/self-hosted
- Open the login page and watch Network for `GET /api/auth/get-session` — should be 200 JSON, **not** `ERR_CONTENT_DECODING_FAILED`
- Sign in — `POST /api/auth/sign-in/email` and `/proxy/account` should succeed without decoding errors
- Console: no CSP block for `data:font/woff2`; UserJot should not load when `PUBLIC_IS_SELFHOSTED=true`
- `cd apps/dashboard && pnpm exec jest src/lib/utils/proxy-api-request.test.ts src/lib/utils/csp.test.ts --config='{"preset":"ts-jest","testEnvironment":"node","transform":{"^.+\\.ts$":"ts-jest"}}'`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build` (dashboard + deps)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb5db36a-d7fb-4bbd-ae22-5c878fcf19ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb5db36a-d7fb-4bbd-ae22-5c878fcf19ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxied API responses by stripping unsafe/encoding-related headers, preserving cookies correctly, and using identity encoding.
  * Enhanced CSP domain parsing to correctly handle special sources like `self`, `data:`, and `blob:`.
  * Updated CSP `font-src` to allow inline `data:` fonts.
  * Improved embedded widget script nonce handling and blocked widgets on self-hosted deployments.
* **Improvements**
  * Added the UserJot CDN domain to default CSP script sources for SaaS builds.
* **Tests**
  * Added coverage for CSP parsing and proxied API request/response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes dashboard auth and proxy response handling. The main changes are:

- Requests uncompressed responses from the API and removes stale transport headers.
- Preserves multiple authentication cookies when proxying responses.
- Supports special CSP sources and allows inlined fonts.
- Disables UserJot for self-hosted deployments and updates its SaaS CSP settings.
- Adds tests for proxy behavior and CSP parsing.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The proxy now preserves separate cookies on the declared Node runtime.
- The new proxy tests use the dashboard's declared Jest runner.
- No blocking issues remain in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/utils/proxy-api-request.ts | Rebuilds proxied responses without stale encoding headers and preserves separate cookie values. |
| apps/dashboard/src/lib/utils/proxy-api-request.test.ts | Adds Jest coverage for proxy routing, response headers, upstream configuration, and multiple cookies. |
| apps/dashboard/src/lib/utils/csp.ts | Preserves special CSP source values while normalizing configured domains. |
| apps/dashboard/src/lib/utils/csp.test.ts | Adds coverage for blank input, special CSP sources, URLs, and bare domains. |
| apps/dashboard/src/lib/utils/services/userjot/index.ts | Skips UserJot initialization for self-hosted builds and improves nonce handling. |
| apps/dashboard/svelte.config.js | Allows data-backed fonts in the dashboard CSP. |

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): preserve Set-Cookie and ..."](https://github.com/classroomio/classroomio/commit/c6093fc416537a747c79bc15000add88237e8af4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46716606)</sub>

<!-- /greptile_comment -->