### PR TITLE
fix(public-api): add pagination to GET /public-api/v1/courses

### DIFF
--- a/apps/api/src/routes/v1/courses.ts
+++ b/apps/api/src/routes/v1/courses.ts
@@ -22,15 +22,46 @@ import { automationKeyScopesMiddleware } from '@api/middlewares/automation-key-s
 import { handlePublicApiError } from '@api/utils/errors';
 import { describeRoute, validator } from 'hono-openapi';
 
+const PaginationSchema = {
+  type: 'object' as const,
+  properties: {
+    page: { type: 'number' as const },
+    limit: { type: 'number' as const },
+    total: { type: 'number' as const },
+    totalPages: { type: 'number' as const }
+  },
+  required: ['page', 'limit', 'total', 'totalPages']
+};
+
+const CoursesQuerySchema = {
+  type: 'object' as const,
+  properties: {
+    page: { type: 'number' as const },
+    limit: { type: 'number' as const },
+    search: { type: 'string' as const },
+    tags: { type: 'string' as const }
+  },
+  required: ['page', 'limit']
+};
+
 const CoursesListResponse = {
   type: 'object' as const,
   properties: {
     success: { type: 'boolean' as const },
     data: { type: 'array' as const, items: { type: 'object' as const } },
-    pagination: { type: 'object' as const },
-    query: { type: 'object' as const }
+    pagination: PaginationSchema,
+    query: CoursesQuerySchema
   },
   required: ['success', 'data', 'pagination', 'query']
+};
+
+const CourseStudentsResponse = {
+  type: 'object' as const,
+  properties: {
+    success: { type: 'boolean' as const },
+    data: { type: 'array' as const, items: { type: 'object' as const } }
+  },
+  required: ['success', 'data']
 };
 
 const CourseDetailResponse = {
@@ -137,7 +168,7 @@ export const v1CoursesRouter = new Hono()
           description: 'Course students returned successfully',
           content: {
             'application/json': {
-              schema: CoursesListResponse
+              schema: CourseStudentsResponse
             }
           }
         },

--- a/apps/api/src/routes/v1/courses.ts
+++ b/apps/api/src/routes/v1/courses.ts
@@ -26,9 +26,11 @@ const CoursesListResponse = {
   type: 'object' as const,
   properties: {
     success: { type: 'boolean' as const },
-    data: { type: 'array' as const, items: { type: 'object' as const } }
+    data: { type: 'array' as const, items: { type: 'object' as const } },
+    pagination: { type: 'object' as const },
+    query: { type: 'object' as const }
   },
-  required: ['success', 'data']
+  required: ['success', 'data', 'pagination', 'query']
 };
 
 const CourseDetailResponse = {
@@ -71,7 +73,9 @@ export const v1CoursesRouter = new Hono()
         return c.json(
           {
             success: true,
-            data: courses
+            data: courses.items,
+            pagination: courses.pagination,
+            query: courses.query
           },
           200
         );

--- a/apps/api/src/services/v1/course.ts
+++ b/apps/api/src/services/v1/course.ts
@@ -31,14 +31,7 @@ async function assertCourseBelongsToOrganization(orgId: string, courseId: string
 }
 
 export async function listCoursesService(orgId: string, query: TPublicApiCoursesQuery) {
-  const result = await getOrganizationCourses(orgId, '', ROLE.ADMIN, {
-    page: 1,
-    limit: 100,
-    search: undefined,
-    tags: query.tags
-  });
-
-  return result.items;
+  return getOrganizationCourses(orgId, '', ROLE.ADMIN, query);
 }
 
 export async function getCourseService(orgId: string, params: TPublicApiCourseParam) {

--- a/packages/utils/src/validation/public-api/course.ts
+++ b/packages/utils/src/validation/public-api/course.ts
@@ -2,10 +2,9 @@ import * as z from 'zod';
 
 import { ZCourseCreateBase, ZCourseUpdateBase } from '../course/course';
 import { ZCourseImportDraftPayload } from '../course-import/course-import';
+import { ZGetOrganizationCoursesQuery } from '../organization';
 
-export const ZPublicApiCoursesQuery = z.object({
-  tags: z.string().optional()
-});
+export const ZPublicApiCoursesQuery = ZGetOrganizationCoursesQuery;
 export type TPublicApiCoursesQuery = z.infer<typeof ZPublicApiCoursesQuery>;
 
 export const ZPublicApiCourseParam = z.object({


### PR DESCRIPTION
## What does this PR do?

Fixes the silent 100-course cap on `GET /public-api/v1/courses`. Previously the endpoint hardcoded `page: 1, limit: 100` internally, only accepted a `tags` query param, and returned just the items array — so any org with more than 100 courses could never retrieve courses 101+ through the public API.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #803 

<!-- Please provide a screenshots or upload a video for visual changes to speed up reviews -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A — page size: GET /public-api/v1/courses?page=1&limit=100 → data has 100 items and pagination equals page: 1, limit: 100, total: <org course count>, totalPages: ceil(total/100) }.
- Test B — full retrieval: GET /public-api/v1/courses?page=2&limit=100 → returns the remaining courses; no course is unreachable, and pagination.total matches the org's full count.
- Test C — defaults: GET /public-api/v1/courses (no params) → returns up to 20 courses with the pagination wrapper.


## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Course list responses now include pagination details and the applied query parameters.
  * Course searches support the complete organization course query options, including consistent filtering.
  * Public course query validation now follows the standard course search rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes the public course API’s fixed 100-course cap by forwarding validated pagination and filtering parameters and returning structured pagination metadata.
- Reuses the organization course-query validator for public API requests.
- Returns course items alongside pagination and normalized query details.
- Separates the students response schema from the paginated course-list contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/v1/courses.ts | Returns structured pagination metadata and correctly separates the course-list and student-list OpenAPI response contracts. |
| apps/api/src/services/v1/course.ts | Forwards the validated public query to the organization course-list service instead of enforcing a fixed first page. |
| packages/utils/src/validation/public-api/course.ts | Reuses the standard organization course query schema, providing validated pagination defaults and filters. |

<sub>Reviews (2): Last reviewed commit: ["fix metadata pagination structure"](https://github.com/classroomio/classroomio/commit/c887c76ae71eae393e13b2bc1cbe1edda338cbdb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49622127)</sub>

**Context used:**

- Knowledge Base — [API app (`apps/api`)](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/api-app.md)

<!-- /greptile_comment -->