### PR TITLE
chore(ci): harden supply-chain controls before reopening PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# High-risk supply-chain paths — prefer maintainer review before merge.
+/.github/workflows/ @rotimi-best
+/pnpm-lock.yaml @rotimi-best
+/pnpm-workspace.yaml @rotimi-best
+/package.json @rotimi-best

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,6 +39,7 @@ Fixes # (place issue number here without bracket)
 - [ ] Removed all `console.logs`
 - [ ] Merged the latest changes from main onto my branch with `git pull origin main`
 - [ ] My changes don't cause any responsiveness issues
+- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description
 
 ### Appreciated
 

--- a/.github/workflows/apply-issue-labels-to-pr.yml
+++ b/.github/workflows/apply-issue-labels-to-pr.yml
@@ -1,18 +1,22 @@
 name: 'Apply issue labels to PR'
 
+# pull_request_target is used so labeling works for fork PRs.
+# SAFE ONLY because this workflow never checks out or executes PR code.
+# Do not add actions/checkout, pnpm install, build, or cache steps here.
+
 on:
   pull_request_target:
     types:
       - opened
 
+permissions:
+  contents: none
+  issues: read
+  pull-requests: write
+
 jobs:
   label_on_pr:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: none
-      issues: read
-      pull-requests: write
 
     steps:
       - name: Apply labels from linked issue to PR

--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -5,6 +5,11 @@ on:
     types:
       - created
       - edited
+
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   take-issue:
     name: Disable take issue

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm i
+        run: pnpm install --frozen-lockfile
 
       - name: Build Storybook
         run: |

--- a/.github/workflows/mcp-package-build-check.yml
+++ b/.github/workflows/mcp-package-build-check.yml
@@ -1,0 +1,44 @@
+name: MCP package build check
+
+# Verifies @classroomio/mcp still builds on PRs/pushes that touch it.
+# Intentionally separate from publish-mcp.yml so PR CI never sees NPM_TOKEN.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/mcp/**'
+      - 'packages/question-types/**'
+      - 'packages/utils/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/mcp-package-build-check.yml'
+  push:
+    paths:
+      - 'packages/mcp/**'
+      - 'packages/question-types/**'
+      - 'packages/utils/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/mcp-package-build-check.yml'
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.3
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build publishable MCP package
+        run: pnpm mcp:build

--- a/.github/workflows/package-build-check.yml
+++ b/.github/workflows/package-build-check.yml
@@ -24,6 +24,9 @@ on:
       - '.nvmrc'
       - '.github/workflows/package-build-check.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-course-app.yml
+++ b/.github/workflows/publish-course-app.yml
@@ -1,15 +1,19 @@
 name: Publish @classroomio/course-app to NPM
 
-on: workflow_dispatch
+# Publish-only via manual dispatch. Do not add pull_request triggers here.
+
+on:
+  workflow_dispatch:
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: production
     permissions:
-      packages: write
       contents: read
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20.19.3
@@ -17,11 +21,13 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
-      - name: Install, Build & Publish
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build & Publish
         working-directory: packages/course-app
         run: |
-          pnpm i
           pnpm build
           pnpm publish --no-git-checks
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,22 +1,16 @@
 name: Publish @classroomio/mcp to NPM
 
+# Publish-only. Never triggered by pull_request — keeps NPM_TOKEN off the PR trust boundary.
+# PR/push build verification lives in mcp-package-build-check.yml.
+
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "packages/mcp/**"
-
-  push:
-    paths:
-      - "packages/mcp/**"
-    branches:
-      - main
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: production
     permissions:
-      packages: write
       contents: read
     steps:
       - uses: actions/checkout@v4
@@ -24,18 +18,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20.19.3
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - uses: pnpm/action-setup@v4
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build publishable MCP package
         run: pnpm mcp:build
 
       - name: Publish package
-        if: github.event_name == 'workflow_dispatch'
         run: pnpm --filter @classroomio/mcp publish --no-git-checks --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/semantic-pull-requests.yml
+++ b/.github/workflows/semantic-pull-requests.yml
@@ -1,5 +1,9 @@
 name: 'Check PR'
 
+# pull_request_target is used so title lint can comment on fork PRs.
+# SAFE ONLY because this workflow never checks out or executes PR code.
+# Do not add actions/checkout, pnpm install, build, or cache steps here.
+
 on:
   pull_request_target:
     types:
@@ -9,6 +13,7 @@ on:
       - synchronize
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/ui-prefix-check.yml
+++ b/.github/workflows/ui-prefix-check.yml
@@ -12,6 +12,9 @@ on:
       - 'packages/ui/**'
       - '.github/workflows/ui-prefix-check.yml'
 
