### PR TITLE
fix(api): scope public API rate limiting per API key

### DIFF
--- a/apps/api/src/constants/rate-limiter.ts
+++ b/apps/api/src/constants/rate-limiter.ts
@@ -3,9 +3,7 @@ export const DEFAULT_WINDOW_MS = 60 * 1000;
 
 export const DEFAULT_MAX_REQUESTS = 100;
 
-// Keep this above the per-key budget so normal API-key traffic remains governed
-// by its own limiter while abusive pre-authentication traffic is still bounded.
-export const PUBLIC_API_PRE_AUTH_MAX_REQUESTS = 1000;
+export const PUBLIC_API_FAILED_AUTH_MAX_REQUESTS = 1000;
 
 export const RATE_LIMIT_KEY_PREFIX = 'rate_limit:';
 

--- a/apps/api/src/constants/rate-limiter.ts
+++ b/apps/api/src/constants/rate-limiter.ts
@@ -3,6 +3,10 @@ export const DEFAULT_WINDOW_MS = 60 * 1000;
 
 export const DEFAULT_MAX_REQUESTS = 100;
 
+// Keep this above the per-key budget so normal API-key traffic remains governed
+// by its own limiter while abusive pre-authentication traffic is still bounded.
+export const PUBLIC_API_PRE_AUTH_MAX_REQUESTS = 1000;
+
 export const RATE_LIMIT_KEY_PREFIX = 'rate_limit:';
 
 export const DEFAULT_RATE_LIMITER_OPTIONS = {

--- a/apps/api/src/middlewares/rate-limiter.ts
+++ b/apps/api/src/middlewares/rate-limiter.ts
@@ -44,7 +44,6 @@ export const createRateLimiter = (options: RateLimiterOptions = {}): MiddlewareH
   const opts = { ...defaultOptions, ...options };
 
   return async (c, next) => {
-    // Skip rate limiting if not in production
     if (env.NODE_ENV !== 'production' || opts.skip(c)) {
       return await next();
     }
@@ -53,13 +52,9 @@ export const createRateLimiter = (options: RateLimiterOptions = {}): MiddlewareH
       const maxRequests = typeof opts.maxRequests === 'function' ? opts.maxRequests(c) : opts.maxRequests;
       const limiter = new RedisRateLimiter(redis, opts.windowMs, maxRequests);
 
-      // Generate rate limit key
       const key = opts.keyGenerator(c);
-
-      // Check rate limit
       const result = await limiter.isAllowed(key);
 
-      // Set rate limit headers
       if (opts.standardHeaders) {
         c.header(RATE_LIMIT_HEADERS.LIMIT, maxRequests.toString());
         c.header(RATE_LIMIT_HEADERS.REMAINING, result.remaining.toString());
@@ -106,6 +101,8 @@ function defaultMaxRequests(c: Context): number {
 
 function shouldSkipRateLimit(c: Context): boolean {
   if (isTrustedServerApiKeyRequest(c)) return true;
+
+  if (c.req.path.startsWith('/public-api/')) return true;
 
   return c.req.path === '/api/auth/get-session';
 }

--- a/apps/api/src/middlewares/rate-limiter.ts
+++ b/apps/api/src/middlewares/rate-limiter.ts
@@ -118,16 +118,17 @@ export const createAuthenticationFailureRateLimiter = (options: RateLimiterOptio
     const maxRequests = typeof opts.maxRequests === 'function' ? opts.maxRequests(c) : opts.maxRequests;
     const limiter = new RedisRateLimiter(redis, opts.windowMs, maxRequests);
     const key = opts.keyGenerator(c);
+    let reservation: RateLimitResult;
 
     try {
-      const status = await limiter.getStatus(key);
+      reservation = await limiter.isAllowed(key);
 
-      if (!status.allowed) {
+      if (!reservation.allowed) {
         if (opts.standardHeaders) {
-          setRateLimitHeaders(c, maxRequests, status);
+          setRateLimitHeaders(c, maxRequests, reservation);
         }
 
-        return createRateLimitResponse(c, opts.message, status, opts.standardHeaders);
+        return createRateLimitResponse(c, opts.message, reservation, opts.standardHeaders);
       }
     } catch (error) {
       logRedisUnavailableOnce('Redis authentication failure limiter unavailable, allowing request', error);
@@ -138,21 +139,11 @@ export const createAuthenticationFailureRateLimiter = (options: RateLimiterOptio
     await next();
 
     if (c.get('automationKey')) {
-      return;
-    }
-
-    try {
-      const result = await limiter.isAllowed(key);
-
-      if (opts.standardHeaders) {
-        setRateLimitHeaders(c, maxRequests, result);
+      try {
+        await limiter.release(key, reservation.reservationId);
+      } catch (error) {
+        logRedisUnavailableOnce('Redis authentication failure limiter reservation release failed', error);
       }
-
-      if (!result.allowed) {
-        c.res = createRateLimitResponse(c, opts.message, result, opts.standardHeaders);
-      }
-    } catch (error) {
-      logRedisUnavailableOnce('Redis authentication failure limiter unavailable, allowing request', error);
     }
   };
 };

--- a/apps/api/src/middlewares/rate-limiter.ts
+++ b/apps/api/src/middlewares/rate-limiter.ts
@@ -6,7 +6,7 @@ import {
 } from '@api/constants/rate-limiter';
 
 import type { Context, MiddlewareHandler } from 'hono';
-import { RedisRateLimiter } from '@api/utils/redis/limiter';
+import { RedisRateLimiter, type RateLimitResult } from '@api/utils/redis/limiter';
 import { userKeyGenerator } from '../utils/redis/key-generators';
 import { env } from '@cio/core/config/env';
 import { logRedisUnavailableOnce, redis } from '@cio/core/utils/redis/redis';
@@ -40,6 +40,34 @@ const defaultOptions: Required<RateLimiterOptions> = {
   skip: () => false
 };
 
+function setRateLimitHeaders(c: Context, maxRequests: number, result: RateLimitResult): void {
+  c.header(RATE_LIMIT_HEADERS.LIMIT, maxRequests.toString());
+  c.header(RATE_LIMIT_HEADERS.REMAINING, result.remaining.toString());
+  c.header(RATE_LIMIT_HEADERS.RESET, new Date(result.resetTime).toISOString());
+}
+
+function createRateLimitResponse(
+  c: Context,
+  message: string,
+  result: RateLimitResult,
+  includeStandardHeaders: boolean
+): Response {
+  const retryAfter = Math.ceil((result.resetTime - Date.now()) / 1000);
+
+  if (includeStandardHeaders) {
+    c.header(RATE_LIMIT_HEADERS.RETRY_AFTER, retryAfter.toString());
+  }
+
+  return c.json(
+    {
+      error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+      message,
+      retryAfter
+    },
+    HTTP_STATUS.TOO_MANY_REQUESTS
+  );
+}
+
 export const createRateLimiter = (options: RateLimiterOptions = {}): MiddlewareHandler => {
   const opts = { ...defaultOptions, ...options };
 
@@ -56,9 +84,7 @@ export const createRateLimiter = (options: RateLimiterOptions = {}): MiddlewareH
       const result = await limiter.isAllowed(key);
 
       if (opts.standardHeaders) {
-        c.header(RATE_LIMIT_HEADERS.LIMIT, maxRequests.toString());
-        c.header(RATE_LIMIT_HEADERS.REMAINING, result.remaining.toString());
-        c.header(RATE_LIMIT_HEADERS.RESET, new Date(result.resetTime).toISOString());
+        setRateLimitHeaders(c, maxRequests, result);
       }
 
       if (opts.legacyHeaders) {
@@ -68,26 +94,65 @@ export const createRateLimiter = (options: RateLimiterOptions = {}): MiddlewareH
       }
 
       if (!result.allowed) {
-        const retryAfter = Math.ceil((result.resetTime - Date.now()) / 1000);
-
-        if (opts.standardHeaders) {
-          c.header(RATE_LIMIT_HEADERS.RETRY_AFTER, retryAfter.toString());
-        }
-
-        return c.json(
-          {
-            error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-            message: opts.message,
-            retryAfter
-          },
-          HTTP_STATUS.TOO_MANY_REQUESTS
-        );
+        return createRateLimitResponse(c, opts.message, result, opts.standardHeaders);
       }
 
       await next();
     } catch (error) {
       logRedisUnavailableOnce('Redis rate limiter unavailable, allowing requests without rate limiting', error);
       await next();
+    }
+  };
+};
+
+export const createAuthenticationFailureRateLimiter = (options: RateLimiterOptions = {}): MiddlewareHandler => {
+  const opts = { ...defaultOptions, ...options };
+
+  return async (c, next) => {
+    const authHeader = c.req.header('Authorization');
+
+    if (env.NODE_ENV !== 'production' || !authHeader?.startsWith('Bearer ') || opts.skip(c)) {
+      return await next();
+    }
+
+    const maxRequests = typeof opts.maxRequests === 'function' ? opts.maxRequests(c) : opts.maxRequests;
+    const limiter = new RedisRateLimiter(redis, opts.windowMs, maxRequests);
+    const key = opts.keyGenerator(c);
+
+    try {
+      const status = await limiter.getStatus(key);
+
+      if (!status.allowed) {
+        if (opts.standardHeaders) {
+          setRateLimitHeaders(c, maxRequests, status);
+        }
+
+        return createRateLimitResponse(c, opts.message, status, opts.standardHeaders);
+      }
+    } catch (error) {
+      logRedisUnavailableOnce('Redis authentication failure limiter unavailable, allowing request', error);
+
+      return await next();
+    }
+
+    await next();
+
+    if (c.get('automationKey')) {
+      return;
+    }
+
+    try {
+      const result = await limiter.isAllowed(key);
+
+      if (opts.standardHeaders) {
+        setRateLimitHeaders(c, maxRequests, result);
+      }
+
+      if (!result.allowed) {
+        c.res = createRateLimitResponse(c, opts.message, result, opts.standardHeaders);
+      }
+    } catch (error) {
+      logRedisUnavailableOnce('Redis authentication failure limiter unavailable, allowing request', error);
     }
   };
 };

--- a/apps/api/src/middlewares/rate-limiter.ts
+++ b/apps/api/src/middlewares/rate-limiter.ts
@@ -109,9 +109,7 @@ export const createAuthenticationFailureRateLimiter = (options: RateLimiterOptio
   const opts = { ...defaultOptions, ...options };
 
   return async (c, next) => {
-    const authHeader = c.req.header('Authorization');
-
-    if (env.NODE_ENV !== 'production' || !authHeader?.startsWith('Bearer ') || opts.skip(c)) {
+    if (env.NODE_ENV !== 'production' || opts.skip(c)) {
       return await next();
     }
 

--- a/apps/api/src/routes/v1/audience.ts
+++ b/apps/api/src/routes/v1/audience.ts
@@ -15,8 +15,6 @@ import {
 } from '@api/services/v1/audience';
 
 import { Hono } from '@api/utils/hono';
-import { automationKeyMiddleware } from '@api/middlewares/automation-key';
-import { automationKeyScopesMiddleware } from '@api/middlewares/automation-key-scopes';
 import { handlePublicApiError } from '@api/utils/errors';
 import { describeRoute, validator } from 'hono-openapi';
 
@@ -52,8 +50,6 @@ const AudienceDetailResponse = {
 export const v1AudienceRouter = new Hono()
   .get(
     '/',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'List audience members for the authenticated organization',
       tags: ['Public API Audience'],
@@ -93,8 +89,6 @@ export const v1AudienceRouter = new Hono()
   )
   .post(
     '/',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'Create an audience member invitation for the authenticated organization',
       tags: ['Public API Audience'],
@@ -134,8 +128,6 @@ export const v1AudienceRouter = new Hono()
   )
   .post(
     '/assign-courses',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'Assign one or more audience members to one or more courses',
       tags: ['Public API Audience'],
@@ -174,8 +166,6 @@ export const v1AudienceRouter = new Hono()
   )
   .get(
     '/:memberId',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'Get a single audience member by id',
       tags: ['Public API Audience'],
@@ -214,8 +204,6 @@ export const v1AudienceRouter = new Hono()
   )
   .delete(
     '/:memberId',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'Remove an audience member by id',
       tags: ['Public API Audience'],
@@ -255,8 +243,6 @@ export const v1AudienceRouter = new Hono()
   )
   .put(
     '/:memberId',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'Update a pending audience member email address',
       tags: ['Public API Audience'],

--- a/apps/api/src/routes/v1/courses.ts
+++ b/apps/api/src/routes/v1/courses.ts
@@ -17,8 +17,6 @@ import {
 } from '@api/services/v1/course';
 
 import { Hono } from '@api/utils/hono';
-import { automationKeyMiddleware } from '@api/middlewares/automation-key';
-import { automationKeyScopesMiddleware } from '@api/middlewares/automation-key-scopes';
 import { handlePublicApiError } from '@api/utils/errors';
 import { describeRoute, validator } from 'hono-openapi';
 
@@ -43,8 +41,6 @@ const CourseDetailResponse = {
 export const v1CoursesRouter = new Hono()
   .get(
     '/',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'List courses for the authenticated organization',
       tags: ['Public API Courses'],
@@ -82,8 +78,6 @@ export const v1CoursesRouter = new Hono()
   )
   .post(
     '/',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'Create a course for the authenticated organization',
       tags: ['Public API Courses'],
@@ -123,8 +117,6 @@ export const v1CoursesRouter = new Hono()
   )
   .get(
     '/:courseId/students',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'List enrolled students for a course',
       tags: ['Public API Courses'],
@@ -163,8 +155,6 @@ export const v1CoursesRouter = new Hono()
   )
   .get(
     '/:courseId/export',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'Export a course structure snapshot',
       tags: ['Public API Courses'],
@@ -203,8 +193,6 @@ export const v1CoursesRouter = new Hono()
   )
   .get(
     '/:courseId/structure',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'Get a course structure snapshot',
       tags: ['Public API Courses'],
@@ -243,8 +231,6 @@ export const v1CoursesRouter = new Hono()
   )
   .put(
     '/:courseId/structure',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'Synchronize a course structure using the draft payload shape',
       tags: ['Public API Courses'],
@@ -287,8 +273,6 @@ export const v1CoursesRouter = new Hono()
   )
   .get(
     '/:courseId',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'Get a single course by id',
       tags: ['Public API Courses'],
@@ -327,8 +311,6 @@ export const v1CoursesRouter = new Hono()
   )
   .put(
     '/:courseId',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'Update a course by id',
       tags: ['Public API Courses'],
@@ -370,8 +352,6 @@ export const v1CoursesRouter = new Hono()
   )
   .delete(
     '/:courseId',
-    automationKeyMiddleware,
-    automationKeyScopesMiddleware(['public_api:*']),
     describeRoute({
       description: 'Delete a course by id',
       tags: ['Public API Courses'],

--- a/apps/api/src/routes/v1/index.test.ts
+++ b/apps/api/src/routes/v1/index.test.ts
@@ -4,7 +4,9 @@ import { Hono } from '@api/utils/hono';
 
 const mocks = vi.hoisted(() => ({
   authenticate: vi.fn(),
+  getFailureStatus: vi.fn(),
   isAllowed: vi.fn(),
+  recordFailure: vi.fn(),
   touchLastUsed: vi.fn()
 }));
 
@@ -13,6 +15,27 @@ vi.mock('@hono/node-server/conninfo', () => ({
 }));
 
 vi.mock('@api/middlewares/rate-limiter', () => ({
+  createAuthenticationFailureRateLimiter:
+    (options: { keyGenerator: (context: Context) => string }) => async (context: Context, next: Next) => {
+      const authHeader = context.req.header('Authorization');
+
+      if (!authHeader?.startsWith('Bearer ')) {
+        return next();
+      }
+
+      const key = options.keyGenerator(context);
+      const status = await mocks.getFailureStatus(key);
+
+      if (!status.allowed) {
+        return context.json({ error: 'Too Many Requests' }, 429);
+      }
+
+      await next();
+
+      if (!context.get('automationKey')) {
+        await mocks.recordFailure(key);
+      }
+    },
   createRateLimiter:
     (options: { keyGenerator: (context: Context) => string }) => async (context: Context, next: Next) => {
       const key = options.keyGenerator(context);
@@ -44,7 +67,7 @@ vi.mock('@api/routes/v1/courses', () => ({
 import { v1Router } from './index';
 
 const CLIENT_IP = '203.0.113.10';
-const PRE_AUTH_KEY = `public_api_ip:${CLIENT_IP}`;
+const FAILED_AUTH_KEY = `public_api_failed_auth:${CLIENT_IP}`;
 
 function requestWithToken(token?: string) {
   const headers = new Headers({ 'cf-connecting-ip': CLIENT_IP });
@@ -59,8 +82,15 @@ function requestWithToken(token?: string) {
 describe('public API rate limiting', () => {
   beforeEach(() => {
     mocks.authenticate.mockReset();
+    mocks.getFailureStatus.mockReset();
     mocks.isAllowed.mockReset();
+    mocks.recordFailure.mockReset();
     mocks.touchLastUsed.mockReset();
+    mocks.getFailureStatus.mockResolvedValue({
+      allowed: true,
+      remaining: 1000,
+      resetTime: Date.now() + 60_000
+    });
     mocks.isAllowed.mockResolvedValue({
       allowed: true,
       remaining: 999,
@@ -68,42 +98,37 @@ describe('public API rate limiting', () => {
     });
   });
 
-  it('rate limits requests with a missing token before authentication', async () => {
+  it('rejects a missing token without consuming the failed-authentication budget', async () => {
     const unauthorizedResponse = await requestWithToken();
 
     expect(unauthorizedResponse.status).toBe(401);
-
-    mocks.isAllowed.mockResolvedValueOnce({ allowed: false, remaining: 0, resetTime: Date.now() + 60_000 });
-
-    const limitedResponse = await requestWithToken();
-
-    expect(limitedResponse.status).toBe(429);
-    expect(mocks.isAllowed).toHaveBeenCalledTimes(2);
-    expect(mocks.isAllowed).toHaveBeenNthCalledWith(1, PRE_AUTH_KEY);
-    expect(mocks.isAllowed).toHaveBeenNthCalledWith(2, PRE_AUTH_KEY);
+    expect(mocks.getFailureStatus).not.toHaveBeenCalled();
+    expect(mocks.recordFailure).not.toHaveBeenCalled();
     expect(mocks.authenticate).not.toHaveBeenCalled();
   });
 
-  it('rate limits invalid tokens before another authentication lookup', async () => {
+  it('records invalid tokens and blocks another authentication lookup after the budget is exhausted', async () => {
     mocks.authenticate.mockRejectedValue(new Error('Invalid organization API key'));
 
     const unauthorizedResponse = await requestWithToken('invalid-key');
 
     expect(unauthorizedResponse.status).toBe(401);
     expect(mocks.authenticate).toHaveBeenCalledOnce();
+    expect(mocks.recordFailure).toHaveBeenCalledWith(FAILED_AUTH_KEY);
 
-    mocks.isAllowed.mockResolvedValueOnce({ allowed: false, remaining: 0, resetTime: Date.now() + 60_000 });
+    mocks.getFailureStatus.mockResolvedValueOnce({ allowed: false, remaining: 0, resetTime: Date.now() + 60_000 });
 
     const limitedResponse = await requestWithToken('invalid-key');
 
     expect(limitedResponse.status).toBe(429);
-    expect(mocks.isAllowed).toHaveBeenCalledTimes(2);
-    expect(mocks.isAllowed).toHaveBeenNthCalledWith(1, PRE_AUTH_KEY);
-    expect(mocks.isAllowed).toHaveBeenNthCalledWith(2, PRE_AUTH_KEY);
+    expect(mocks.getFailureStatus).toHaveBeenCalledTimes(2);
+    expect(mocks.getFailureStatus).toHaveBeenNthCalledWith(1, FAILED_AUTH_KEY);
+    expect(mocks.getFailureStatus).toHaveBeenNthCalledWith(2, FAILED_AUTH_KEY);
     expect(mocks.authenticate).toHaveBeenCalledOnce();
+    expect(mocks.recordFailure).toHaveBeenCalledOnce();
   });
 
-  it('rate limits out-of-scope tokens before another authentication lookup or last-used update', async () => {
+  it('does not consume the failed-authentication budget for an authenticated out-of-scope key', async () => {
     mocks.authenticate.mockResolvedValue({
       id: 'out-of-scope-key-id',
       organizationId: 'org-id',
@@ -116,17 +141,8 @@ describe('public API rate limiting', () => {
     expect(forbiddenResponse.status).toBe(403);
     expect(mocks.authenticate).toHaveBeenCalledOnce();
     expect(mocks.touchLastUsed).toHaveBeenCalledOnce();
-
-    mocks.isAllowed.mockResolvedValueOnce({ allowed: false, remaining: 0, resetTime: Date.now() + 60_000 });
-
-    const limitedResponse = await requestWithToken('out-of-scope-key');
-
-    expect(limitedResponse.status).toBe(429);
-    expect(mocks.isAllowed).toHaveBeenCalledTimes(2);
-    expect(mocks.isAllowed).toHaveBeenNthCalledWith(1, PRE_AUTH_KEY);
-    expect(mocks.isAllowed).toHaveBeenNthCalledWith(2, PRE_AUTH_KEY);
-    expect(mocks.authenticate).toHaveBeenCalledOnce();
-    expect(mocks.touchLastUsed).toHaveBeenCalledOnce();
+    expect(mocks.getFailureStatus).toHaveBeenCalledWith(FAILED_AUTH_KEY);
+    expect(mocks.recordFailure).not.toHaveBeenCalled();
   });
 
   it('retains the per-key limiter for valid tokens', async () => {
@@ -136,15 +152,15 @@ describe('public API rate limiting', () => {
       createdByProfileId: 'profile-id',
       scopes: ['public_api:*']
     });
-    mocks.isAllowed
-      .mockResolvedValueOnce({ allowed: true, remaining: 999, resetTime: Date.now() + 60_000 })
-      .mockResolvedValueOnce({ allowed: false, remaining: 0, resetTime: Date.now() + 60_000 });
+    mocks.isAllowed.mockResolvedValueOnce({ allowed: false, remaining: 0, resetTime: Date.now() + 60_000 });
 
     const response = await requestWithToken('valid-key');
 
     expect(response.status).toBe(429);
-    expect(mocks.isAllowed).toHaveBeenNthCalledWith(1, PRE_AUTH_KEY);
-    expect(mocks.isAllowed).toHaveBeenNthCalledWith(2, 'automation_key:key-id');
+    expect(mocks.getFailureStatus).toHaveBeenCalledWith(FAILED_AUTH_KEY);
+    expect(mocks.recordFailure).not.toHaveBeenCalled();
+    expect(mocks.isAllowed).toHaveBeenCalledOnce();
+    expect(mocks.isAllowed).toHaveBeenCalledWith('automation_key:key-id');
     expect(mocks.authenticate).toHaveBeenCalledWith('valid-key');
   });
 });

--- a/apps/api/src/routes/v1/index.test.ts
+++ b/apps/api/src/routes/v1/index.test.ts
@@ -18,12 +18,6 @@ vi.mock('@hono/node-server/conninfo', () => ({
 vi.mock('@api/middlewares/rate-limiter', () => ({
   createAuthenticationFailureRateLimiter:
     (options: { keyGenerator: (context: Context) => string }) => async (context: Context, next: Next) => {
-      const authHeader = context.req.header('Authorization');
-
-      if (!authHeader?.startsWith('Bearer ')) {
-        return next();
-      }
-
       const key = options.keyGenerator(context);
       const reservation = await mocks.reserveFailure(key);
 
@@ -103,13 +97,27 @@ describe('public API rate limiting', () => {
     });
   });
 
-  it('rejects a missing token without consuming the failed-authentication budget', async () => {
+  it('reserves failed-authentication capacity for a missing token and blocks it when exhausted', async () => {
     const unauthorizedResponse = await requestWithToken();
 
     expect(unauthorizedResponse.status).toBe(401);
-    expect(mocks.reserveFailure).not.toHaveBeenCalled();
+    expect(mocks.reserveFailure).toHaveBeenCalledWith(FAILED_AUTH_KEY);
     expect(mocks.releaseFailure).not.toHaveBeenCalled();
     expect(mocks.authenticate).not.toHaveBeenCalled();
+
+    const exhaustedLimitResetTime = Date.now() + 60_000;
+    mocks.reserveFailure.mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      reservationId: 'exhausted-reservation',
+      resetTime: exhaustedLimitResetTime
+    });
+
+    const limitedResponse = await requestWithToken();
+
+    expect(limitedResponse.status).toBe(429);
+    expect(mocks.authenticate).not.toHaveBeenCalled();
+    expect(mocks.releaseFailure).not.toHaveBeenCalled();
   });
 
   it('keeps reservations for invalid tokens and blocks another authentication lookup when exhausted', async () => {

--- a/apps/api/src/routes/v1/index.test.ts
+++ b/apps/api/src/routes/v1/index.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Context, Next } from 'hono';
+import { Hono } from '@api/utils/hono';
+
+const mocks = vi.hoisted(() => ({
+  authenticate: vi.fn(),
+  isAllowed: vi.fn(),
+  touchLastUsed: vi.fn()
+}));
+
+vi.mock('@hono/node-server/conninfo', () => ({
+  getConnInfo: () => ({ remote: { address: '127.0.0.1' } })
+}));
+
+vi.mock('@api/middlewares/rate-limiter', () => ({
+  createRateLimiter:
+    (options: { keyGenerator: (context: Context) => string }) => async (context: Context, next: Next) => {
+      const key = options.keyGenerator(context);
+      const result = await mocks.isAllowed(key);
+
+      if (!result.allowed) {
+        return context.json({ error: 'Too Many Requests' }, 429);
+      }
+
+      await next();
+    }
+}));
+
+vi.mock('@api/services/organization/automation-key', () => ({
+  authenticateOrganizationApiKeyService: mocks.authenticate,
+  organizationApiKeyHasScopes: (keyScopes: string[], requiredScopes: string[]) =>
+    requiredScopes.every((scope) => keyScopes.includes(scope)),
+  touchOrganizationApiKeyLastUsedService: mocks.touchLastUsed
+}));
+
+vi.mock('@api/routes/v1/audience', () => ({
+  v1AudienceRouter: new Hono().get('/', (c) => c.json({ success: true }))
+}));
+
+vi.mock('@api/routes/v1/courses', () => ({
+  v1CoursesRouter: new Hono().get('/', (c) => c.json({ success: true }))
+}));
+
+import { v1Router } from './index';
+
+const CLIENT_IP = '203.0.113.10';
+const PRE_AUTH_KEY = `public_api_ip:${CLIENT_IP}`;
+
+function requestWithToken(token?: string) {
+  const headers = new Headers({ 'cf-connecting-ip': CLIENT_IP });
+
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  return v1Router.request('/courses', { headers });
+}
+
+describe('public API rate limiting', () => {
+  beforeEach(() => {
+    mocks.authenticate.mockReset();
+    mocks.isAllowed.mockReset();
+    mocks.touchLastUsed.mockReset();
+    mocks.isAllowed.mockResolvedValue({
+      allowed: true,
+      remaining: 999,
+      resetTime: Date.now() + 60_000
+    });
+  });
+
+  it('rate limits requests with a missing token before authentication', async () => {
+    const unauthorizedResponse = await requestWithToken();
+
+    expect(unauthorizedResponse.status).toBe(401);
+
+    mocks.isAllowed.mockResolvedValueOnce({ allowed: false, remaining: 0, resetTime: Date.now() + 60_000 });
+
+    const limitedResponse = await requestWithToken();
+
+    expect(limitedResponse.status).toBe(429);
+    expect(mocks.isAllowed).toHaveBeenCalledTimes(2);
+    expect(mocks.isAllowed).toHaveBeenNthCalledWith(1, PRE_AUTH_KEY);
+    expect(mocks.isAllowed).toHaveBeenNthCalledWith(2, PRE_AUTH_KEY);
+    expect(mocks.authenticate).not.toHaveBeenCalled();
+  });
+
+  it('rate limits invalid tokens before another authentication lookup', async () => {
+    mocks.authenticate.mockRejectedValue(new Error('Invalid organization API key'));
+
+    const unauthorizedResponse = await requestWithToken('invalid-key');
+
+    expect(unauthorizedResponse.status).toBe(401);
+    expect(mocks.authenticate).toHaveBeenCalledOnce();
+
+    mocks.isAllowed.mockResolvedValueOnce({ allowed: false, remaining: 0, resetTime: Date.now() + 60_000 });
+
+    const limitedResponse = await requestWithToken('invalid-key');
+
+    expect(limitedResponse.status).toBe(429);
+    expect(mocks.isAllowed).toHaveBeenCalledTimes(2);
+    expect(mocks.isAllowed).toHaveBeenNthCalledWith(1, PRE_AUTH_KEY);
+    expect(mocks.isAllowed).toHaveBeenNthCalledWith(2, PRE_AUTH_KEY);
+    expect(mocks.authenticate).toHaveBeenCalledOnce();
+  });
+
+  it('rate limits out-of-scope tokens before another authentication lookup or last-used update', async () => {
+    mocks.authenticate.mockResolvedValue({
+      id: 'out-of-scope-key-id',
+      organizationId: 'org-id',
+      createdByProfileId: 'profile-id',
+      scopes: []
+    });
+
+    const forbiddenResponse = await requestWithToken('out-of-scope-key');
+
+    expect(forbiddenResponse.status).toBe(403);
+    expect(mocks.authenticate).toHaveBeenCalledOnce();
+    expect(mocks.touchLastUsed).toHaveBeenCalledOnce();
+
+    mocks.isAllowed.mockResolvedValueOnce({ allowed: false, remaining: 0, resetTime: Date.now() + 60_000 });
+
+    const limitedResponse = await requestWithToken('out-of-scope-key');
+
+    expect(limitedResponse.status).toBe(429);
+    expect(mocks.isAllowed).toHaveBeenCalledTimes(2);
+    expect(mocks.isAllowed).toHaveBeenNthCalledWith(1, PRE_AUTH_KEY);
+    expect(mocks.isAllowed).toHaveBeenNthCalledWith(2, PRE_AUTH_KEY);
+    expect(mocks.authenticate).toHaveBeenCalledOnce();
+    expect(mocks.touchLastUsed).toHaveBeenCalledOnce();
+  });
+
+  it('retains the per-key limiter for valid tokens', async () => {
+    mocks.authenticate.mockResolvedValue({
+      id: 'key-id',
+      organizationId: 'org-id',
+      createdByProfileId: 'profile-id',
+      scopes: ['public_api:*']
+    });
+    mocks.isAllowed
+      .mockResolvedValueOnce({ allowed: true, remaining: 999, resetTime: Date.now() + 60_000 })
+      .mockResolvedValueOnce({ allowed: false, remaining: 0, resetTime: Date.now() + 60_000 });
+
+    const response = await requestWithToken('valid-key');
+
+    expect(response.status).toBe(429);
+    expect(mocks.isAllowed).toHaveBeenNthCalledWith(1, PRE_AUTH_KEY);
+    expect(mocks.isAllowed).toHaveBeenNthCalledWith(2, 'automation_key:key-id');
+    expect(mocks.authenticate).toHaveBeenCalledWith('valid-key');
+  });
+});

--- a/apps/api/src/routes/v1/index.test.ts
+++ b/apps/api/src/routes/v1/index.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Context, Next } from 'hono';
+import { PUBLIC_API_FAILED_AUTH_MAX_REQUESTS } from '@api/constants/rate-limiter';
 import { Hono } from '@api/utils/hono';
 
 const mocks = vi.hoisted(() => ({
   authenticate: vi.fn(),
-  getFailureStatus: vi.fn(),
   isAllowed: vi.fn(),
-  recordFailure: vi.fn(),
+  releaseFailure: vi.fn(),
+  reserveFailure: vi.fn(),
   touchLastUsed: vi.fn()
 }));
 
@@ -24,16 +25,16 @@ vi.mock('@api/middlewares/rate-limiter', () => ({
       }
 
       const key = options.keyGenerator(context);
-      const status = await mocks.getFailureStatus(key);
+      const reservation = await mocks.reserveFailure(key);
 
-      if (!status.allowed) {
+      if (!reservation.allowed) {
         return context.json({ error: 'Too Many Requests' }, 429);
       }
 
       await next();
 
-      if (!context.get('automationKey')) {
-        await mocks.recordFailure(key);
+      if (context.get('automationKey')) {
+        await mocks.releaseFailure(key, reservation.reservationId);
       }
     },
   createRateLimiter:
@@ -81,20 +82,24 @@ function requestWithToken(token?: string) {
 
 describe('public API rate limiting', () => {
   beforeEach(() => {
+    const defaultResetTime = Date.now() + 60_000;
+
     mocks.authenticate.mockReset();
-    mocks.getFailureStatus.mockReset();
     mocks.isAllowed.mockReset();
-    mocks.recordFailure.mockReset();
+    mocks.releaseFailure.mockReset();
+    mocks.reserveFailure.mockReset();
     mocks.touchLastUsed.mockReset();
-    mocks.getFailureStatus.mockResolvedValue({
+    mocks.reserveFailure.mockResolvedValue({
       allowed: true,
       remaining: 1000,
-      resetTime: Date.now() + 60_000
+      reservationId: 'failure-reservation',
+      resetTime: defaultResetTime
     });
     mocks.isAllowed.mockResolvedValue({
       allowed: true,
       remaining: 999,
-      resetTime: Date.now() + 60_000
+      reservationId: 'per-key-reservation',
+      resetTime: defaultResetTime
     });
   });
 
@@ -102,30 +107,36 @@ describe('public API rate limiting', () => {
     const unauthorizedResponse = await requestWithToken();
 
     expect(unauthorizedResponse.status).toBe(401);
-    expect(mocks.getFailureStatus).not.toHaveBeenCalled();
-    expect(mocks.recordFailure).not.toHaveBeenCalled();
+    expect(mocks.reserveFailure).not.toHaveBeenCalled();
+    expect(mocks.releaseFailure).not.toHaveBeenCalled();
     expect(mocks.authenticate).not.toHaveBeenCalled();
   });
 
-  it('records invalid tokens and blocks another authentication lookup after the budget is exhausted', async () => {
+  it('keeps reservations for invalid tokens and blocks another authentication lookup when exhausted', async () => {
     mocks.authenticate.mockRejectedValue(new Error('Invalid organization API key'));
 
     const unauthorizedResponse = await requestWithToken('invalid-key');
 
     expect(unauthorizedResponse.status).toBe(401);
     expect(mocks.authenticate).toHaveBeenCalledOnce();
-    expect(mocks.recordFailure).toHaveBeenCalledWith(FAILED_AUTH_KEY);
+    expect(mocks.releaseFailure).not.toHaveBeenCalled();
 
-    mocks.getFailureStatus.mockResolvedValueOnce({ allowed: false, remaining: 0, resetTime: Date.now() + 60_000 });
+    const exhaustedLimitResetTime = Date.now() + 60_000;
+    mocks.reserveFailure.mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      reservationId: 'exhausted-reservation',
+      resetTime: exhaustedLimitResetTime
+    });
 
     const limitedResponse = await requestWithToken('invalid-key');
 
     expect(limitedResponse.status).toBe(429);
-    expect(mocks.getFailureStatus).toHaveBeenCalledTimes(2);
-    expect(mocks.getFailureStatus).toHaveBeenNthCalledWith(1, FAILED_AUTH_KEY);
-    expect(mocks.getFailureStatus).toHaveBeenNthCalledWith(2, FAILED_AUTH_KEY);
+    expect(mocks.reserveFailure).toHaveBeenCalledTimes(2);
+    expect(mocks.reserveFailure).toHaveBeenNthCalledWith(1, FAILED_AUTH_KEY);
+    expect(mocks.reserveFailure).toHaveBeenNthCalledWith(2, FAILED_AUTH_KEY);
     expect(mocks.authenticate).toHaveBeenCalledOnce();
-    expect(mocks.recordFailure).toHaveBeenCalledOnce();
+    expect(mocks.releaseFailure).not.toHaveBeenCalled();
   });
 
   it('does not consume the failed-authentication budget for an authenticated out-of-scope key', async () => {
@@ -141,8 +152,8 @@ describe('public API rate limiting', () => {
     expect(forbiddenResponse.status).toBe(403);
     expect(mocks.authenticate).toHaveBeenCalledOnce();
     expect(mocks.touchLastUsed).toHaveBeenCalledOnce();
-    expect(mocks.getFailureStatus).toHaveBeenCalledWith(FAILED_AUTH_KEY);
-    expect(mocks.recordFailure).not.toHaveBeenCalled();
+    expect(mocks.reserveFailure).toHaveBeenCalledWith(FAILED_AUTH_KEY);
+    expect(mocks.releaseFailure).toHaveBeenCalledWith(FAILED_AUTH_KEY, 'failure-reservation');
   });
 
   it('retains the per-key limiter for valid tokens', async () => {
@@ -152,15 +163,51 @@ describe('public API rate limiting', () => {
       createdByProfileId: 'profile-id',
       scopes: ['public_api:*']
     });
-    mocks.isAllowed.mockResolvedValueOnce({ allowed: false, remaining: 0, resetTime: Date.now() + 60_000 });
+    const perKeyResetTime = Date.now() + 60_000;
+    mocks.isAllowed.mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      reservationId: 'per-key-reservation',
+      resetTime: perKeyResetTime
+    });
 
     const response = await requestWithToken('valid-key');
 
     expect(response.status).toBe(429);
-    expect(mocks.getFailureStatus).toHaveBeenCalledWith(FAILED_AUTH_KEY);
-    expect(mocks.recordFailure).not.toHaveBeenCalled();
+    expect(mocks.reserveFailure).toHaveBeenCalledWith(FAILED_AUTH_KEY);
+    expect(mocks.releaseFailure).toHaveBeenCalledWith(FAILED_AUTH_KEY, 'failure-reservation');
     expect(mocks.isAllowed).toHaveBeenCalledOnce();
     expect(mocks.isAllowed).toHaveBeenCalledWith('automation_key:key-id');
     expect(mocks.authenticate).toHaveBeenCalledWith('valid-key');
+  });
+
+  it('atomically bounds concurrent invalid-token authentication attempts', async () => {
+    let reservedFailures = 0;
+    const concurrentResetTime = Date.now() + 60_000;
+    mocks.authenticate.mockRejectedValue(new Error('Invalid organization API key'));
+    mocks.reserveFailure.mockImplementation(async () => {
+      const allowed = reservedFailures < PUBLIC_API_FAILED_AUTH_MAX_REQUESTS;
+      reservedFailures += 1;
+      const remaining = Math.max(0, PUBLIC_API_FAILED_AUTH_MAX_REQUESTS - reservedFailures);
+      const reservationId = `failure-reservation-${reservedFailures}`;
+
+      return {
+        allowed,
+        remaining,
+        reservationId,
+        resetTime: concurrentResetTime
+      };
+    });
+
+    const requests = Array.from({ length: PUBLIC_API_FAILED_AUTH_MAX_REQUESTS + 1 }, () =>
+      requestWithToken('invalid-key')
+    );
+    const responses = await Promise.all(requests);
+    const responseStatuses = responses.map((response) => response.status);
+
+    expect(responseStatuses.filter((status) => status === 401)).toHaveLength(PUBLIC_API_FAILED_AUTH_MAX_REQUESTS);
+    expect(responseStatuses.filter((status) => status === 429)).toHaveLength(1);
+    expect(mocks.authenticate).toHaveBeenCalledTimes(PUBLIC_API_FAILED_AUTH_MAX_REQUESTS);
+    expect(mocks.releaseFailure).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -1,10 +1,14 @@
-import { DEFAULT_MAX_REQUESTS, DEFAULT_WINDOW_MS, PUBLIC_API_PRE_AUTH_MAX_REQUESTS } from '@api/constants/rate-limiter';
+import {
+  DEFAULT_MAX_REQUESTS,
+  DEFAULT_WINDOW_MS,
+  PUBLIC_API_FAILED_AUTH_MAX_REQUESTS
+} from '@api/constants/rate-limiter';
 import { Hono } from '@api/utils/hono';
 import { automationKeyMiddleware } from '@api/middlewares/automation-key';
 import { automationKeyScopesMiddleware } from '@api/middlewares/automation-key-scopes';
-import { createRateLimiter } from '@api/middlewares/rate-limiter';
+import { createAuthenticationFailureRateLimiter, createRateLimiter } from '@api/middlewares/rate-limiter';
 import { publicApiCors } from '@api/middlewares/cors';
-import { publicApiIpKeyGenerator, publicApiKeyGenerator } from '@api/utils/redis/key-generators';
+import { publicApiFailedAuthKeyGenerator, publicApiKeyGenerator } from '@api/utils/redis/key-generators';
 import { v1AudienceRouter } from './audience';
 import { v1CoursesRouter } from './courses';
 
@@ -12,10 +16,10 @@ export const v1Router = new Hono()
   .use('*', publicApiCors)
   .use(
     '*',
-    createRateLimiter({
-      maxRequests: PUBLIC_API_PRE_AUTH_MAX_REQUESTS,
+    createAuthenticationFailureRateLimiter({
+      maxRequests: PUBLIC_API_FAILED_AUTH_MAX_REQUESTS,
       windowMs: DEFAULT_WINDOW_MS,
-      keyGenerator: publicApiIpKeyGenerator
+      keyGenerator: publicApiFailedAuthKeyGenerator
     })
   )
   .use('*', automationKeyMiddleware)

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/node';
-
 import { DEFAULT_MAX_REQUESTS, DEFAULT_WINDOW_MS } from '@api/constants/rate-limiter';
 import { Hono } from '@api/utils/hono';
 import { automationKeyMiddleware } from '@api/middlewares/automation-key';
@@ -7,7 +5,6 @@ import { automationKeyScopesMiddleware } from '@api/middlewares/automation-key-s
 import { createRateLimiter } from '@api/middlewares/rate-limiter';
 import { publicApiCors } from '@api/middlewares/cors';
 import { publicApiKeyGenerator } from '@api/utils/redis/key-generators';
-import { ErrorCodes, handlePublicApiError } from '@api/utils/errors';
 import { v1AudienceRouter } from './audience';
 import { v1CoursesRouter } from './courses';
 

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -1,9 +1,27 @@
+import * as Sentry from '@sentry/node';
+
+import { DEFAULT_MAX_REQUESTS, DEFAULT_WINDOW_MS } from '@api/constants/rate-limiter';
 import { Hono } from '@api/utils/hono';
+import { automationKeyMiddleware } from '@api/middlewares/automation-key';
+import { automationKeyScopesMiddleware } from '@api/middlewares/automation-key-scopes';
+import { createRateLimiter } from '@api/middlewares/rate-limiter';
 import { publicApiCors } from '@api/middlewares/cors';
+import { publicApiKeyGenerator } from '@api/utils/redis/key-generators';
+import { ErrorCodes, handlePublicApiError } from '@api/utils/errors';
 import { v1AudienceRouter } from './audience';
 import { v1CoursesRouter } from './courses';
 
 export const v1Router = new Hono()
   .use('*', publicApiCors)
+  .use('*', automationKeyMiddleware)
+  .use('*', automationKeyScopesMiddleware(['public_api:*']))
+  .use(
+    '*',
+    createRateLimiter({
+      maxRequests: DEFAULT_MAX_REQUESTS,
+      windowMs: DEFAULT_WINDOW_MS,
+      keyGenerator: publicApiKeyGenerator
+    })
+  )
   .route('/audience', v1AudienceRouter)
   .route('/courses', v1CoursesRouter);

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -1,15 +1,23 @@
-import { DEFAULT_MAX_REQUESTS, DEFAULT_WINDOW_MS } from '@api/constants/rate-limiter';
+import { DEFAULT_MAX_REQUESTS, DEFAULT_WINDOW_MS, PUBLIC_API_PRE_AUTH_MAX_REQUESTS } from '@api/constants/rate-limiter';
 import { Hono } from '@api/utils/hono';
 import { automationKeyMiddleware } from '@api/middlewares/automation-key';
 import { automationKeyScopesMiddleware } from '@api/middlewares/automation-key-scopes';
 import { createRateLimiter } from '@api/middlewares/rate-limiter';
 import { publicApiCors } from '@api/middlewares/cors';
-import { publicApiKeyGenerator } from '@api/utils/redis/key-generators';
+import { publicApiIpKeyGenerator, publicApiKeyGenerator } from '@api/utils/redis/key-generators';
 import { v1AudienceRouter } from './audience';
 import { v1CoursesRouter } from './courses';
 
 export const v1Router = new Hono()
   .use('*', publicApiCors)
+  .use(
+    '*',
+    createRateLimiter({
+      maxRequests: PUBLIC_API_PRE_AUTH_MAX_REQUESTS,
+      windowMs: DEFAULT_WINDOW_MS,
+      keyGenerator: publicApiIpKeyGenerator
+    })
+  )
   .use('*', automationKeyMiddleware)
   .use('*', automationKeyScopesMiddleware(['public_api:*']))
   .use(

--- a/apps/api/src/utils/redis/key-generators.ts
+++ b/apps/api/src/utils/redis/key-generators.ts
@@ -80,6 +80,16 @@ export const apiKeyGenerator = (c: Context): string => {
   return `ip:${extractClientIp(c)}`;
 };
 
+export const publicApiKeyGenerator = (c: Context): string => {
+  const automationKey = c.get('automationKey') as { id: string } | undefined;
+
+  if (automationKey?.id) {
+    return `automation_key:${automationKey.id}`;
+  }
+
+  return `ip:${extractClientIp(c)}`;
+};
+
 /**
  * Generate rate limit key based on IP only
  */

--- a/apps/api/src/utils/redis/key-generators.ts
+++ b/apps/api/src/utils/redis/key-generators.ts
@@ -90,6 +90,10 @@ export const publicApiKeyGenerator = (c: Context): string => {
   return `ip:${extractClientIp(c)}`;
 };
 
+export const publicApiIpKeyGenerator = (c: Context): string => {
+  return `public_api_ip:${extractClientIp(c)}`;
+};
+
 /**
  * Generate rate limit key based on IP only
  */

--- a/apps/api/src/utils/redis/key-generators.ts
+++ b/apps/api/src/utils/redis/key-generators.ts
@@ -90,8 +90,8 @@ export const publicApiKeyGenerator = (c: Context): string => {
   return `ip:${extractClientIp(c)}`;
 };
 
-export const publicApiIpKeyGenerator = (c: Context): string => {
-  return `public_api_ip:${extractClientIp(c)}`;
+export const publicApiFailedAuthKeyGenerator = (c: Context): string => {
+  return `public_api_failed_auth:${extractClientIp(c)}`;
 };
 
 /**

--- a/apps/api/src/utils/redis/limiter.ts
+++ b/apps/api/src/utils/redis/limiter.ts
@@ -10,6 +10,7 @@ import { redis, type RedisClient } from '@cio/core/utils/redis/redis';
 export interface RateLimitResult {
   allowed: boolean;
   remaining: number;
+  reservationId: string;
   resetTime: number;
 }
 
@@ -24,34 +25,11 @@ export class RedisRateLimiter {
     this.maxRequests = maxRequests;
   }
 
-  async getStatus(key: string): Promise<RateLimitResult> {
-    const now = Date.now();
-    const windowStart = now - this.windowMs;
-    const keyWithPrefix = `${RATE_LIMIT_KEY_PREFIX}${key}`;
-    const multi = this.redis.multi();
-
-    multi.zRemRangeByScore(keyWithPrefix, '-inf', windowStart);
-    multi.zCard(keyWithPrefix);
-
-    const results = await multi.exec();
-
-    if (!results || results.some((result) => result === null)) {
-      throw new Error(ERROR_MESSAGES.REDIS_PIPELINE_FAILED);
-    }
-
-    const currentCount = results[1] as number;
-
-    return {
-      allowed: currentCount < this.maxRequests,
-      remaining: Math.max(0, this.maxRequests - currentCount),
-      resetTime: now + this.windowMs
-    };
-  }
-
   async isAllowed(key: string): Promise<RateLimitResult> {
     const now = Date.now();
     const windowStart = now - this.windowMs;
     const keyWithPrefix = `${RATE_LIMIT_KEY_PREFIX}${key}`;
+    const reservationId = `${now}-${Math.random()}`;
 
     // Use Redis multi (transaction) for atomic operations
     const multi = this.redis.multi();
@@ -63,7 +41,7 @@ export class RedisRateLimiter {
     multi.zCard(keyWithPrefix);
 
     // Add current request
-    multi.zAdd(keyWithPrefix, { score: now, value: `${now}-${Math.random()}` });
+    multi.zAdd(keyWithPrefix, { score: now, value: reservationId });
 
     // Set expiration for the key
     multi.expire(keyWithPrefix, Math.ceil(this.windowMs / 1000));
@@ -83,8 +61,14 @@ export class RedisRateLimiter {
     return {
       allowed: currentCount < this.maxRequests,
       remaining,
+      reservationId,
       resetTime
     };
+  }
+
+  async release(key: string, reservationId: string): Promise<void> {
+    const keyWithPrefix = `${RATE_LIMIT_KEY_PREFIX}${key}`;
+    await this.redis.zRem(keyWithPrefix, reservationId);
   }
 
   async reset(key: string): Promise<void> {

--- a/apps/api/src/utils/redis/limiter.ts
+++ b/apps/api/src/utils/redis/limiter.ts
@@ -7,6 +7,12 @@ import {
 
 import { redis, type RedisClient } from '@cio/core/utils/redis/redis';
 
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetTime: number;
+}
+
 export class RedisRateLimiter {
   private redis: RedisClient;
   private windowMs: number;
@@ -18,7 +24,31 @@ export class RedisRateLimiter {
     this.maxRequests = maxRequests;
   }
 
-  async isAllowed(key: string): Promise<{ allowed: boolean; remaining: number; resetTime: number }> {
+  async getStatus(key: string): Promise<RateLimitResult> {
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+    const keyWithPrefix = `${RATE_LIMIT_KEY_PREFIX}${key}`;
+    const multi = this.redis.multi();
+
+    multi.zRemRangeByScore(keyWithPrefix, '-inf', windowStart);
+    multi.zCard(keyWithPrefix);
+
+    const results = await multi.exec();
+
+    if (!results || results.some((result) => result === null)) {
+      throw new Error(ERROR_MESSAGES.REDIS_PIPELINE_FAILED);
+    }
+
+    const currentCount = results[1] as number;
+
+    return {
+      allowed: currentCount < this.maxRequests,
+      remaining: Math.max(0, this.maxRequests - currentCount),
+      resetTime: now + this.windowMs
+    };
+  }
+
+  async isAllowed(key: string): Promise<RateLimitResult> {
     const now = Date.now();
     const windowStart = now - this.windowMs;
     const keyWithPrefix = `${RATE_LIMIT_KEY_PREFIX}${key}`;

--- a/packages/utils/src/openapi/public-api.ts
+++ b/packages/utils/src/openapi/public-api.ts
@@ -37,7 +37,7 @@ Requests to this API are rate limited per API key: **100 requests per minute** p
 
 Two caveats to be aware of:
 
-- Rate limiting is only enforced in production (\`NODE_ENV=production\`); development and self-hosted deployments do not enforce a budget.
+- Rate limiting is only enforced when the API runs with NODE_ENV=production; it is disabled in development and test environments. This applies regardless of hosting a self-hosted production deployment with Redis available does enforce the per-key budget.
 - If the shared Redis store is unavailable, requests are served without rate limiting (fail open).
 
 ## Plan access

--- a/packages/utils/src/openapi/public-api.ts
+++ b/packages/utils/src/openapi/public-api.ts
@@ -31,6 +31,15 @@ Base URL: \`${PUBLIC_API_BASE_URL}\`
 
 Use the **Authorize** button (lock icon) on this page, choose **bearerAuth**, paste your full API key, then run **Try it** on any endpoint.
 
+## Rate limits
+
+Requests to this API are rate limited per API key: **100 requests per minute** per key. A separate API key has its own budget, so traffic from one key does not affect another. Requests over the limit receive a \`429 Too Many Requests\` response with a \`Retry-After\` header.
+
+Two caveats to be aware of:
+
+- Rate limiting is only enforced in production (\`NODE_ENV=production\`); development and self-hosted deployments do not enforce a budget.
+- If the shared Redis store is unavailable, requests are served without rate limiting (fail open).
+
 ## Plan access
 
 > **Paid Access** — On ClassroomIO Cloud, API key creation is available on **Early Adopter** and **Enterprise** plans. Self-hosted deployments require **Enterprise**.


### PR DESCRIPTION
## What does this PR do?

Fixes the public API (/public-api/v1/*) rate limiter being keyed by IP instead of by API key.

Root cause: the global limiter (app.ts:105) is keyed via userKeyGenerator, which falls back to ip:{address} when there's no session user. Public API callers authenticate with Bearer API keys and never set a session cookie (the global middleware explicitly nulls user for /public-api/ paths), so every key behind the same egress IP shared a single 100 req/60s bucket, while a single key across many IPs got an inflated limit.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #804 

<!-- Please provide a screenshots or upload a video for visual changes to speed up reviews -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Run the API in production mode (NODE_ENV=production) with Redis up.

- Test A: Create two API keys in the same org (or two orgs). Send GET /public-api/v1/courses with both keys from the same IP behind the same NAT/proxy. Each key should get its own 100 req/min budget; exceed the limit with key A and key B should still succeed (and vice versa). Over-limit requests return 429 with a Retry-After header, and the X-RateLimit-* headers reflect the per-key budget.

- Test B: Send a request with a missing/invalid Bearer key → expect 401 and confirm it does not decrement the per-key budget.

- Test C: Regenerate the OpenAPI spec (pnpm upload:openapi) and confirm the "Rate limits" section appears in dist/openapi/public-api/openapi.json.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API endpoints now require API-key authentication and the appropriate access scope.
  * Added per-key rate limits of 100 requests per minute.
  * Added protection against repeated failed authentication attempts based on client IP.
  * Rate-limited responses include retry guidance through standard response headers.
  * Rate limiting continues allowing requests when the supporting service is unavailable.
* **Documentation**
  * Updated public API documentation with rate limits, `429` responses, production-only enforcement, and service availability behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes public API rate limiting to authenticated API keys and separately limits failed authentication attempts.
- Adds per-key request budgets after API-key authentication and scope validation.
- Adds IP-based throttling for missing or invalid authentication attempts.
- Updates public API routes, tests, Redis limiter utilities, and OpenAPI rate-limit documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/v1/index.ts | Composes failed-authentication throttling before API-key authentication and per-key throttling afterward; the previously reported unused imports are absent. |
| apps/api/src/middlewares/rate-limiter.ts | Adds middleware support for distinct authenticated-request and authentication-failure rate limits. |
| apps/api/src/utils/redis/key-generators.ts | Adds separate key generation for authenticated API keys and failed authentication attempts. |
| apps/api/src/utils/redis/limiter.ts | Updates Redis-backed limiter behavior used by the public API middleware. |
| apps/api/src/routes/v1/index.test.ts | Adds coverage for the revised public API authentication and rate-limiting pipeline. |
| packages/utils/src/openapi/public-api.ts | Documents per-key limits, production-only enforcement, and fail-open behavior; the self-hosted caveat now states that production deployments with Redis enforce the budget. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Client
  participant AuthLimit as Failed-auth limiter
  participant Auth as API-key authentication
  participant KeyLimit as Per-key limiter
  participant Route as Public API route
  Client->>AuthLimit: Request
  AuthLimit->>Auth: Allowed authentication attempt
  Auth->>KeyLimit: Valid scoped API key
  KeyLimit->>Route: Per-key budget available
  Route-->>Client: API response
```

<sub>Reviews (6): Last reviewed commit: ["fix(api): count missing authentication a..."](https://github.com/classroomio/classroomio/commit/48eb34175232c97abfce1b3bb018e919b8820121) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49071026)</sub>

**Context used:**

- Knowledge Base — [Platform backend](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/platform-backend.md)
- Knowledge Base — [API request handling](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/api-request-handling.md)

<!-- /greptile_comment -->