### PR TITLE
fix(ui): show disabled state on course landing hero CTA

### DIFF
--- a/packages/ui/src/custom/org-landing-page/course-primary-action.svelte
+++ b/packages/ui/src/custom/org-landing-page/course-primary-action.svelte
@@ -1,24 +1,39 @@
 <script lang="ts">
-  import { Button, type ButtonVariant } from '../../base/button';
+  import { cn } from '../../tools';
+  import LandingButton from './landing-button.svelte';
   import type { LandingPrimaryAction } from './types';
+
+  type LandingButtonVariant = 'primary' | 'secondary' | 'tertiary';
+  type LandingButtonSize = 'sm' | 'md' | 'lg';
 
   interface Props {
     action: LandingPrimaryAction;
     size?: 'default' | 'sm' | 'lg';
-    variant?: ButtonVariant;
+    variant?: LandingButtonVariant;
     class?: string;
   }
 
-  let { action, size = 'default', variant = 'default', class: className = '' }: Props = $props();
+  let { action, size = 'default', variant = 'primary', class: className = '' }: Props = $props();
+
+  const landingSize = $derived<LandingButtonSize>(size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : 'md');
+  const isDisabled = $derived(action.disabled ?? false);
+
+  const disabledClass = $derived(
+    variant === 'secondary'
+      ? 'ui:!bg-[var(--landing-button-secondary-bg)] ui:!text-[var(--landing-button-secondary-fg)] ui:hover:!bg-[var(--landing-button-secondary-bg)]'
+      : variant === 'tertiary'
+        ? 'ui:!bg-transparent ui:!text-[var(--landing-button-tertiary-fg)] ui:hover:!bg-transparent'
+        : 'ui:!bg-[var(--landing-button-primary-bg)] ui:!text-[var(--landing-button-primary-fg)] ui:hover:!bg-[var(--landing-button-primary-bg)]'
+  );
 </script>
 
-<Button
+<LandingButton
+  {variant}
+  size={landingSize}
   href={action.onclick ? undefined : action.href}
   onclick={action.onclick}
-  disabled={action.disabled ?? false}
-  {size}
-  {variant}
-  class={className}
+  disabled={isDisabled}
+  class={cn(className, isDisabled && disabledClass)}
 >
   {action.label}
-</Button>
+</LandingButton>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On paid course landing pages where enrollment is closed, the pricing **Buy Now** button correctly appears disabled (muted gray), but the hero **Buy Now** button still looks active (solid black in the editorial theme).

Both CTAs already shared the same `disabled` flag — the hero just didn't reflect it visually because `CoursePrimaryAction` used the base `Button` with per-theme color classes (`bg-[var(--landing-fg)]`, etc.) that overrode the disabled opacity styling.

## Fix

- Switch `CoursePrimaryAction` to use `LandingButton` (same component as the pricing CTA)
- When disabled, reset theme color overrides to the landing button CSS variables so the muted/disabled appearance matches pricing

## Testing

- `pnpm --filter @cio/ui prefix:check:staged`
- `pnpm --filter @cio/ui build`
- `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17aa0bf6-d250-48e6-b8fd-31f8c98cd2b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17aa0bf6-d250-48e6-b8fd-31f8c98cd2b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the course landing hero CTA to use the shared landing-page button and applies variant-specific theme colors when disabled.
- Maps the existing hero CTA sizes and variants to `LandingButton`.
- Preserves href, click-handler, and disabled behavior.
- Ensures disabled hero CTAs use landing-theme colors together with the shared disabled opacity and cursor styling.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the disabled hero CTA now using the same landing-button behavior as the pricing CTA.

Current callers use compatible variants and sizes, while disabled links and click actions become native disabled buttons with the intended themed appearance.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/custom/org-landing-page/course-primary-action.svelte | Replaces the base button with `LandingButton`, maps compatible props, and adds disabled-state theme classes without introducing an actionable defect. |

<sub>Reviews (1): Last reviewed commit: ["fix(ui): show disabled state on course l..."](https://github.com/classroomio/classroomio/commit/98d6b83f14790e8720d5a4cc1649f70f2a735fd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49364759)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the course landing page action button with consistent landing-page styling.
  * Added clearer disabled-state behavior and styling.
  * Preserved custom classes while applying the appropriate button appearance and size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->