+permissions:
+  contents: read
+
 jobs:
   ui-prefix:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,10 @@ Ready to dive into the code and make a real impact? Here's your path:
 
 Would you prefer a chat before you dive into a lot of work? Our [Discord server](https://dub.sh/ciodiscord) is your harbor. Share your thoughts, and we'll meet you there with open arms. We're responsive and friendly, promise!
 
+## Dependency and workflow changes
+
+PRs that touch `pnpm-lock.yaml`, `.github/workflows/**`, or npm publish config get extra review. Prefer the smallest lockfile diff that matches your change, and do not add `pull_request_target` workflows that check out or build untrusted PR code.
+
 ## Features
 
 If you spot a feature that isn't part of our official plan but could propel ClassroomIO forward, don't hesitate. Raise it as an enhancement issue, and let us know you're ready to take the lead. We'll be quick to respond.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,9 @@ packages:
 onlyBuiltDependencies:
   - esbuild
   - '@tailwindcss/oxide'
+# Block brand-new registry publishes for 24h (supply-chain cooldown).
+# Locked versions in pnpm-lock.yaml stay installable; this gates adds/updates.
+minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@getworkbench/hono'
   - '@getworkbench/core'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens CI/publish before reopening external PRs after the TanStack npm supply-chain incident.

This does **not** replace GitHub repo settings (collaborator-only contributions). After merge, you can reopen PRs safely with these controls in place.

### What changed
- **Isolated npm publish from PR CI**
  - `publish-mcp.yml` and `publish-course-app.yml` are now `workflow_dispatch` only
  - MCP PR/push build moved to `mcp-package-build-check.yml` (no `NPM_TOKEN`)
  - Both publish workflows use `environment: production` + frozen lockfile
- **`minimumReleaseAge: 1440`** in `pnpm-workspace.yaml` (24h cooldown on newly published registry versions; existing excludes kept)
- **`pull_request_target` workflows documented + least privilege** — still title-lint / label-only, explicitly must not checkout/build PR code
- **Default `contents: read`** on several CI workflows
- **CODEOWNERS** for workflows / lockfile / root package manifests
- **CONTRIBUTING + PR template** call out lockfile/workflow review

### Manual follow-ups (GitHub settings — not in this PR)
1. Re-enable external PRs when ready
2. Turn on branch protection for `main`: require PR + CODEOWNERS review (so `.github/workflows/**` and `pnpm-lock.yaml` need `@rotimi-best`)
3. In the `production` environment, require reviewer approval for npm publishes if you want a human gate on every publish
4. Confirm `NPM_TOKEN` is repo/environment-scoped and not available to fork PR workflows (should already be true)

### Test plan
- [ ] Confirm `Publish @classroomio/mcp` / `course-app` workflows only show `workflow_dispatch`
- [ ] Open a test PR touching `packages/mcp/**` and confirm **MCP package build check** runs without publish
- [ ] Confirm existing PR title lint / issue-label workflows still comment on PRs
- [ ] After merge, try `pnpm add` of a package published <24h ago and confirm cooldown behavior (or use an excluded package)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e000d237-156b-48e0-a926-faea766ae04e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e000d237-156b-48e0-a926-faea766ae04e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Strengthened workflow permissions and documented safeguards for automated pull request workflows.
  * Added supply-chain protections, including release-age checks and required review for sensitive configuration changes.
  * Standardized reproducible dependency installation.

* **Developer Experience**
  * Added checks to validate MCP package builds during relevant changes.
  * Updated contribution and pull request guidance for dependency, workflow, and publishing changes.

* **Release Management**
  * Restricted package publishing to controlled, manual production workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR separates MCP build validation from credentialed publishing and hardens CI permissions, dependency installation, and supply-chain review controls.
- Restricts npm publishing to manually dispatched production-environment workflows.
- Adds an unprivileged MCP build check for pull requests and main-branch pushes.
- Uses frozen lockfile installations and introduces a 24-hour dependency release cooldown.
- Adds CODEOWNERS and contributor guidance for high-risk workflow and dependency changes.
- Documents the restrictions required for safe `pull_request_target` workflows.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with publishing credentials isolated from pull-request build execution and no concrete regressions identified.

The changed workflows preserve build coverage while moving npm publication behind manual production-environment dispatches, using read-only permissions for PR checks, and keeping untrusted PR code out of pull-request-target workflows.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/mcp-package-build-check.yml | Adds read-only MCP build validation for pull requests and main pushes without exposing npm credentials. |
| .github/workflows/publish-mcp.yml | Restricts MCP publishing to manual production-environment dispatches and uses frozen dependency installation. |
| .github/workflows/publish-course-app.yml | Adds production-environment protection and separates frozen installation from the course-app build and publish step. |
| pnpm-workspace.yaml | Introduces a 24-hour minimum package release age while retaining the existing package exclusions. |
| .github/CODEOWNERS | Assigns ownership for workflow, lockfile, workspace, and root manifest changes. |
| .github/workflows/apply-issue-labels-to-pr.yml | Documents the pull-request-target trust boundary and retains narrowly scoped labeling permissions. |
| .github/workflows/semantic-pull-requests.yml | Documents the pull-request-target trust boundary and explicitly scopes title-lint permissions. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  PR[Pull request changes MCP] --> Check[MCP package build check]
  Check --> ReadOnly[Read-only token]
  Check --> Build[Install from frozen lockfile and build]
  Dispatch[Manual workflow dispatch] --> Env[Production environment]
  Env --> PublishBuild[Install and build]
  PublishBuild --> Token[NPM token]
  Token --> NPM[Publish package]
  PR -. no publish credentials .-> Check
```

<sub>Reviews (1): Last reviewed commit: ["chore(ci): harden supply-chain controls ..."](https://github.com/classroomio/classroomio/commit/d19e876b22a72c01671139c4bd6292a63ad9c036) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51942839)</sub>

<!-- /greptile_comment -->