### PR TITLE
docs: Fixes the public API reference (`/docs/api`)

### DIFF
--- a/apps/api/scripts/upload-openapi-spec.ts
+++ b/apps/api/scripts/upload-openapi-spec.ts
@@ -147,6 +147,18 @@ class OpenAPISpecGenerator {
               url: 'http://localhost:3002',
               description: 'Development environment'
             }
+          ],
+          tags: [
+            {
+              name: 'Public API Audience',
+              description:
+                "Manage your organization's audience, invite, list, update, and remove members, and assign them to courses."
+            },
+            {
+              name: 'Public API Courses',
+              description:
+                "Manage your organization's courses, create, list, update, delete, and export course structure and content."
+            }
           ]
         }
       });

--- a/apps/docs/theme.css
+++ b/apps/docs/theme.css
@@ -1,0 +1,55 @@
+/*
+ * Scalar's embedded API reference (openapi.renderer: 'scalar' in blume.config.ts)
+ * manages its own light/dark state independently of Blume's [data-theme]
+ * attribute on <html> -- the two never talk to each other, so the reference
+ * can get stuck looking dark even when the rest of the site is light.
+ *
+ * Force Scalar's palette to follow the site's actual theme instead, regardless
+ * of which of Scalar's own .light-mode/.dark-mode classes it happens to apply.
+ * Values below are copied from Scalar's own default theme (its .light-mode and
+ * .dark-mode blocks in the CDN-loaded @scalar/api-reference bundle), not
+ * invented, so this matches what Scalar looks like when it does pick the
+ * matching class itself.
+ *
+ * Fragile by nature: @scalar/api-reference loads unpinned from jsDelivr
+ * (see blume's getScriptTags), so if Scalar renames or restructures these
+ * variables upstream, this override silently stops matching and the two
+ * palettes can drift. Re-check against the live bundle if the API page's
+ * colors look off after a Scalar update.
+ */
+
+html[data-theme='light'] .light-mode,
+html[data-theme='light'] .dark-mode {
+  --scalar-background-1: #fff !important;
+  --scalar-background-2: #f6f6f6 !important;
+  --scalar-background-3: #e7e7e7 !important;
+  --scalar-background-accent: #8ab4f81f !important;
+  --scalar-color-1: #1b1b1b !important;
+  --scalar-color-2: #757575 !important;
+  --scalar-color-3: #8e8e8e !important;
+  --scalar-border-color: #dfdfdf !important;
+  --scalar-button-1: #000 !important;
+  --scalar-button-1-hover: #000c !important;
+  --scalar-button-1-color: #fff !important;
+  --scalar-scrollbar-color: #0000002e !important;
+  --scalar-scrollbar-color-active: #0000005c !important;
+  color-scheme: light !important;
+}
+
+html[data-theme='dark'] .light-mode,
+html[data-theme='dark'] .dark-mode {
+  --scalar-background-1: #020202 !important;
+  --scalar-background-2: #1a1a1a !important;
+  --scalar-background-3: #272727 !important;
+  --scalar-background-accent: #3ea6ff1f !important;
+  --scalar-color-1: #e7e7e7 !important;
+  --scalar-color-2: #a4a4a4 !important;
+  --scalar-color-3: #797979 !important;
+  --scalar-border-color: #2d2d2d !important;
+  --scalar-button-1: #fff !important;
+  --scalar-button-1-hover: #ffffffe6 !important;
+  --scalar-button-1-color: #000 !important;
+  --scalar-scrollbar-color: #ffffff2e !important;
+  --scalar-scrollbar-color-active: #ffffff5c !important;
+  color-scheme: dark !important;
+}

