### PR TITLE
fix(dashboard): persist notification preferences after save

### DIFF
--- a/apps/dashboard/src/lib/features/settings/pages/notifications.svelte
+++ b/apps/dashboard/src/lib/features/settings/pages/notifications.svelte
@@ -78,10 +78,8 @@
 
     const result = await memberEmailNotificationsApi.fetch();
 
-    if (loadVersion !== personalLoadVersion) {
-      isLoadingPersonal = false;
-      return;
-    }
+    // A newer load or a save started while this request was in flight — it owns the state now.
+    if (loadVersion !== personalLoadVersion) return;
 
     if (result?.data) {
       applyPersonalToggleState(result.data);
@@ -95,7 +93,6 @@
 
     if (!orgId) return;
 
-    personalLoadVersion++;
     void loadPersonalPreferences();
   });
 
@@ -176,16 +173,14 @@
     if (!$currentOrg) return;
 
     isSavingOrg = true;
-    const existingSettings = ($currentOrg.settings as Record<string, unknown>) || {};
     const emailNotifications = toStoredPreferences(EMAIL_NOTIFICATION_TOGGLE_KEYS, orgToggles);
 
+    // The API deep-merges `settings`, so only send the key being changed —
+    // spreading local settings here could write stale values over other keys.
     await orgApi.update(
       $currentOrg.id,
       {
-        settings: {
-          ...existingSettings,
-          emailNotifications
-        }
+        settings: { emailNotifications }
       },
       {
         onSuccess: () => {

--- a/apps/dashboard/src/lib/features/settings/pages/notifications.svelte
+++ b/apps/dashboard/src/lib/features/settings/pages/notifications.svelte
@@ -29,6 +29,7 @@
   let isSavingOrg = $state(false);
   let isLoadingPersonal = $state(false);
   let personalLoadVersion = 0;
+  let lastHydratedOrgId: string | null = null;
 
   interface Props {
     hasUnsavedChanges?: boolean;
@@ -96,17 +97,17 @@
     void loadPersonalPreferences();
   });
 
+  // Org defaults hydrate once per organization. `/account` returns `settings`
+  // together with the org id and role, so an id transition never misses
+  // late-arriving settings — and unsaved edits from another org are discarded
+  // instead of being saved against the wrong organization.
   $effect(() => {
-    if (!$isOrgAdmin || !$currentOrg?.id) return;
+    const orgId = $isOrgAdmin ? $currentOrg?.id : null;
 
-    if (orgHasChanges) return;
+    if (!orgId || orgId === lastHydratedOrgId) return;
 
-    const next = buildToggleState(EMAIL_NOTIFICATION_TOGGLE_KEYS, $currentOrg.settings?.emailNotifications);
-    const alreadySynced = EMAIL_NOTIFICATION_TOGGLE_KEYS.every((key) => savedOrgToggles[key] === next[key]);
-
-    if (alreadySynced) return;
-
-    applyOrgToggleState($currentOrg.settings?.emailNotifications);
+    lastHydratedOrgId = orgId;
+    applyOrgToggleState($currentOrg?.settings?.emailNotifications);
   });
 
   const personalHasChanges = $derived(

--- a/apps/dashboard/src/lib/features/settings/pages/notifications.svelte
+++ b/apps/dashboard/src/lib/features/settings/pages/notifications.svelte
@@ -16,8 +16,6 @@
   import { Switch } from '@cio/ui/base/switch';
   import BellIcon from '@lucide/svelte/icons/bell';
   import Building2Icon from '@lucide/svelte/icons/building-2';
-  import { onMount } from 'svelte';
-  import { get } from 'svelte/store';
 
   function buildToggleState<T extends string>(keys: readonly T[], source?: Partial<Record<T, boolean>> | null) {
     return Object.fromEntries(keys.map((key) => [key, source?.[key] !== false])) as Record<T, boolean>;
@@ -26,10 +24,11 @@
   let personalToggles = $state(buildToggleState(PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS));
   let savedPersonalToggles = $state(buildToggleState(PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS));
   let orgToggles = $state(buildToggleState(EMAIL_NOTIFICATION_TOGGLE_KEYS));
+  let savedOrgToggles = $state(buildToggleState(EMAIL_NOTIFICATION_TOGGLE_KEYS));
   let isSavingPersonal = $state(false);
   let isSavingOrg = $state(false);
   let isLoadingPersonal = $state(false);
-  let hasHydratedOrgToggles = $state(false);
+  let personalLoadVersion = 0;
 
   interface Props {
     hasUnsavedChanges?: boolean;
@@ -63,24 +62,26 @@
     }
   }
 
-  function syncOrgTogglesFromCurrentOrg() {
-    const org = get(currentOrg);
-
-    if (!org) return;
-
-    const next = buildToggleState(EMAIL_NOTIFICATION_TOGGLE_KEYS, org.settings?.emailNotifications);
+  function applyOrgToggleState(source?: Partial<Record<string, boolean>> | null) {
+    const next = buildToggleState(EMAIL_NOTIFICATION_TOGGLE_KEYS, source);
 
     for (const key of EMAIL_NOTIFICATION_TOGGLE_KEYS) {
       orgToggles[key] = next[key];
+      savedOrgToggles[key] = next[key];
     }
   }
 
   async function loadPersonalPreferences() {
-    if (!$currentOrg?.id) return;
+    const loadVersion = ++personalLoadVersion;
 
     isLoadingPersonal = true;
 
     const result = await memberEmailNotificationsApi.fetch();
+
+    if (loadVersion !== personalLoadVersion) {
+      isLoadingPersonal = false;
+      return;
+    }
 
     if (result?.data) {
       applyPersonalToggleState(result.data);
@@ -89,35 +90,26 @@
     isLoadingPersonal = false;
   }
 
-  function tryHydrateOrgToggles() {
-    if (hasHydratedOrgToggles || !get(isOrgAdmin)) return;
-
-    if (!get(currentOrg)?.id) return;
-
-    syncOrgTogglesFromCurrentOrg();
-    hasHydratedOrgToggles = true;
-  }
-
-  onMount(() => {
-    tryHydrateOrgToggles();
-  });
-
   $effect(() => {
     const orgId = $currentOrg?.id;
 
     if (!orgId) return;
 
+    personalLoadVersion++;
     void loadPersonalPreferences();
   });
 
   $effect(() => {
-    if (hasHydratedOrgToggles) return;
+    if (!$isOrgAdmin || !$currentOrg?.id) return;
 
-    const orgId = $isOrgAdmin ? $currentOrg?.id : null;
+    if (orgHasChanges) return;
 
-    if (!orgId) return;
+    const next = buildToggleState(EMAIL_NOTIFICATION_TOGGLE_KEYS, $currentOrg.settings?.emailNotifications);
+    const alreadySynced = EMAIL_NOTIFICATION_TOGGLE_KEYS.every((key) => savedOrgToggles[key] === next[key]);
 
-    tryHydrateOrgToggles();
+    if (alreadySynced) return;
+
+    applyOrgToggleState($currentOrg.settings?.emailNotifications);
   });
 
   const personalHasChanges = $derived(
@@ -125,9 +117,7 @@
   );
 
   const orgHasChanges = $derived(
-    EMAIL_NOTIFICATION_TOGGLE_KEYS.some(
-      (key) => orgToggles[key] !== ($currentOrg?.settings?.emailNotifications?.[key] !== false)
-    )
+    EMAIL_NOTIFICATION_TOGGLE_KEYS.some((key) => orgToggles[key] !== savedOrgToggles[key])
   );
 
   $effect(() => {
@@ -146,7 +136,11 @@
 
   export function handleDiscard() {
     applyPersonalToggleState(savedPersonalToggles);
-    syncOrgTogglesFromCurrentOrg();
+
+    for (const key of EMAIL_NOTIFICATION_TOGGLE_KEYS) {
+      orgToggles[key] = savedOrgToggles[key];
+    }
+
     hasUnsavedChanges = false;
   }
 
@@ -164,6 +158,7 @@
     if (!$currentOrg?.id) return;
 
     isSavingPersonal = true;
+    personalLoadVersion++;
 
     const result = await memberEmailNotificationsApi.update(
       toStoredPreferences(PERSONAL_EMAIL_NOTIFICATION_TOGGLE_KEYS, personalToggles)
@@ -182,18 +177,26 @@
 
     isSavingOrg = true;
     const existingSettings = ($currentOrg.settings as Record<string, unknown>) || {};
+    const emailNotifications = toStoredPreferences(EMAIL_NOTIFICATION_TOGGLE_KEYS, orgToggles);
 
     await orgApi.update(
       $currentOrg.id,
       {
         settings: {
           ...existingSettings,
-          emailNotifications: toStoredPreferences(EMAIL_NOTIFICATION_TOGGLE_KEYS, orgToggles)
+          emailNotifications
         }
       },
       {
         onSuccess: () => {
-          syncOrgTogglesFromCurrentOrg();
+          currentOrg.update((org) => ({
+            ...org,
+            settings: {
+              ...(org.settings as Record<string, unknown> | undefined),
+              emailNotifications
+            }
+          }));
+          applyOrgToggleState(emailNotifications);
           snackbar.success(t.get('settings.notifications.org.save_success'));
         }
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the notification settings page, toggling personal preferences off and clicking Save could reset all toggles back on and show **"Organization notification defaults saved"** instead of applying the user's personal choices.

## Root cause

Three interacting bugs in `notifications.svelte`:

1. **Stale personal-prefs fetch overwrote saved state** — The page loads personal preferences on mount. If that GET completed *after* a successful PUT save, it reapplied the old defaults and wiped the user's toggles.

2. **Spurious org save** — `orgHasChanges` compared `orgToggles` directly to `currentOrg.settings.emailNotifications`. Org toggles were hydrated once on mount, and `currentOrg` can be re-set by unrelated code paths with payloads missing `emailNotifications`. The live comparison then treated org defaults as "dirty" even when the user only edited personal toggles, so Save also ran the org save path and showed the org snackbar.

3. **Org save didn't update local state** — After org save, the UI re-synced from a stale `currentOrg` (because `orgApi.update` with a custom `onSuccess` skips updating the store), so the toggles reset.

## Fix

- Track `savedOrgToggles` and compare org changes against that baseline (same pattern as personal prefs).
- Hydrate org toggles once per organization, gated on `currentOrg.id` transitions — `/account` returns `settings` together with the org id and role, so settings never arrive late for the same id. Switching orgs re-hydrates, which also discards unsaved edits from the previous org instead of saving them against the wrong one.
- Version-guard personal preference loads and invalidate in-flight ones when a save starts, so stale GET responses can't overwrite saved state or clear the loading flag.
- After org save, update `currentOrg` and `savedOrgToggles` with the saved values.
- Send only `settings.emailNotifications` in the org update payload — the API deep-merges `settings` server-side, so spreading local settings risked clobbering unrelated keys with stale values.

## Verification

- `pnpm --filter @cio/dashboard^... build` and `pnpm --filter @cio/dashboard build` pass
- `pnpm format:check` passes
- CodeRabbit review comments addressed

## Manual test checklist

- [ ] As admin: toggle personal notifications off → Save → toggles stay off, personal success snackbar shown
- [ ] As admin: only change personal toggles → Save should not trigger org save snackbar
- [ ] As admin: change org defaults → Save → toggles stay as saved after reload
- [ ] As admin: switch orgs with unsaved org edits → new org's saved defaults are shown
- [ ] As student: toggle personal notifications off → Save → preferences persist
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c0dfb96-5c95-4846-9e5c-ee125c059976?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c0dfb96-5c95-4846-9e5c-ee125c059976&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification settings synchronization when switching between organizations.
  * Prevented outdated personal notification preferences from overwriting newer settings.
  * Ensured discard reliably restores saved personal and organization preferences.
  * Updated notification settings immediately after successful organization changes.
  * Improved unsaved-change tracking against the latest saved state.
  * Limited organization notification updates to email preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves persistence and synchronization of personal and organization notification preferences.
- Guards personal preference state against stale fetch responses.
- Tracks saved organization toggles as the dirty-state and discard baseline.
- Updates local organization state after successful saves while limiting the payload to notification settings.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge within the scope of this follow-up review.

No blocking failure remains in the eligible review scope.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/settings/pages/notifications.svelte | Adds request versioning, saved organization-toggle baselines, organization-aware hydration, and local state synchronization after notification preference saves. |

<sub>Reviews (3): Last reviewed commit: ["refactor(dashboard): hydrate org notific..."](https://github.com/classroomio/classroomio/commit/d80dfec06a6bf131fb426a7530ab7e96ee59f00c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49541013)</sub>

<!-- /greptile_comment -->