### PR TITLE
fix(ui): align LandingButton sizing and hero/pricing CTA consistency

### DIFF
--- a/packages/ui/src/custom/org-landing-page/course-primary-action.svelte
+++ b/packages/ui/src/custom/org-landing-page/course-primary-action.svelte
@@ -1,17 +1,21 @@
 <script lang="ts">
   import { cn } from '../../tools';
-  import { Button, type ButtonVariant } from '../../base/button';
+  import LandingButton from './landing-button.svelte';
   import type { LandingPrimaryAction } from './types';
+
+  type LandingButtonVariant = 'primary' | 'secondary' | 'tertiary';
+  type LandingButtonSize = 'sm' | 'md' | 'lg';
 
   interface Props {
     action: LandingPrimaryAction;
     size?: 'default' | 'sm' | 'lg';
-    variant?: ButtonVariant;
+    variant?: LandingButtonVariant;
     class?: string;
   }
 
-  let { action, size = 'default', variant = 'default', class: className = '' }: Props = $props();
+  let { action, size = 'default', variant = 'primary', class: className = '' }: Props = $props();
 
+  const landingSize = $derived<LandingButtonSize>(size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : 'md');
   const isDisabled = $derived(action.disabled ?? false);
 
   // Match pricing CTA disabled appearance: theme hero color overrides must not win when enrollment is closed.
@@ -21,13 +25,13 @@
     ' ui:hover:!bg-[var(--landing-button-primary-bg)] ui:hover:!opacity-50 ui:!border-transparent';
 </script>
 
-<Button
+<LandingButton
+  {variant}
+  size={landingSize}
   href={action.onclick ? undefined : action.href}
   onclick={action.onclick}
   disabled={isDisabled}
-  {size}
-  {variant}
   class={cn(className, isDisabled && disabledClass)}
 >
   {action.label}
-</Button>
+</LandingButton>

--- a/packages/ui/src/custom/org-landing-page/course-primary-action.svelte
+++ b/packages/ui/src/custom/org-landing-page/course-primary-action.svelte
@@ -1,39 +1,33 @@
 <script lang="ts">
   import { cn } from '../../tools';
-  import LandingButton from './landing-button.svelte';
+  import { Button, type ButtonVariant } from '../../base/button';
   import type { LandingPrimaryAction } from './types';
-
-  type LandingButtonVariant = 'primary' | 'secondary' | 'tertiary';
-  type LandingButtonSize = 'sm' | 'md' | 'lg';
 
   interface Props {
     action: LandingPrimaryAction;
     size?: 'default' | 'sm' | 'lg';
-    variant?: LandingButtonVariant;
+    variant?: ButtonVariant;
     class?: string;
   }
 
-  let { action, size = 'default', variant = 'primary', class: className = '' }: Props = $props();
+  let { action, size = 'default', variant = 'default', class: className = '' }: Props = $props();
 
-  const landingSize = $derived<LandingButtonSize>(size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : 'md');
   const isDisabled = $derived(action.disabled ?? false);
 
-  const disabledClass = $derived(
-    variant === 'secondary'
-      ? 'ui:!bg-[var(--landing-button-secondary-bg)] ui:!text-[var(--landing-button-secondary-fg)] ui:hover:!bg-[var(--landing-button-secondary-bg)]'
-      : variant === 'tertiary'
-        ? 'ui:!bg-transparent ui:!text-[var(--landing-button-tertiary-fg)] ui:hover:!bg-transparent'
-        : 'ui:!bg-[var(--landing-button-primary-bg)] ui:!text-[var(--landing-button-primary-fg)] ui:hover:!bg-[var(--landing-button-primary-bg)]'
-  );
+  // Match pricing CTA disabled appearance: theme hero color overrides must not win when enrollment is closed.
+  const disabledClass =
+    'ui:pointer-events-none ui:!opacity-50 ui:disabled:opacity-50 ui:aria-disabled:opacity-50' +
+    ' ui:!bg-[var(--landing-button-primary-bg)] ui:!text-[var(--landing-button-primary-fg)]' +
+    ' ui:hover:!bg-[var(--landing-button-primary-bg)] ui:hover:!opacity-50 ui:!border-transparent';
 </script>
 