--- a/packages/utils/src/openapi/public-api.ts
+++ b/packages/utils/src/openapi/public-api.ts
@@ -13,7 +13,7 @@ All public API endpoints require an **organization-scoped API key** sent as a Be
 ## Get an API key
 
 1. Sign in to [ClassroomIO](https://app.classroomio.com) as an **organization admin**.
-2. In the org sidebar, open the **Automation** section, then **API** ([/org/*/api](https://app.classroomio.com/org/*/api) — \`*\` picks your current organization automatically).
+2. In the org sidebar, open the **Automation** section, then **API** (\`app.classroomio.com/org/*/api\`, where \`*\` is automatically your current organization).
 3. Click **Generate API key** and copy the secret immediately (it is shown only once).
 4. Keys look like \`cio_api_...\` and include the \`public_api:*\` scope.
 
@@ -34,9 +34,95 @@ Use the **Authorize** button (lock icon) on this page, choose **bearerAuth**, pa
 ## Plan access
 
 > **Paid Access** — On ClassroomIO Cloud, API key creation is available on **Early Adopter** and **Enterprise** plans. Self-hosted deployments require **Enterprise**.
+
+# HTTP methods
+
+The public API uses standard HTTP verbs:
+
+| Method | Use | Example |
+| --- | --- | --- |
+| \`GET\` | Fetch a resource or list | \`GET /public-api/v1/courses\` |
+| \`POST\` | Create a resource | \`POST /public-api/v1/audience\` |
+| \`PUT\` | Replace or update a resource | \`PUT /public-api/v1/courses/{courseId}\` |
+| \`DELETE\` | Remove a resource | \`DELETE /public-api/v1/audience/{memberId}\` |
+
+# Pagination
+
+List endpoints (\`GET /courses\`, \`GET /audience\`) accept:
+
+| Param | Type | Default | Notes |
+| --- | --- | --- | --- |
+| \`page\` | integer | \`1\` | 1-indexed |
+| \`limit\` | integer | \`20\` | Maximum \`100\` |
+
+Responses wrap results in a shared shape:
+
+\`\`\`json
+{
+  "success": true,
+  "data": [],
+  "pagination": { "page": 1, "limit": 20, "total": 42, "totalPages": 3 },
+  "query": { "page": 1, "limit": 20 }
+}
+\`\`\`
+
+\`pagination\` reports the actual result set; \`query\` echoes back the resolved request parameters (including any filters, e.g. \`search\` or \`tags\`).
+
+# Rate limiting
+
+Requests are limited **per API key**: 100 requests per minute. Every response includes:
+
+| Header | Meaning |
+| --- | --- |
+| \`X-RateLimit-Limit\` | Requests allowed in the current window |
+| \`X-RateLimit-Remaining\` | Requests left in the current window |
+| \`X-RateLimit-Reset\` | When the current window resets |
+
+Exceeding the limit returns \`429\` with a \`Retry-After\` header (seconds until you can retry).
+
+# Errors
+
+Failed requests return:
+
+\`\`\`json
+{
+  "success": false,
+  "error": "Human-readable message",
+  "code": "MACHINE_READABLE_CODE",
+  "field": "optional.field.path"
+}
+\`\`\`
+
+\`field\` is only present for validation errors that can be traced to a specific input.
+
+| Status | Meaning |
+| --- | --- |
+| \`400\` | Invalid request body or query: \`code\` is \`VALIDATION_ERROR\`, \`field\` identifies the offending input when known |
+| \`401\` | Missing or invalid API key |
+| \`403\` | The key is missing a required scope, or the organization's plan doesn't allow public API access |
+| \`404\` | The requested resource doesn't exist (or doesn't belong to your organization) |
+| \`429\` | Rate limit exceeded. See [Rate limiting](#rate-limiting): this response uses a different body, \`{ "error": "Too Many Requests", "message": "...", "retryAfter": 42 }\`, not the shape above |
+| \`500\` | Unexpected server error |
 `;
 
 type OpenApiDocument = Record<string, unknown>;
+
+/**
+ * `PUBLIC_API_BASE_URL`'s pathname, e.g. `/public-api/v1`. Path keys in the spec
+ * carry this same prefix (Hono reports each route's full mounted path), so it
+ * must be stripped or a client resolves `servers[0].url + path` with the prefix
+ * doubled.
+ */
+const PUBLIC_API_PATH_PREFIX = new URL(PUBLIC_API_BASE_URL).pathname;
+
+function stripBasePathPrefix(paths: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(paths).map(([path, value]) => [
+      path.startsWith(PUBLIC_API_PATH_PREFIX) ? path.slice(PUBLIC_API_PATH_PREFIX.length) || '/' : path,
+      value
+    ])
+  );
+}
 
 function applySecurityToOperations(paths: Record<string, unknown>) {
   for (const pathItem of Object.values(paths)) {
@@ -59,7 +145,7 @@ function applySecurityToOperations(paths: Record<string, unknown>) {
 export function enrichPublicApiOpenApiSpec<T extends OpenApiDocument>(spec: T): T {
   const components = (spec.components ?? {}) as Record<string, unknown>;
   const securitySchemes = (components.securitySchemes ?? {}) as Record<string, unknown>;
-  const paths = (spec.paths ?? {}) as Record<string, unknown>;
+  const paths = stripBasePathPrefix((spec.paths ?? {}) as Record<string, unknown>);
   const info = (spec.info ?? {}) as Record<string, unknown>;
 
   applySecurityToOperations(paths);
@@ -72,6 +158,7 @@ export function enrichPublicApiOpenApiSpec<T extends OpenApiDocument>(spec: T): 
       version: typeof info.version === 'string' ? info.version : '1.0.0',
       description: PUBLIC_API_OPENAPI_DESCRIPTION
     },
+    servers: [{ url: PUBLIC_API_BASE_URL, description: 'Public API v1' }],
     paths,
     components: {
       ...components,


### PR DESCRIPTION
## What does this PR do?

Fixes the public API reference (`/docs/api`): wrong server URL (and a path-duplication bug from fixing it), missing tag group descriptions, missing Errors/HTTP methods/Pagination/Rate limiting docs, a broken literal-`*` link, and the reference page not following the site's light/dark theme.

Fixes # (not tied to a tracked issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (small improvements)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

```bash
pnpm --filter @cio/utils run build
pnpm --filter @cio/docs exec node scripts/fetch-openapi.mjs
pnpm --filter @cio/docs exec blume dev
```

- Visit `/docs/api`, confirm the server URL is correct and "Try it" doesn't duplicate the path.
- Toggle light/dark theme and confirm the reference page follows it.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the ClassroomIO Docs if changes were necessary
