### PR TITLE
fix: changed empty import path

### DIFF
--- a/apps/dashboard/src/lib/features/ai-tutor-settings/pages/org-settings.svelte
+++ b/apps/dashboard/src/lib/features/ai-tutor-settings/pages/org-settings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  // import { onMount } from 'svelte';
   import { defaultAiTutorSettings } from '@cio/ai-assistant/tutor-config';
 
   import * as Page from '@cio/ui/base/page';
@@ -9,14 +9,34 @@
   import { aiTutorApi } from '../api/ai-tutor.svelte';
   import { applyOrgSettings, orgTutorSettingsStore } from '../store/tutor-settings-store';
   import TutorSettingsForm from '../components/tutor-settings-form.svelte';
+  import { currentOrg } from '$lib/utils/store/org';
 
   let initialized = $state(false);
 
-  onMount(async () => {
+  let fetchedOrgId = $state<string | null>(null);
+
+  async function intitializeSettings() {
     await aiTutorApi.fetchOrgSettings();
+
     applyOrgSettings(aiTutorApi.orgSettings ?? defaultAiTutorSettings);
+
     initialized = true;
+  }
+
+  $effect(() => {
+    const orgId = $currentOrg?.id;
+
+    if (!orgId || fetchedOrgId === orgId) return;
+    fetchedOrgId = orgId;
+
+    intitializeSettings();
   });
+
+  // onMount(async () => {
+  //   await aiTutorApi.fetchOrgSettings();
+  //   applyOrgSettings(aiTutorApi.orgSettings ?? defaultAiTutorSettings);
+  //   initialized = true;
+  // });
 
   async function handleSave() {
     await aiTutorApi.updateOrgSettings($orgTutorSettingsStore);

--- a/apps/dashboard/src/lib/features/ai-tutor-settings/pages/org-settings.svelte
+++ b/apps/dashboard/src/lib/features/ai-tutor-settings/pages/org-settings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  // import { onMount } from 'svelte';
+  import { onMount } from 'svelte';
   import { defaultAiTutorSettings } from '@cio/ai-assistant/tutor-config';
 
   import * as Page from '@cio/ui/base/page';
@@ -9,34 +9,14 @@
   import { aiTutorApi } from '../api/ai-tutor.svelte';
   import { applyOrgSettings, orgTutorSettingsStore } from '../store/tutor-settings-store';
   import TutorSettingsForm from '../components/tutor-settings-form.svelte';
-  import { currentOrg } from '$lib/utils/store/org';
 
   let initialized = $state(false);
 
-  let fetchedOrgId = $state<string | null>(null);
-
-  async function intitializeSettings() {
+  onMount(async () => {
     await aiTutorApi.fetchOrgSettings();
-
     applyOrgSettings(aiTutorApi.orgSettings ?? defaultAiTutorSettings);
-
     initialized = true;
-  }
-
-  $effect(() => {
-    const orgId = $currentOrg?.id;
-
-    if (!orgId || fetchedOrgId === orgId) return;
-    fetchedOrgId = orgId;
-
-    intitializeSettings();
   });
-
-  // onMount(async () => {
-  //   await aiTutorApi.fetchOrgSettings();
-  //   applyOrgSettings(aiTutorApi.orgSettings ?? defaultAiTutorSettings);
-  //   initialized = true;
-  // });
 
   async function handleSave() {
     await aiTutorApi.updateOrgSettings($orgTutorSettingsStore);

--- a/packages/ui/src/custom/exercise-question/renderers/shared/submission-response-bar-chart.svelte
+++ b/packages/ui/src/custom/exercise-question/renderers/shared/submission-response-bar-chart.svelte
@@ -8,7 +8,7 @@
 <script lang="ts">
   import { Spinner } from '../../../../base/spinner';
   import type { ChartConfig } from '../../../../base/chart/types';
-  import Empty from '$src/custom/empty/empty.svelte';
+  import Empty from '../../../empty/empty.svelte';
   import { BarChart3 } from '@lucide/svelte';
 
   const isBrowser = typeof window !== 'undefined';


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixed the Empty component import route

<!-- Please provide a screenshots or upload a video for visual changes to speed up reviews -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI Tutor settings loading when switching between organizations, ensuring the correct settings are fetched and applied.
  * Preserved default settings when no organization-specific configuration is available.
  * Fixed an internal component reference without changing chart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken import path in `submission-response-bar-chart.svelte`, replacing the non-existent alias `$src/custom/empty/empty.svelte` with a correct relative path `../../../empty/empty.svelte`.

- The old path used a `$src` alias that is not configured in the `packages/ui` package, which would cause a build/module resolution failure at runtime.
- The new relative path correctly resolves to `packages/ui/src/custom/empty/empty.svelte`, matching the existing file on disk.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line import path correction with no logic changes.

Only one line changes: replacing an unresolvable path alias with a verified relative path that points to the correct existing file. The fix is straightforwardly correct and introduces no new logic or side effects.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/custom/exercise-question/renderers/shared/submission-response-bar-chart.svelte | Fixes broken `$src` alias import for Empty component with a correct relative path that resolves to the existing file. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["submission-response-bar-chart.svelte"] -->|"import Empty"| B["../../../empty/empty.svelte ✅"]
    A -.->|"old broken import"| C["'$src/custom/empty/empty.svelte' ❌\n(alias not defined in packages/ui)"]
```

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into empty-comp-path..."](https://github.com/classroomio/classroomio/commit/e80f6409dc61d5923d42734d6308da3e18e301cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46997382)</sub>

<!-- /greptile_comment -->