### PR TITLE
fix(dashboard): align hero enroll CTA with pricing section

### DIFF
--- a/apps/dashboard/src/lib/features/ui/course-landing-page/course-landing-page.svelte
+++ b/apps/dashboard/src/lib/features/ui/course-landing-page/course-landing-page.svelte
@@ -49,7 +49,7 @@
     return slug ? resolve(`/course/${slug}/enroll`, {}) : '#';
   });
 
-  const enrollmentsOpen = $derived(get(courseData, 'metadata.allowNewStudent') === true);
+  const enrollmentsOpen = $derived(get(courseData, 'metadata.allowNewStudent') !== false);
   const enrollDisabled = $derived(editMode || !enrollmentsOpen);
 
   const discount = $derived(get(courseData, 'metadata.discount', 0));
@@ -60,7 +60,7 @@
   function handlePaidEnrollClick(event: MouseEvent) {
     event.preventDefault();
 
-    if (editMode || !$currentOrg.siteName) {
+    if (editMode || !activeOrg.siteName) {
       return;
     }
 

--- a/apps/dashboard/src/lib/features/ui/course-landing-page/utils.ts
+++ b/apps/dashboard/src/lib/features/ui/course-landing-page/utils.ts
@@ -250,6 +250,7 @@ export function buildCourseLandingPageProps(
       ctaLabel: pricingCtaLabel,
       ctaHref: paidEnrollClick ? undefined : options.enrollHref,
       ctaOnclick: paidEnrollClick,
+      ctaDisabled: options.enrollDisabled,
       reward: metadata?.reward?.show ? { show: true, description: metadata.reward.description ?? '' } : undefined
     },
     footer: landing.footer

--- a/packages/ui/src/custom/org-landing-page/course-landing-page.helpers.ts
+++ b/packages/ui/src/custom/org-landing-page/course-landing-page.helpers.ts
@@ -10,7 +10,7 @@ export function alignHeroCtaWithPricing(
       label: pricing.ctaLabel,
       href: pricing.ctaOnclick ? undefined : (pricing.ctaHref ?? '#pricing'),
       onclick: pricing.ctaOnclick,
-      disabled: hero.primaryAction.disabled
+      disabled: pricing.ctaDisabled ?? hero.primaryAction.disabled
     }
   };
 }

--- a/packages/ui/src/custom/org-landing-page/course-pricing.svelte
+++ b/packages/ui/src/custom/org-landing-page/course-pricing.svelte
@@ -73,6 +73,7 @@
           size="lg"
           href={pricing.ctaOnclick ? undefined : (pricing.ctaHref ?? '#enroll')}
           onclick={pricing.ctaOnclick}
+          disabled={pricing.ctaDisabled ?? false}
           class={t.pricingCta}
         >
           {pricing.ctaLabel}

--- a/packages/ui/src/custom/org-landing-page/types.ts
+++ b/packages/ui/src/custom/org-landing-page/types.ts
@@ -229,6 +229,7 @@ export type CoursePricing = {
   ctaLabel: string;
   ctaHref?: string;
   ctaOnclick?: (event: MouseEvent) => void;
+  ctaDisabled?: boolean;
   features?: string[];
   reward?: {
     show: boolean;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On course landing pages, the hero **Enroll Now** button did nothing while the pricing section **Enroll Now** button worked correctly.

## Root cause

The hero CTA was disabled unless `metadata.allowNewStudent === true` (strict equality). The pricing CTA and enroll flow treat enrollment as open when the flag is unset (`!== false`), which matches the API default and enroll page logic.

Courses with `allowNewStudent` left at its default/unset state therefore had a disabled hero button but a working pricing button.

## Fix

- Treat enrollment as open when `allowNewStudent !== false` (consistent with enroll page/API)
- Pass `ctaDisabled` through to the pricing CTA so both buttons share the same disabled state
- Keep hero/pricing disabled flags aligned in `alignHeroCtaWithPricing`
- Use `activeOrg` (not `$currentOrg`) for paid-enroll clicks on public org-site pages

## Testing

- `pnpm --filter @cio/ui prefix:check:staged`
- `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17aa0bf6-d250-48e6-b8fd-31f8c98cd2b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17aa0bf6-d250-48e6-b8fd-31f8c98cd2b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for explicitly disabling course enrollment and pricing calls to action.
  - Pricing and hero enrollment buttons now stay synchronized when enrollment is disabled.
  - Course enrollment availability now defaults to open unless explicitly disabled.

- **Bug Fixes**
  - Improved paid-enrollment validation by using the active site’s settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Aligns the course landing-page enrollment CTAs so unset enrollment metadata remains open, explicit closure disables both buttons, and public paid enrollment uses the active organization.
- Propagates the enrollment-disabled state into the shared pricing CTA.
- Keeps hero and pricing CTA disabled states synchronized across themes.
- Uses the route-resolved organization when opening paid enrollment.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with both enrollment CTAs now following the same explicit-false closure semantics.

The changed default matches the enrollment page, backend guard, validation default, and course discovery behavior, while the new disabled-state propagation consistently prevents both hero and pricing CTA interaction when enrollment is closed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/ui/course-landing-page/course-landing-page.svelte | Aligns the enrollment-open check with backend and enrollment-page semantics and uses the active organization for paid enrollment. |
| apps/dashboard/src/lib/features/ui/course-landing-page/utils.ts | Passes the existing enrollment-disabled state to the pricing CTA. |
| packages/ui/src/custom/org-landing-page/course-landing-page.helpers.ts | Synchronizes the hero CTA disabled state with pricing while preserving backward compatibility when the new field is absent. |
| packages/ui/src/custom/org-landing-page/course-pricing.svelte | Applies the propagated disabled state through the shared landing button. |
| packages/ui/src/custom/org-landing-page/types.ts | Adds the optional pricing CTA disabled-state contract. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): align hero enroll CTA wi..."](https://github.com/classroomio/classroomio/commit/7f404d264363802c02602f58c2f38eff7de75bd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49029287)</sub>

**Context used:**

- Knowledge Base — [Dashboard app (`apps/dashboard`)](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/dashboard-app.md)

<!-- /greptile_comment -->