### PR TITLE
fix(ui): let Page.SettingsActions sticky bar escape its wrapper

### DIFF
--- a/packages/ui/src/base/page/page-settings-actions.svelte
+++ b/packages/ui/src/base/page/page-settings-actions.svelte
@@ -45,33 +45,36 @@
   });
 </script>
 
-<div bind:this={ref} class={cn('ui:shrink-0', className)} {...restProps}>
-  <div data-slot="page-settings-actions" class="ui:sticky ui:bottom-0 ui:z-10 ui:pb-4">
-    <div
-      class={cn(
-        'ui:flex ui:flex-col ui:gap-3 ui:sm:flex-row ui:sm:items-center ui:sm:justify-between',
-        'ui:rounded-lg ui:border ui:border-border ui:bg-background ui:p-4 ui:transition-shadow',
-        !isDocked && 'ui:shadow-md',
-        contentClassName
-      )}
-    >
-      <p class="ui:text-sm ui:text-muted-foreground">{statusLabel}</p>
+<div
+  bind:this={ref}
+  data-slot="page-settings-actions"
+  class={cn('ui:sticky ui:bottom-0 ui:z-50 ui:pb-4 ui:shrink-0', className)}
+  {...restProps}
+>
+  <div
+    class={cn(
+      'ui:flex ui:flex-col ui:gap-3 ui:sm:flex-row ui:sm:items-center ui:sm:justify-between',
+      'ui:rounded-lg ui:border ui:border-border ui:bg-background ui:p-4 ui:transition-shadow',
+      !isDocked && 'ui:shadow-md',
+      contentClassName
+    )}
+  >
+    <p class="ui:text-sm ui:text-muted-foreground">{statusLabel}</p>
 
-      <div class="ui:flex ui:shrink-0 ui:items-center ui:justify-end ui:gap-2">
-        <Button variant="ghost" type="button" disabled={actionsDisabled} onclick={onDiscard}>
-          {discardLabel}
-        </Button>
-        <Button type="button" {loading} disabled={actionsDisabled || disabled} onclick={onSave}>
-          {saveLabel}
-        </Button>
-      </div>
+    <div class="ui:flex ui:shrink-0 ui:items-center ui:justify-end ui:gap-2">
+      <Button variant="ghost" type="button" disabled={actionsDisabled} onclick={onDiscard}>
+        {discardLabel}
+      </Button>
+      <Button type="button" {loading} disabled={actionsDisabled || disabled} onclick={onSave}>
+        {saveLabel}
+      </Button>
     </div>
   </div>
-
-  <div
-    bind:this={dockSentinel}
-    data-slot="page-settings-actions-sentinel"
-    class="ui:h-px ui:shrink-0"
-    aria-hidden="true"
-  ></div>
 </div>
+
+<div
+  bind:this={dockSentinel}
+  data-slot="page-settings-actions-sentinel"
+  class="ui:h-px ui:shrink-0"
+  aria-hidden="true"
+></div>


### PR DESCRIPTION
## Problem

On settings pages the save/discard bar does not float while you scroll. It only shows up at the very bottom of the page, as a normal element in the flow.

## Cause

`Page.SettingsActions` nests the sticky bar inside an extra wrapper, together with the dock sentinel:

```svelte
<div bind:this={ref} class={cn('ui:shrink-0', className)} {...restProps}>
  <div data-slot="page-settings-actions" class="ui:sticky ui:bottom-0 ui:z-10 ui:pb-4">
```

A sticky element is constrained to its **containing block** — it can be offset, but never pushed outside its parent's box. That wrapper is only as tall as the bar plus a 1px sentinel, so the bar has about 1px of travel. It cannot reach the viewport, so it renders where it naturally sits: the end of the content.

Measured in headless Chrome, same CSS, only the nesting differs (viewport 713px, scrolled to 600):

| Structure | bar `rect.bottom` | On screen? |
| --- | --- | --- |
| wrapped in `shrink-0` div (before) | 2484 | no |
| sibling of `Page.Root` (after) | 713 — pinned to viewport bottom | yes |

## Fix

Render the bar and the sentinel as siblings, so the containing block becomes `Page.Root` and the bar has the whole page to travel over.

Also raises the bar from `z-10` to `z-50`. The editor root (`packages/ui/src/custom/editor/editor.svelte`) is `relative z-50`, so it painted over the bar on any settings page containing an editor — the course welcome email field is the visible case. Matching `50` rather than exceeding it wins the tie on DOM order, while keeping body-portaled dialogs and sheets (`z-50`, appended later) above the bar.

## Verification

Headless Chrome, replicating the emitted classes. Pinned at every scroll position, un-pins only at the end, and the sentinel flips exactly when it docks so the shadow tracks the floating state:

```
viewportHeight=713
top:          scrollY=0    barBottom=713 pinned=true  sentinelVisible=false
mid:          scrollY=600  barBottom=713 pinned=true  sentinelVisible=false
over-editor:  scrollY=1800 barBottom=713 pinned=true  sentinelVisible=false
bottom:       scrollY=2706 barBottom=696 pinned=false sentinelVisible=true
```

Paint order over the editor, via `document.elementFromPoint` at the card's center while the editor is behind it:

```
z-10 bar: hit=editor  -> COVERED
z-50 bar: hit=cardNew -> BAR ON TOP
```

Checks run manually, since the worktree has no `node_modules` for the pre-commit hook: `prettier --check` clean, `add-ui-prefix.cjs --check` clean (0 changes over 821 files). I did not run the dashboard build.

## Note on `ref`

`bind:this={ref}` now points at the sticky element instead of the removed wrapper. No dashboard caller binds `ref` on this component today.

## Not covered here

`/org/[slug]/settings/auth` will still show a flat bar, for an unrelated third reason: `routes/(app)/org/[slug]/settings/auth/+page.svelte` passes `<AuthPage />` into `Page.Body`'s `child` snippet, and `lib/features/settings/pages/auth.svelte` renders `Page.SettingsActions` from inside it. `Page.Body` sets `overflow-x-hidden`, which makes CSS compute `overflow-y` to `auto`, so it is a scroll container that never scrolls. Fixing it means hoisting the bar into the route and lifting the dirty/saving state up, plus deciding whether the bar belongs on the `sso` and `token-auth` tabs. Worth a follow-up.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restructures `Page.SettingsActions` so its sticky action bar and docking sentinel are siblings, allowing the bar to remain pinned while scrolling. It also raises the bar to `z-50` so page editors no longer paint over it.
- Removes the extra wrapper that constrained sticky positioning.
- Moves the component ref, slot marker, classes, and forwarded attributes onto the sticky element.
- Keeps docking state detection through a following sentinel.
- Raises the action bar stacking level from `z-10` to `z-50`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

Current callers place the component directly under the page flex root and do not rely on the changed ref or attribute ownership, while existing overlays retain appropriate layering above the raised sticky bar.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/base/page/page-settings-actions.svelte | Restructures the sticky action bar and sentinel and adjusts stacking without revealing a concrete regression in current callers. |

<sub>Reviews (1): Last reviewed commit: ["fix(ui): let Page.SettingsActions sticky..."](https://github.com/classroomio/classroomio/commit/fa6504fd40f0f147577f1ab244ff0e24bf4905f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49543584)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page settings actions behavior while scrolling.
  * Preserved borders and conditional shadows for the actions area.
  * Improved dock detection for more consistent layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->