### PR TITLE
fix(api): allow inviting students to compliance courses without a certificate deadline

### DIFF
--- a/apps/api/src/services/course/compliance.ts
+++ b/apps/api/src/services/course/compliance.ts
@@ -135,16 +135,17 @@ async function getTargetStudentMembers(courseId: string, profileIds?: string[]) 
   return students;
 }
 
-function resolveComplianceInitialDueDate(course: Awaited<ReturnType<typeof getComplianceCourseOrThrow>>) {
+/**
+ * Resolves the initial compliance cycle due date from the course certificate
+ * deadline. Returns `null` when no deadline is set — callers must then skip
+ * record creation (enrollment itself is still allowed). Throws only when a
+ * deadline is present but malformed.
+ */
+function getComplianceInitialDueDate(course: Awaited<ReturnType<typeof getComplianceCourseOrThrow>>): string | null {
   const dueDate = course.certificate?.deadline ?? null;
 
   if (!dueDate) {
-    throw new AppError(
-      'Compliance courses require a certificate deadline before learners can be enrolled',
-      ErrorCodes.VALIDATION_ERROR,
-      400,
-      'certificate.deadline'
-    );
+    return null;
   }
 
   const parsedDueDate = new Date(dueDate);
@@ -211,7 +212,12 @@ async function getComplianceCompletionSnapshot(params: {
 
 async function ensureComplianceEnrollmentRecordForLearner(courseId: string, groupMemberId: string, profileId: string) {
   const course = await getComplianceCourseOrThrow(courseId);
-  const dueDate = resolveComplianceInitialDueDate(course);
+  const dueDate = getComplianceInitialDueDate(course);
+
+  if (!dueDate) {
+    return null;
+  }
+
   const [existingRecord] = await getLatestComplianceRecordsByProfiles(courseId, [profileId]);
 
   if (existingRecord) {
@@ -242,11 +248,14 @@ export async function ensureComplianceEnrollmentRecordsForProfiles(courseIds: st
   for (const courseId of courseIds) {
     const [course] = await getCourseById(courseId);
 
-    if (!course || course.type !== 'COMPLIANCE') {
+    if (!course || course.type !== 'COMPLIANCE' || !course.compliance) {
       continue;
     }
 
-    resolveComplianceInitialDueDate(await getComplianceCourseOrThrow(courseId));
+    const initialDueDate = getComplianceInitialDueDate(course);
+    if (!initialDueDate) {
+      continue;
+    }
 
     const learners = await getStudentCourseMembersForCompliance(courseId, profileIds);
     for (const learner of learners) {
@@ -283,6 +292,14 @@ export async function syncComplianceProgressFromSubmission(courseId: string, gro
   }
 
   const activeRecord = await ensureComplianceEnrollmentRecordForLearner(courseId, groupMemberId, profile.id);
+
+  if (!activeRecord) {
+    return {
+      status: 'not_started',
+      completed: false
+    };
+  }
+
   if (!activeRecord.completedAt && activeRecord.status === 'not_started') {
     await updateCourseCompletionRecord(activeRecord.id, {
       status: 'in_progress',
@@ -299,6 +316,14 @@ export async function syncComplianceProgressFromSubmission(courseId: string, gro
   }
 
   const latestRecord = await ensureComplianceEnrollmentRecordForLearner(courseId, groupMemberId, profile.id);
+
+  if (!latestRecord) {
+    return {
+      status: 'not_started',
+      completed: false
+    };
+  }
+
   if (latestRecord.completedAt) {
     return {
       status: latestRecord.status,

--- a/apps/dashboard/src/lib/features/course/api/compliance.svelte.ts
+++ b/apps/dashboard/src/lib/features/course/api/compliance.svelte.ts
@@ -49,8 +49,8 @@ export class ComplianceApi extends BaseApiWithErrors {
     return result?.data;
   }
 
-  async ensureOverview(courseId: string) {
-    if (this.overviewKey === courseId && this.overview) {
+  async ensureOverview(courseId: string, refresh = false) {
+    if (!refresh && this.overviewKey === courseId && this.overview) {
       return this.overview;
     }
 
@@ -80,9 +80,9 @@ export class ComplianceApi extends BaseApiWithErrors {
     return result?.data;
   }
 
-  async ensureLearnerHistory(courseId: string, profileId: string) {
+  async ensureLearnerHistory(courseId: string, profileId: string, refresh = false) {
     const requestKey = `${courseId}:${profileId}`;
-    if (this.learnerHistoryKey === requestKey && this.learnerHistory) {
+    if (!refresh && this.learnerHistoryKey === requestKey && this.learnerHistory) {
       return this.learnerHistory;
     }
 

--- a/apps/dashboard/src/lib/features/course/pages/compliance.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/compliance.svelte
@@ -22,6 +22,7 @@
   type StaffAction = 'reset' | 'extend' | 'waive' | null;
 
   let staffTab = $state<'overview' | 'learners'>('overview');
+  let loadedCourseId = $state<string | null>(null);
   let activeAction = $state<StaffAction>(null);
   let bulkActionType = $state<Exclude<StaffAction, null> | null>(null);
   let isBulkActionModalOpen = $state(false);
@@ -75,16 +76,20 @@
 
     if (!isComplianceCourse) {
       complianceApi.reset();
+      loadedCourseId = null;
       return;
     }
 
     const courseId = courseApi.course.id;
+    const needsRefresh = loadedCourseId !== courseId;
+    loadedCourseId = courseId;
+
     if (isStudent && currentMember?.profileId) {
-      void complianceApi.ensureLearnerHistory(courseId, currentMember.profileId);
+      void complianceApi.ensureLearnerHistory(courseId, currentMember.profileId, needsRefresh);
       return;
     }
 
-    void complianceApi.ensureOverview(courseId);
+    void complianceApi.ensureOverview(courseId, needsRefresh);
   });
 
   $effect(() => {

--- a/apps/dashboard/src/lib/features/course/pages/compliance.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/compliance.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import { Badge } from '@cio/ui/base/badge';
   import { Button } from '@cio/ui/base/button';
   import { Checkbox } from '@cio/ui/base/checkbox';
@@ -81,7 +82,7 @@
     }
 
     const courseId = courseApi.course.id;
-    const needsRefresh = loadedCourseId !== courseId;
+    const needsRefresh = untrack(() => loadedCourseId) !== courseId;
     loadedCourseId = courseId;
 
     if (isStudent && currentMember?.profileId) {

--- a/apps/dashboard/src/lib/features/course/pages/compliance.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/compliance.svelte
@@ -21,7 +21,6 @@
   type ComplianceStatus = CourseComplianceLearner['status'] | LearnerComplianceRecord['status'] | 'no_record';
   type StaffAction = 'reset' | 'extend' | 'waive' | null;
 
-  let lastRequestKey = $state<string | null>(null);
   let staffTab = $state<'overview' | 'learners'>('overview');
   let activeAction = $state<StaffAction>(null);
   let bulkActionType = $state<Exclude<StaffAction, null> | null>(null);
@@ -76,28 +75,15 @@
 
     if (!isComplianceCourse) {
       complianceApi.reset();
-      lastRequestKey = null;
       return;
     }
 
     const courseId = courseApi.course.id;
     if (isStudent && currentMember?.profileId) {
-      const requestKey = `${courseId}:${currentMember.profileId}:learner`;
-      if (lastRequestKey === requestKey) {
-        return;
-      }
-
-      lastRequestKey = requestKey;
       void complianceApi.ensureLearnerHistory(courseId, currentMember.profileId);
       return;
     }
 
-    const requestKey = `${courseId}:overview`;
-    if (lastRequestKey === requestKey) {
-      return;
-    }
-
-    lastRequestKey = requestKey;
     void complianceApi.ensureOverview(courseId);
   });
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Teachers couldn't invite students into a compliance course without a certificate deadline, every invite/enroll path failed with a 400 certificate.deadline error. Per the PRD, the deadline gates compliance record creation, not enrollment, so this makes deadline-less enrollment work:

- getComplianceInitialDueDate returns null when no deadline is set; the ensure/sync helpers skip record creation instead of throwing.
- syncComplianceProgressFromSubmission returns not_started when no record can exist, so submissions keep working.
- Also removes the compliance page's lastRequestKey dedup so the overview reloads on refresh (the API already dedupes).


Fixes #837 

<!-- Please provide a screenshots or upload a video for visual changes to speed up reviews -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Create a compliance course without a certificate deadline.
2. From the People page, grant access to a student (or add via the invite link).
   Verify the student joins without a 400 error and appears in the course.
3. Verify the compliance overview renders the new member with a
   no record/not started status (no "Student compliance records" crash).
4. As the student, submit an exercise in the course. Verify the submission is
   accepted and graded normally.
5. Set a deadline, invite another student, and confirm their compliance record
   is created with the correct due date (existing behavior unchanged).
6. Verify the compliance overview still reloads correctly when clicking refresh.


## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compliance courses with missing certificate deadlines no longer fail enrollment or record creation.
  * Bulk compliance syncing now ignores compliance courses that don’t have an initial due date.
  * Course progress now stays “Not started” when no enrollment record exists.
* **Improvements**
  * Compliance dashboard loading now prevents stale course data when switching courses and supports a refresh option for learner overview and learner history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR allows enrollment and submission processing for compliance courses without certificate deadlines while skipping compliance-record creation until a deadline exists.
- Returns `null` instead of rejecting deadline-less compliance courses.
- Handles absent compliance records as `not_started`.
- Adds explicit cache-bypass support while preserving fresh-data loading through the page refresh flow.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported refresh issue is resolved because the refresh handler resets the compliance cache before the course reload reruns the loading effect.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/services/course/compliance.ts | Makes initial due dates optional and safely skips record creation and progress synchronization when no deadline exists. |
| apps/dashboard/src/lib/features/course/api/compliance.svelte.ts | Adds an explicit refresh argument to bypass cached overview and learner-history responses. |
| apps/dashboard/src/lib/features/course/pages/compliance.svelte | Replaces request-key suppression with course-aware loading; explicit page refresh still clears cached compliance state before reloading. |

<sub>Reviews (3): Last reviewed commit: ["coderabbit comment fix"](https://github.com/classroomio/classroomio/commit/912242247a2ec05e0c4ddaab0da8efc4188c3284) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50473890)</sub>

**Context used:**

- Knowledge Base — [API app (`apps/api`)](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/api-app.md)
- Knowledge Base — [Dashboard app (`apps/dashboard`)](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/dashboard-app.md)

<!-- /greptile_comment -->