-<LandingButton
-  {variant}
-  size={landingSize}
+<Button
   href={action.onclick ? undefined : action.href}
   onclick={action.onclick}
   disabled={isDisabled}
+  {size}
+  {variant}
   class={cn(className, isDisabled && disabledClass)}
 >
   {action.label}
-</LandingButton>
+</Button>

--- a/packages/ui/src/custom/org-landing-page/landing-button.svelte
+++ b/packages/ui/src/custom/org-landing-page/landing-button.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { cn } from '../../tools';
 
   type Variant = 'primary' | 'secondary' | 'tertiary';
   type Size = 'sm' | 'md' | 'lg';
@@ -45,9 +46,9 @@
   );
 
   const baseClass =
-    'ui:inline-flex ui:items-center ui:justify-center ui:gap-1.5 ui:rounded-md ui:font-medium ui:border ui:transition-colors ui:focus-visible:outline-none ui:focus-visible:ring-2 ui:focus-visible:ring-[var(--landing-accent)]/50 ui:disabled:opacity-50 ui:disabled:cursor-not-allowed ui:cursor-pointer ui:no-underline ui:whitespace-nowrap';
+    'ui:inline-flex ui:items-center ui:justify-center ui:gap-1.5 ui:[border-radius:var(--landing-radius-pill)] ui:font-medium ui:border ui:transition-colors ui:focus-visible:outline-none ui:focus-visible:ring-2 ui:focus-visible:ring-[var(--landing-accent)]/50 ui:disabled:opacity-50 ui:disabled:cursor-not-allowed ui:cursor-pointer ui:no-underline ui:whitespace-nowrap';
 
-  const finalClass = $derived(`${baseClass} ${sizeClass} ${variantClass} ${extraClass}`);
+  const finalClass = $derived(cn(baseClass, sizeClass, variantClass, extraClass));
 </script>
 
 {#if href && !disabled}

--- a/packages/ui/src/custom/org-landing-page/landing-button.svelte
+++ b/packages/ui/src/custom/org-landing-page/landing-button.svelte
@@ -46,7 +46,7 @@
   );
 
   const baseClass =
-    'ui:inline-flex ui:items-center ui:justify-center ui:gap-1.5 ui:[border-radius:var(--landing-radius-pill)] ui:font-medium ui:border ui:transition-colors ui:focus-visible:outline-none ui:focus-visible:ring-2 ui:focus-visible:ring-[var(--landing-accent)]/50 ui:disabled:opacity-50 ui:disabled:cursor-not-allowed ui:cursor-pointer ui:no-underline ui:whitespace-nowrap';
+    'ui:inline-flex ui:items-center ui:justify-center ui:gap-1.5 ui:rounded-md ui:font-medium ui:border ui:transition-colors ui:focus-visible:outline-none ui:focus-visible:ring-2 ui:focus-visible:ring-[var(--landing-accent)]/50 ui:disabled:opacity-50 ui:disabled:cursor-not-allowed ui:cursor-pointer ui:no-underline ui:whitespace-nowrap';
 
   const finalClass = $derived(cn(baseClass, sizeClass, variantClass, extraClass));
 </script>

