### PR TITLE
fix(course): coerce metadata.discount to number before save

### DIFF
--- a/apps/dashboard/src/lib/features/ui/course-landing-page/components/editor/pricing-form.svelte
+++ b/apps/dashboard/src/lib/features/ui/course-landing-page/components/editor/pricing-form.svelte
@@ -7,6 +7,7 @@
   import type { Course } from '$features/course/utils/types';
   import { t } from '$lib/utils/functions/translations';
   import { isCourseFree } from '$lib/utils/functions/course';
+  import { toFiniteNumber } from '@cio/utils/functions';
 
   import { InputField } from '@cio/ui/custom/input-field';
   import { TextEditor } from '$features/ui';
@@ -18,24 +19,9 @@
 
   let { course = $bindable(), setter }: Props = $props();
 
-  function parseMetadataDiscount(value: unknown): number {
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      return value;
-    }
-
-    if (typeof value === 'string' && value.trim()) {
-      const parsed = Number(value);
-      if (Number.isFinite(parsed)) {
-        return parsed;
-      }
-    }
-
-    return 0;
-  }
-
   let paymentLink = $state(get(course, 'metadata.paymentLink', '') as string);
   let showDiscount = $state(Boolean(get(course, 'metadata.showDiscount', false)));
-  let discount = $state(parseMetadataDiscount(get(course, 'metadata.discount', 0)));
+  let discount = $state(toFiniteNumber(get(course, 'metadata.discount', 0)) ?? 0);
   let giftToggled = $state(Boolean(get(course, 'metadata.reward.show', false)));
 
   function handleChange(content: string) {
@@ -49,7 +35,7 @@
     setter(paymentLink, 'metadata.paymentLink');
   });
   $effect(() => {
-    setter(parseMetadataDiscount(discount), 'metadata.discount');
+    setter(toFiniteNumber(discount) ?? 0, 'metadata.discount');
   });
   $effect(() => {
     setter(giftToggled, 'metadata.reward.show');

--- a/apps/dashboard/src/lib/features/ui/course-landing-page/components/editor/pricing-form.svelte
+++ b/apps/dashboard/src/lib/features/ui/course-landing-page/components/editor/pricing-form.svelte
@@ -19,10 +19,10 @@
 
   let { course = $bindable(), setter }: Props = $props();
 
-  let paymentLink = $state(get(course, 'metadata.paymentLink', '') as string);
-  let showDiscount = $state(Boolean(get(course, 'metadata.showDiscount', false)));
-  let discount = $state(toFiniteNumber(get(course, 'metadata.discount', 0)) ?? 0);
-  let giftToggled = $state(Boolean(get(course, 'metadata.reward.show', false)));
+  let paymentLink = $derived(get(course, 'metadata.paymentLink', ''));
+  let showDiscount = $derived(Boolean(get(course, 'metadata.showDiscount', false)));
+  let discount = $derived(toFiniteNumber(get(course, 'metadata.discount', 0)) ?? 0);
+  let giftToggled = $derived(Boolean(get(course, 'metadata.reward.show', false)));
 
   function handleChange(content: string) {
     setter(content, 'metadata.reward.description');

--- a/apps/dashboard/src/lib/features/ui/course-landing-page/components/editor/pricing-form.svelte
+++ b/apps/dashboard/src/lib/features/ui/course-landing-page/components/editor/pricing-form.svelte
@@ -18,10 +18,25 @@
 
   let { course = $bindable(), setter }: Props = $props();
 
-  let discount = $derived(get(course, 'metadata.discount', 0));
-  let paymentLink = $derived(get(course, 'metadata.paymentLink', ''));
-  let showDiscount = $derived(get(course, 'metadata.showDiscount', false));
-  let giftToggled = $derived(get(course, 'metadata.reward.show', false));
+  function parseMetadataDiscount(value: unknown): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+
+    if (typeof value === 'string' && value.trim()) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+
+    return 0;
+  }
+
+  let paymentLink = $state(get(course, 'metadata.paymentLink', '') as string);
+  let showDiscount = $state(Boolean(get(course, 'metadata.showDiscount', false)));
+  let discount = $state(parseMetadataDiscount(get(course, 'metadata.discount', 0)));
+  let giftToggled = $state(Boolean(get(course, 'metadata.reward.show', false)));
 
   function handleChange(content: string) {
     setter(content, 'metadata.reward.description');
@@ -34,7 +49,7 @@
     setter(paymentLink, 'metadata.paymentLink');
   });
   $effect(() => {
-    setter(discount, 'metadata.discount');
+    setter(parseMetadataDiscount(discount), 'metadata.discount');
   });
   $effect(() => {
     setter(giftToggled, 'metadata.reward.show');

--- a/packages/utils/src/functions/index.ts
+++ b/packages/utils/src/functions/index.ts
@@ -1,6 +1,7 @@
 export * from './array';
 export * from './currency';
 export * from './fileValidation';
+export * from './number';
 export * from './sanitize';
 export * from './slug';
 export * from './transcript-vtt';

--- a/packages/utils/src/functions/number.ts
+++ b/packages/utils/src/functions/number.ts
@@ -1,6 +1,7 @@
 /**
- * Coerces unknown input to a finite number.
- * String numbers are parsed; empty, null, and invalid values return undefined.
+ * Coerces a number or numeric string to a finite number.
+ * Does not coerce booleans, arrays, or other types (unlike bare `Number()`).
+ * Empty, null, and invalid values return undefined.
  */
 export function toFiniteNumber(value: unknown): number | undefined {
   if (typeof value === 'number' && Number.isFinite(value)) {

--- a/packages/utils/src/functions/number.ts
+++ b/packages/utils/src/functions/number.ts
@@ -1,0 +1,18 @@
+/**
+ * Coerces unknown input to a finite number.
+ * String numbers are parsed; empty, null, and invalid values return undefined.
+ */
+export function toFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+}

--- a/packages/utils/src/validation/course/course.ts
+++ b/packages/utils/src/validation/course/course.ts
@@ -322,7 +322,13 @@ function preprocessCourseMetadata(value: unknown): unknown {
     metadata.allowNewStudent = true;
   }
 
-  if (metadata.discount !== undefined) {
+  if (metadata.discount === null || metadata.discount === '') {
+    metadata.discount = undefined;
+  } else if (typeof metadata.discount === 'number') {
+    if (!Number.isFinite(metadata.discount)) {
+      metadata.discount = undefined;
+    }
+  } else if (typeof metadata.discount === 'string') {
     metadata.discount = toFiniteNumber(metadata.discount);
   }
 

--- a/packages/utils/src/validation/course/course.ts
+++ b/packages/utils/src/validation/course/course.ts
@@ -1,5 +1,6 @@
 import * as z from 'zod';
 
+import { toFiniteNumber } from '../../functions/number';
 import { ALLOWED_CONTENT_TYPES, ALLOWED_DOCUMENT_TYPES } from '../constants';
 import { ZCourseCalloutInput } from './callout';
 import { ZCourseType } from './course-type';
@@ -321,11 +322,8 @@ function preprocessCourseMetadata(value: unknown): unknown {
     metadata.allowNewStudent = true;
   }
 
-  if (metadata.discount === '' || metadata.discount === null) {
-    metadata.discount = undefined;
-  } else if (metadata.discount !== undefined) {
-    const parsedDiscount = Number(metadata.discount);
-    metadata.discount = Number.isFinite(parsedDiscount) ? parsedDiscount : undefined;
+  if (metadata.discount !== undefined) {
+    metadata.discount = toFiniteNumber(metadata.discount);
   }
 
   return metadata;

--- a/packages/utils/src/validation/course/course.ts
+++ b/packages/utils/src/validation/course/course.ts
@@ -324,12 +324,11 @@ function preprocessCourseMetadata(value: unknown): unknown {
 
   if (metadata.discount === null || metadata.discount === '') {
     metadata.discount = undefined;
-  } else if (typeof metadata.discount === 'number') {
-    if (!Number.isFinite(metadata.discount)) {
-      metadata.discount = undefined;
-    }
   } else if (typeof metadata.discount === 'string') {
-    metadata.discount = toFiniteNumber(metadata.discount);
+    const parsedDiscount = toFiniteNumber(metadata.discount);
+    if (parsedDiscount !== undefined) {
+      metadata.discount = parsedDiscount;
+    }
   }
 
   return metadata;

--- a/packages/utils/src/validation/course/course.ts
+++ b/packages/utils/src/validation/course/course.ts
@@ -321,6 +321,13 @@ function preprocessCourseMetadata(value: unknown): unknown {
     metadata.allowNewStudent = true;
   }
 
+  if (metadata.discount === '' || metadata.discount === null) {
+    metadata.discount = undefined;
+  } else if (metadata.discount !== undefined) {
+    const parsedDiscount = Number(metadata.discount);
+    metadata.discount = Number.isFinite(parsedDiscount) ? parsedDiscount : undefined;
+  }
+
   return metadata;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes a Zod validation error when saving course settings (`metadata.discount` expected `number`, received `string`).

The landing page pricing form wrote discount values from a `type="number"` input as strings into `course.metadata.discount`. Course settings then re-sent the full metadata blob unchanged, so `ZCourseUpdate` failed even when discount was not edited.

This PR:
- Normalizes discount to a number in the landing page pricing form before syncing metadata (matching the instructor form `$state` pattern).
- Coerces legacy string `metadata.discount` values during `preprocessCourseMetadata` so existing in-memory/DB data validates on save.

Fixes #828

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Open a course landing page editor → Pricing section.
2. Enable discount and enter a percentage (e.g. `15`), save the landing page.
3. Go to Course Settings and save (change title or any other field).
4. Confirm save succeeds with no Zod error about `metadata.discount`.
5. Reload the course and confirm discount still displays correctly on the landing page.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efad274f-1e40-42d9-bde9-8ab15cf40340?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efad274f-1e40-42d9-bde9-8ab15cf40340&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved course discount handling across pricing forms and course settings.
  * Discount values are now consistently converted to valid finite numbers.
  * Empty, invalid, or unsupported discount entries are safely ignored during validation.
  * Pricing updates now synchronize more reliably when discount or gift settings change.
  * Prevented invalid discount values from being saved or affecting course pricing.
  * Improved handling of boolean gift settings to ensure consistent saved values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR normalizes numeric discount strings while preserving strict validation for malformed values.
- Adds a shared helper that accepts only finite numbers and numeric strings.
- Normalizes discounts in the landing-page pricing editor before synchronizing metadata.
- Coerces legacy numeric-string discounts during course metadata preprocessing.
- Exports the numeric conversion helper from the shared functions package.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/ui/course-landing-page/components/editor/pricing-form.svelte | Normalizes derived and synchronized discount values to finite numbers and normalizes toggle state to booleans. |
| packages/utils/src/functions/index.ts | Exports the new shared numeric conversion utility. |
| packages/utils/src/functions/number.ts | Adds strict finite-number conversion for numbers and numeric strings without coercing unrelated types. |
| packages/utils/src/validation/course/course.ts | Coerces legacy numeric-string discounts while leaving malformed values for Zod to reject. |

<sub>Reviews (5): Last reviewed commit: ["fix(utils): reject invalid metadata.disc..."](https://github.com/classroomio/classroomio/commit/8decc9a09fe1f2215bb589ded8833b1541a61686) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50056350)</sub>

<!-- /greptile_comment -->