### PR TITLE
fix(dashboard): ensure @cio/ui output.css exists before build

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -5,6 +5,7 @@
   "main": "main.js",
   "scripts": {
     "dev": "vite dev --port 5173",
+    "prebuild": "pnpm --filter @cio/ui run build",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint ./src",

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turborepo.org/schema.json",
   "globalEnv": ["PUBLIC_IS_SELFHOSTED"],
   "pipeline": {
+    "@cio/ui#build": {
+      "outputs": ["src/output.css"]
+    },
     "@cio/dashboard#build": {
       "dependsOn": ["@cio/api#build", "@cio/ui#build", "@cio/db#build", "@cio/analytics#build"],
       "outputs": [".svelte-kit/**", "build/**"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes a Render/Turbo build failure where the dashboard import of `@cio/ui/output.css` failed with `ENOENT` because the file is generated at build time and was not restored on Turbo cache hits.

- **`turbo.json`** — declare `src/output.css` as an output of `@cio/ui#build` so Turbo restores it when the task is cached.
- **`apps/dashboard/package.json`** — add a `prebuild` script (same pattern as embeds) to run `@cio/ui` CSS generation before `vite build`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Delete `packages/ui/src/output.css`.
2. Run `pnpm turbo run build --filter=@cio/dashboard`.
3. Confirm the build succeeds and `packages/ui/src/output.css` is recreated (including on a full Turbo cache hit).

## Checklist

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Ran dashboard build successfully after the change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2206824a-6ee1-408d-a7b1-695962872472?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2206824a-6ee1-408d-a7b1-695962872472&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ensures the generated `@cio/ui/output.css` file is available before dashboard builds and restored on Turbo cache hits.
- Declares `packages/ui/src/output.css` as an output of the `@cio/ui#build` Turbo task.
- Adds a dashboard prebuild step that generates the shared UI CSS before Vite runs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the dashboard’s direct and Turbo-driven build paths both ensuring the generated UI stylesheet is available.

The declared Turbo output matches the UI build’s generated file, and the added prebuild invokes the existing idempotent CSS generation command before Vite.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/package.json | Adds the established UI CSS generation prebuild step so direct dashboard builds cannot encounter a missing stylesheet. |
| turbo.json | Registers the UI build’s sole generated artifact for correct Turbo caching and restoration. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): ensure @cio/ui output.cs..."](https://github.com/classroomio/classroomio/commit/d0452538a48d42c5aa7040afae4baac13ab61721) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50337877)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard build reliability by ensuring shared interface styles are built before the dashboard.
  * Updated build tracking so generated interface styles are correctly included in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->