### PR TITLE
fix: prevent landing page editor sidebar from expanding on long embed/description text

### DIFF
--- a/apps/dashboard/src/lib/features/settings/pages/landingpage-editor.svelte
+++ b/apps/dashboard/src/lib/features/settings/pages/landingpage-editor.svelte
@@ -150,7 +150,7 @@
   {/if}
 </Sidebar.Header>
 
-<Sidebar.Content class="flex-1 overflow-y-auto">
+<Sidebar.Content class="min-w-0 flex-1 overflow-x-hidden overflow-y-auto">
   {#if !$landingPageEditorSelection}
     <Sidebar.Group>
       <Sidebar.GroupLabel class="px-2">
@@ -176,7 +176,7 @@
     </Sidebar.Group>
   {:else if selectedSectionDefinition}
     {@const SectionComponent = selectedSectionDefinition.component}
-    <div class="p-4">
+    <div class="min-w-0 overflow-x-hidden p-4">
       <SectionComponent bind:settings {markDirty} />
     </div>
   {/if}

--- a/apps/dashboard/src/lib/features/settings/pages/landingpage-editor/embed-section.svelte
+++ b/apps/dashboard/src/lib/features/settings/pages/landingpage-editor/embed-section.svelte
@@ -77,7 +77,7 @@
   }
 </script>
 
-<Field.Group class="space-y-6">
+<Field.Group class="min-w-0 space-y-6 overflow-x-hidden">
   <Field.Set>
     <Field.Legend>{$t('settings.landing_page.editor.sections.embed')}</Field.Legend>
 
@@ -112,7 +112,7 @@
             />
           </div>
           <Textarea
-            class="ui:[field-sizing:fixed] ui:min-w-0 ui:w-full ui:max-w-full ui:box-border ui:resize-y"
+            class="ui:[field-sizing:fixed] ui:min-w-0 ui:w-full ui:max-w-full ui:box-border ui:resize-y ui:break-all ui:overflow-x-auto"
             value={settings.embed.description ?? ''}
             placeholder={$t('settings.landing_page.editor.embed.description_placeholder')}
             oninput={(event) => setter(event.currentTarget.value, 'embed.description')}
@@ -123,7 +123,7 @@
           <Field.Label>{$t('settings.landing_page.editor.embed.code')}</Field.Label>
           <Field.Description>{$t('settings.landing_page.editor.embed.code_description')}</Field.Description>
           <Textarea
-            class="ui:[field-sizing:fixed] ui:min-w-0 ui:w-full ui:max-w-full ui:box-border ui:resize-y"
+            class="ui:[field-sizing:fixed] ui:min-w-0 ui:w-full ui:max-w-full ui:box-border ui:resize-y ui:break-all ui:overflow-x-auto"
             value={settings.embed.code}
             placeholder={$t('settings.landing_page.editor.embed.code_placeholder')}
             oninput={(event) => setter(event.currentTarget.value, 'embed.code')}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes a layout issue in the Landing Page Editor sidebar.
When a long embed code (e.g. an iframe with a long URL) or a long description was entered, the left sidebar expanded horizontally and showed a bottom scrollbar. The sidebar should keep a fixed width; long content should wrap or scroll inside the textarea instead of stretching the layout.


Fixes #796 

<!-- Please provide a screenshots or upload a video for visual changes to speed up reviews -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Log in as an org admin.
2. Go to Organization → Settings → Landing page.
3. Click Customize landing page.
4. In the left sidebar, select Embed.
5. Turn on Show embed section.
6. Paste a long iframe snippet into the Embed code field, for example:

<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSc1B9-DhffNGr-pndoP_pmUzT2ac_qFDrhlclbKOBUVKvGg-Q/viewform?embedded=true" width="640" height="1715" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>

7. Also try a long string in the Description field.

Expected:

 • Sidebar width stays the same as when the fields are empty.
 • Long text wraps or scrolls inside the textarea.
 • No horizontal scrollbar appears on the sidebar.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the landing page editor layout to prevent horizontal clipping and overflow.
  * Updated embed fields to handle long text and code more cleanly, with improved wrapping and horizontal scrolling.
  * Preserved textarea resizing while making embedded content easier to view and edit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents long landing-page embed and description content from widening the editor sidebar.
- Constrains the sidebar and embed-section containers against horizontal overflow.
- Keeps textareas within available width and enables long content to wrap or scroll internally.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/settings/pages/landingpage-editor.svelte | Constrains sidebar content and the selected-section wrapper to prevent horizontal expansion. |
| apps/dashboard/src/lib/features/settings/pages/landingpage-editor/embed-section.svelte | Constrains the embed form and updates its textareas to handle long unbroken content internally. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into Embed-code-text..."](https://github.com/classroomio/classroomio/commit/c4c8645a8c68cf508ca584785332642f6fddb568) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48274927)</sub>

<!-- /greptile_comment -->