--- a/packages/ui/src/custom/org-landing-page/landing-button.svelte
+++ b/packages/ui/src/custom/org-landing-page/landing-button.svelte
@@ -31,10 +31,10 @@
 
   const sizeClass = $derived(
     size === 'sm'
-      ? 'ui:px-3 ui:py-1.5 ui:text-sm'
+      ? 'ui:h-8 ui:px-3 ui:text-sm'
       : size === 'lg'
-        ? 'ui:px-6 ui:py-3 ui:text-base'
-        : 'ui:px-4 ui:py-2 ui:text-sm'
+        ? 'ui:h-10 ui:px-6 ui:text-sm'
+        : 'ui:h-9 ui:px-4 ui:text-sm'
   );
 
   const variantClass = $derived(

--- a/packages/ui/src/custom/org-landing-page/terminal/hero.svelte
+++ b/packages/ui/src/custom/org-landing-page/terminal/hero.svelte
@@ -108,11 +108,7 @@
               {hero.secondaryAction.label}
             </Button>
           {/if}
-          <CoursePrimaryAction
-            action={hero.primaryAction}
-            size="sm"
-            class="ui:rounded-full ui:px-4 ui:font-medium ui:bg-[#f4f5f7] ui:text-[#0a0b0e] ui:hover:bg-white"
-          />
+          <CoursePrimaryAction action={hero.primaryAction} size="sm" class="ui:rounded-full ui:px-4 ui:font-medium" />
         </div>
       {/if}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Hero Enroll CTA regressions after switching to `LandingButton` (#815):
- Wrong border radius (fixed via `cn()` on `LandingButton`)
- Oversized button (`LandingButton` `lg` used `py-3` + `text-base` vs `Button` `h-10` + `text-sm`)
- Disabled hero CTA could look active while pricing looked muted
- Hero enabled colors used `bg-primary` instead of `--landing-button-*` on some themes (e.g. terminal)

## Solution

1. **Align `LandingButton` sizes with shared `Button`** (`h-8` / `h-9` / `h-10`, `text-sm`)
2. **Use `LandingButton` for hero primary CTA** (`CoursePrimaryAction`) so enabled colors match pricing via `--landing-button-*` tokens
3. **Keep disabled overrides** so theme hero color classes cannot win when enrollment is closed
4. **Terminal hero** drops hardcoded hex colors; uses landing tokens via `LandingButton`

## Architecture

| CTA | Component | Colors | Size |
|---|---|---|---|
| Go to LMS / View curriculum | `Button` | App / outline theme classes | `default` / `lg` |
| Hero Enroll + Pricing Enroll | `LandingButton` | `--landing-button-*` | Aligned `sm`/`md`/`lg` |

## Testing

- Svelte autofixer: no issues
- `pnpm format:check`, `pnpm --filter @cio/ui build`
- Live minimal course page: disabled hero/pricing parity; hero size matches View curriculum
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-554c0d87-1bf3-4723-8206-ee6acdfaa5eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-554c0d87-1bf3-4723-8206-ee6acdfaa5eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated landing page buttons with more consistent sizing, spacing, colors, and hover states.
  * Improved disabled buttons with clearer visual feedback and prevented unintended interaction.
  * Refined the hero section’s primary action button for a cleaner, more consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns landing CTA dimensions with shared button sizes and standardizes hero and pricing CTA styling.
- Replaces vertical padding-based sizes with fixed shared-style heights.
- Uses conflict-aware class merging so theme-specific radius and spacing overrides apply correctly.
- Applies landing-button color tokens and consistent disabled presentation to hero enrollment CTAs.
- Removes terminal-theme hardcoded CTA colors.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/custom/org-landing-page/course-primary-action.svelte | Standardizes disabled hero CTA styling with landing-button tokens and prevents theme overrides from making closed enrollment appear active. |
| packages/ui/src/custom/org-landing-page/landing-button.svelte | Aligns size dimensions with the shared button component and merges caller styling through the existing cn utility. |
| packages/ui/src/custom/org-landing-page/terminal/hero.svelte | Removes hardcoded CTA colors so the terminal hero uses landing theme tokens while retaining its shape and spacing overrides. |

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into cursor/fix-enro..."](https://github.com/classroomio/classroomio/commit/5c5a5887b7c473a3a690f4606b73a9046bffcac8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50135629)</sub>

<!-- /greptile_comment -->