### PR TITLE
fix(dashboard): Certain menus inside of modals are hidden

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
   ],
   "deno.importMap": "./supabase/functions/import_map.json",
   "editor.formatOnSave": true,
+  "editor.wordWrap": "on",
   "[svelte]": {
     "editor.defaultFormatter": "svelte.svelte-vscode"
   },

--- a/apps/dashboard/src/app.css
+++ b/apps/dashboard/src/app.css
@@ -8,32 +8,6 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
-/**
- * Shared z-index scale, mirrored from `packages/ui/src/index.css`.
- *
- * Dashboard code has its own (unprefixed) Tailwind pipeline, separate from `@cio/ui`'s
- * `ui:`-prefixed one — a `ui:`-prefixed utility only compiles if that exact class string is
- * also used somewhere under `packages/ui/src`. So dashboard-only usages (page headers, the
- * course sidebar, dropdowns/selects that need to escape a sticky header or a modal) must use
- * these unprefixed names instead. Keep the two scales numerically in sync; see
- * `packages/ui/README.md` for the full write-up of each layer.
- */
-@utility z-app-bar {
-  z-index: 100;
-}
-
-@utility z-app-bar-elevated {
-  z-index: 150;
-}
-
-@utility z-modal {
-  z-index: 200;
-}
-
-@utility z-menu-elevated {
-  z-index: 250;
-}
-
 /* Geist variable font — self-hosted */
 @font-face {
   font-family: 'Geist';

--- a/apps/dashboard/src/lib/features/ai-assistant/chat-header.svelte
+++ b/apps/dashboard/src/lib/features/ai-assistant/chat-header.svelte
@@ -229,7 +229,7 @@
             </Button>
           {/snippet}
         </Popover.Trigger>
-        <Popover.Content class="ui:p-0! z-200! w-72" align="center">
+        <Popover.Content class="ui:p-0! w-72" align="center">
           <ChatHistoryPopover
             {conversations}
             {activeConversationId}

--- a/apps/dashboard/src/lib/features/cohort/components/cohort-header.svelte
+++ b/apps/dashboard/src/lib/features/cohort/components/cohort-header.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <header
-  class="border-border ui:bg-background z-app-bar sticky top-0 flex h-12 w-full shrink-0 items-center gap-2 border-b backdrop-blur transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-8"
+  class="border-border ui:bg-background ui:z-app-bar sticky top-0 flex h-12 w-full shrink-0 items-center gap-2 border-b backdrop-blur transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-8"
 >
   <div class="flex w-full items-center gap-2 px-4">
     <Sidebar.Trigger />

--- a/apps/dashboard/src/lib/features/cohort/components/sidebar/cohort-sidebar.svelte
+++ b/apps/dashboard/src/lib/features/cohort/components/sidebar/cohort-sidebar.svelte
@@ -29,7 +29,7 @@
 {#if !isOrgLoaded}
   <SidebarSkeleton />
 {:else}
-  <Sidebar.Root collapsible="icon">
+  <Sidebar.Root collapsible="icon" class="ui:z-app-bar-elevated">
     <Sidebar.Header>
       <OrgLogo />
     </Sidebar.Header>

--- a/apps/dashboard/src/lib/features/course/components/course-header.svelte
+++ b/apps/dashboard/src/lib/features/course/components/course-header.svelte
@@ -59,7 +59,7 @@
 </script>
 
 <header
-  class="border-border ui:bg-background z-app-bar sticky top-0 flex h-12 w-full shrink-0 items-center gap-2 border-b backdrop-blur transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-8"
+  class="border-border ui:bg-background ui:z-app-bar sticky top-0 flex h-12 w-full shrink-0 items-center gap-2 border-b backdrop-blur transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-8"
 >
   <div class="flex w-full items-center gap-2 px-4">
     <Sidebar.Trigger />

--- a/apps/dashboard/src/lib/features/course/components/exercise/mark-exercise-modal.svelte
+++ b/apps/dashboard/src/lib/features/course/components/exercise/mark-exercise-modal.svelte
@@ -296,7 +296,7 @@
               >
                 <EllipsisVerticalIcon class="h-5 w-5" />
               </DropdownMenu.Trigger>
-              <DropdownMenu.Content align="end" class="z-menu-elevated">
+              <DropdownMenu.Content align="end">
                 <DropdownMenu.Item
                   class="text-red-600"
                   onclick={() => {
@@ -366,7 +366,7 @@
               <Select.Trigger class="w-full">
                 {status.text}
               </Select.Trigger>
-              <Select.Content class="z-menu-elevated">
+              <Select.Content>
                 {#each SELECTABLE_STATUS as statusOption}
                   <Select.Item value={statusOption.id.toString()}>
                     {statusOption.text}

--- a/apps/dashboard/src/lib/features/course/components/lesson/document/document.svelte
+++ b/apps/dashboard/src/lib/features/course/components/lesson/document/document.svelte
@@ -339,7 +339,7 @@
 
 <!-- PDF Viewer Modal -->
 {#if pdfViewerOpen}
-  <div class="z-modal fixed inset-0 flex flex-col bg-white dark:bg-neutral-800">
+  <div class="ui:z-modal fixed inset-0 flex flex-col bg-white dark:bg-neutral-800">
     <!-- Header -->
     <div class="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-3 dark:bg-neutral-800">
       <div class="flex items-center space-x-4">

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar.svelte
@@ -118,7 +118,7 @@
 {#if !isOrgLoaded}
   <SidebarSkeleton />
 {:else}
-  <Sidebar.Root collapsible="icon" class="z-app-bar-elevated!" mobileOverlayClass="z-app-bar-elevated!">
+  <Sidebar.Root collapsible="icon" class="ui:z-app-bar-elevated" mobileOverlayClass="ui:z-app-bar-elevated">
     <Sidebar.Header>
       <CourseSidebarLogo isStudent={$isStudentExperience} />
     </Sidebar.Header>

--- a/apps/dashboard/src/lib/features/course/pages/exercise.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/exercise.svelte
@@ -592,7 +592,7 @@
   }
 </script>
 
-<Page.Header isSticky={true} class="z-app-bar! top-12! min-h-[36px]">
+<Page.Header isSticky={true} class="ui:z-app-bar top-12! min-h-[36px]">
   <Page.HeaderContent>
     <Page.Title class="flex flex-col gap-2">
       <span>{exerciseDisplayTitle}</span>
@@ -638,7 +638,7 @@
                       </Button>
                     {/snippet}
                   </DropdownMenu.Trigger>
-                  <DropdownMenu.Content align="end" class="z-menu-elevated!">
+                  <DropdownMenu.Content align="end">
                     <DropdownMenu.Item onclick={addSectionFromHeader}>
                       {$t('course.navItem.lessons.exercises.all_exercises.add_section')}
                     </DropdownMenu.Item>
@@ -677,7 +677,7 @@
                       </Button>
                     {/snippet}
                   </DropdownMenu.Trigger>
-                  <DropdownMenu.Content align="end" class="z-menu-elevated!">
+                  <DropdownMenu.Content align="end">
                     {#if hasSections($questionnaire.sections)}
                       <DropdownMenu.Item onclick={() => (reorderQuestions = !reorderQuestions)}>
                         {reorderQuestions

--- a/apps/dashboard/src/lib/features/people/components/tutor-select-section.svelte
+++ b/apps/dashboard/src/lib/features/people/components/tutor-select-section.svelte
@@ -66,7 +66,7 @@
         {/if}
       </div>
     </Select.Trigger>
-    <Select.Content class="ui:z-menu-elevated">
+    <Select.Content>
       {#each tutors as tutor (tutor.id)}
         <Select.Item value={tutor.id.toString()}>
           {tutor.text}

--- a/apps/dashboard/src/lib/features/people/components/tutor-select-section.svelte
+++ b/apps/dashboard/src/lib/features/people/components/tutor-select-section.svelte
@@ -66,7 +66,7 @@
         {/if}
       </div>
     </Select.Trigger>
-    <Select.Content>
+    <Select.Content class="ui:z-menu-elevated">
       {#each tutors as tutor (tutor.id)}
         <Select.Item value={tutor.id.toString()}>
           {tutor.text}

--- a/apps/dashboard/src/lib/features/side-panel/side-panel-rail.svelte
+++ b/apps/dashboard/src/lib/features/side-panel/side-panel-rail.svelte
@@ -148,7 +148,7 @@
     <div class="hidden shrink-0 md:block md:w-(--side-panel-width)"></div>
 
     <aside
-      class="ui:bg-background z-app-bar fixed inset-y-0 right-0 flex h-screen w-full flex-col border-l md:w-(--side-panel-width)"
+      class="ui:bg-background ui:z-app-bar fixed inset-y-0 right-0 flex h-screen w-full flex-col border-l md:w-(--side-panel-width)"
       aria-label={t.get(def.titleKey)}
     >
       <button

--- a/apps/dashboard/src/lib/features/tag/pages/tags-admin.svelte
+++ b/apps/dashboard/src/lib/features/tag/pages/tags-admin.svelte
@@ -383,7 +383,7 @@
                 : $t('tags_admin.tag_modal.select_category')}
             </p>
           </Select.Trigger>
-          <Select.Content class="z-menu-elevated">
+          <Select.Content class="ui:z-menu-elevated">
             {#each tagApi.tagGroups as group (group.id)}
               <Select.Item value={group.id}>{group.name}</Select.Item>
             {/each}

--- a/apps/dashboard/src/lib/features/tag/pages/tags-admin.svelte
+++ b/apps/dashboard/src/lib/features/tag/pages/tags-admin.svelte
@@ -383,7 +383,7 @@
                 : $t('tags_admin.tag_modal.select_category')}
             </p>
           </Select.Trigger>
-          <Select.Content class="ui:z-menu-elevated">
+          <Select.Content>
             {#each tagApi.tagGroups as group (group.id)}
               <Select.Item value={group.id}>{group.name}</Select.Item>
             {/each}
@@ -409,7 +409,7 @@
               </Button>
             {/snippet}
           </Popover.Trigger>
-          <Popover.Content align="start" class="z-250! w-44 p-3">
+          <Popover.Content align="start" class="w-44 p-3">
             <div class="grid grid-cols-5 gap-2">
               {#each TAG_COLOR_OPTIONS as color (color)}
                 <Button

--- a/apps/dashboard/src/lib/features/ui/course-landing-page/components/editor/pricing-form.svelte
+++ b/apps/dashboard/src/lib/features/ui/course-landing-page/components/editor/pricing-form.svelte
@@ -49,7 +49,7 @@
       <Select.Trigger class="w-full">
         <p>{course.currency === 'NGN' ? 'NGN' : 'USD'}</p>
       </Select.Trigger>
-      <Select.Content class="z-menu-elevated">
+      <Select.Content>
         <Select.Item value="NGN">NGN</Select.Item>
         <Select.Item value="USD">USD</Select.Item>
       </Select.Content>

--- a/packages/ui/src/base/dropdown-menu/dropdown-menu-content.svelte
+++ b/packages/ui/src/base/dropdown-menu/dropdown-menu-content.svelte
@@ -24,7 +24,7 @@
     {sideOffset}
     {preventScroll}
     class={cn(
-      'ui:bg-popover ui:text-popover-foreground ui:data-[state=open]:animate-in ui:data-[state=closed]:animate-out ui:data-[state=closed]:fade-out-0 ui:data-[state=open]:fade-in-0 ui:data-[state=closed]:zoom-out-95 ui:data-[state=open]:zoom-in-95 ui:data-[side=bottom]:slide-in-from-top-2 ui:data-[side=left]:slide-in-from-right-2 ui:data-[side=right]:slide-in-from-left-2 ui:data-[side=top]:slide-in-from-bottom-2 ui:max-h-(--bits-dropdown-menu-content-available-height) ui:origin-(--bits-dropdown-menu-content-transform-origin) ui:z-50 ui:min-w-32 ui:overflow-y-auto ui:overflow-x-hidden ui:rounded-md ui:border ui:p-1 ui:shadow-md ui:outline-none',
+      'ui:bg-popover ui:text-popover-foreground ui:data-[state=open]:animate-in ui:data-[state=closed]:animate-out ui:data-[state=closed]:fade-out-0 ui:data-[state=open]:fade-in-0 ui:data-[state=closed]:zoom-out-95 ui:data-[state=open]:zoom-in-95 ui:data-[side=bottom]:slide-in-from-top-2 ui:data-[side=left]:slide-in-from-right-2 ui:data-[side=right]:slide-in-from-left-2 ui:data-[side=top]:slide-in-from-bottom-2 ui:max-h-(--bits-dropdown-menu-content-available-height) ui:origin-(--bits-dropdown-menu-content-transform-origin) ui:z-menu-elevated ui:min-w-32 ui:overflow-y-auto ui:overflow-x-hidden ui:rounded-md ui:border ui:p-1 ui:shadow-md ui:outline-none',
       className
     )}
     {...restProps}

--- a/packages/ui/src/base/dropdown-menu/dropdown-menu-sub-content.svelte
+++ b/packages/ui/src/base/dropdown-menu/dropdown-menu-sub-content.svelte
@@ -9,7 +9,7 @@
   bind:ref
   data-slot="dropdown-menu-sub-content"
   class={cn(
-    'ui:bg-popover ui:text-popover-foreground ui:data-[state=open]:animate-in ui:data-[state=closed]:animate-out ui:data-[state=closed]:fade-out-0 ui:data-[state=open]:fade-in-0 ui:data-[state=closed]:zoom-out-95 ui:data-[state=open]:zoom-in-95 ui:data-[side=bottom]:slide-in-from-top-2 ui:data-[side=left]:slide-in-from-right-2 ui:data-[side=right]:slide-in-from-left-2 ui:data-[side=top]:slide-in-from-bottom-2 ui:origin-(--bits-dropdown-menu-content-transform-origin) ui:z-50 ui:min-w-32 ui:overflow-hidden ui:rounded-md ui:border ui:p-1 ui:shadow-lg',
+    'ui:bg-popover ui:text-popover-foreground ui:data-[state=open]:animate-in ui:data-[state=closed]:animate-out ui:data-[state=closed]:fade-out-0 ui:data-[state=open]:fade-in-0 ui:data-[state=closed]:zoom-out-95 ui:data-[state=open]:zoom-in-95 ui:data-[side=bottom]:slide-in-from-top-2 ui:data-[side=left]:slide-in-from-right-2 ui:data-[side=right]:slide-in-from-left-2 ui:data-[side=top]:slide-in-from-bottom-2 ui:origin-(--bits-dropdown-menu-content-transform-origin) ui:z-menu-elevated ui:min-w-32 ui:overflow-hidden ui:rounded-md ui:border ui:p-1 ui:shadow-lg',
     className
   )}
   {...restProps}

--- a/packages/ui/src/base/popover/popover-content.svelte
+++ b/packages/ui/src/base/popover/popover-content.svelte
@@ -21,7 +21,7 @@
     {sideOffset}
     {align}
     class={cn(
-      'ui:bg-popover ui:text-popover-foreground ui:data-[state=open]:animate-in ui:data-[state=closed]:animate-out ui:data-[state=closed]:fade-out-0 ui:data-[state=open]:fade-in-0 ui:data-[state=closed]:zoom-out-95 ui:data-[state=open]:zoom-in-95 ui:data-[side=bottom]:slide-in-from-top-2 ui:data-[side=left]:slide-in-from-right-2 ui:data-[side=right]:slide-in-from-left-2 ui:data-[side=top]:slide-in-from-bottom-2 ui:origin-(--bits-popover-content-transform-origin) ui:outline-hidden ui:z-50 ui:w-72 ui:rounded-md ui:border ui:p-4 ui:shadow-md',
+      'ui:bg-popover ui:text-popover-foreground ui:data-[state=open]:animate-in ui:data-[state=closed]:animate-out ui:data-[state=closed]:fade-out-0 ui:data-[state=open]:fade-in-0 ui:data-[state=closed]:zoom-out-95 ui:data-[state=open]:zoom-in-95 ui:data-[side=bottom]:slide-in-from-top-2 ui:data-[side=left]:slide-in-from-right-2 ui:data-[side=right]:slide-in-from-left-2 ui:data-[side=top]:slide-in-from-bottom-2 ui:origin-(--bits-popover-content-transform-origin) ui:outline-hidden ui:z-menu-elevated ui:w-72 ui:rounded-md ui:border ui:p-4 ui:shadow-md',
       className
     )}
     {...restProps}

--- a/packages/ui/src/base/select/select-content.svelte
+++ b/packages/ui/src/base/select/select-content.svelte
@@ -22,7 +22,7 @@
     {sideOffset}
     data-slot="select-content"
     class={cn(
-      'ui:bg-popover ui:text-popover-foreground ui:data-[state=open]:animate-in ui:data-[state=closed]:animate-out ui:data-[state=closed]:fade-out-0 ui:data-[state=open]:fade-in-0 ui:data-[state=closed]:zoom-out-95 ui:data-[state=open]:zoom-in-95 ui:data-[side=bottom]:slide-in-from-top-2 ui:data-[side=left]:slide-in-from-right-2 ui:data-[side=right]:slide-in-from-left-2 ui:data-[side=top]:slide-in-from-bottom-2 ui:max-h-(--bits-select-content-available-height) ui:origin-(--bits-select-content-transform-origin) ui:relative ui:z-50 ui:min-w-32 ui:overflow-y-auto ui:overflow-x-hidden ui:rounded-md ui:border ui:shadow-md ui:data-[side=bottom]:translate-y-1 ui:data-[side=left]:-translate-x-1 ui:data-[side=right]:translate-x-1 ui:data-[side=top]:-translate-y-1',
+      'ui:bg-popover ui:text-popover-foreground ui:data-[state=open]:animate-in ui:data-[state=closed]:animate-out ui:data-[state=closed]:fade-out-0 ui:data-[state=open]:fade-in-0 ui:data-[state=closed]:zoom-out-95 ui:data-[state=open]:zoom-in-95 ui:data-[side=bottom]:slide-in-from-top-2 ui:data-[side=left]:slide-in-from-right-2 ui:data-[side=right]:slide-in-from-left-2 ui:data-[side=top]:slide-in-from-bottom-2 ui:max-h-(--bits-select-content-available-height) ui:origin-(--bits-select-content-transform-origin) ui:relative ui:z-menu-elevated ui:min-w-32 ui:overflow-y-auto ui:overflow-x-hidden ui:rounded-md ui:border ui:shadow-md ui:data-[side=bottom]:translate-y-1 ui:data-[side=left]:-translate-x-1 ui:data-[side=right]:translate-x-1 ui:data-[side=top]:-translate-y-1',
       className
     )}
     {...restProps}


### PR DESCRIPTION
## What does this PR do?

This PR standardizes z-index management for menu items (drop downs, select items and popovers) across the dashboard, using utilities (`ui:z-menu-elevated`, `ui:z-app-bar`, `ui:z-app-bar-elevated`, `ui:z-modal`), and fixes some modal menus that are hidden behind the modal (eg menu for selecting tutors to be invited in a cohort, and menu for selecting tag category during tag creation)

Fixes #858 and #864 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Go to `Cohorts`, select one, go to `People`, click `Invite`, select the `Invite Tutors` tab, click the dropdown and verify visibility.
- Go to `Tags`, click `Create Tag`, click the Category dropdown and verify visibility.
- Open any other random menu (eg select, popover etc) and verify that they are not hidden

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layering for headers, sidebars, menus, dropdowns, popovers, selects, and modals.
  * Reduced stacking conflicts that could cause overlays or navigation elements to appear behind other content.
  * Standardized menu and popover elevation behavior across the dashboard.

* **Style**
  * Updated editor settings to enable word wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes the dashboard’s stacking-order scale in the shared UI package and applies elevated defaults to dropdown, select, and popover content.
- Replaces dashboard-local z-index utilities with shared `ui:`-prefixed utilities.
- Raises shared menu content above modal and application chrome layers.
- Removes redundant per-call-site menu z-index overrides.
- Aligns sticky headers, sidebars, side panels, and the PDF viewer with the shared layer scale.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed overlays and dashboard chrome consistently using the shared stacking-order scale.

The shared z-index utilities are emitted by the UI package and imported by the dashboard, while component class merging preserves the intended caller overrides; no concrete stacking regression remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/base/dropdown-menu/dropdown-menu-content.svelte | Replaces the generic dropdown z-index with the shared elevated-menu layer. |
| packages/ui/src/base/popover/popover-content.svelte | Moves portaled popover content to the shared elevated-menu layer. |
| packages/ui/src/base/select/select-content.svelte | Moves portaled select content above modal and application chrome layers. |
| apps/dashboard/src/app.css | Removes duplicated dashboard z-index utilities in favor of the shared UI package scale. |
| apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar.svelte | Migrates desktop and mobile sidebar layering to the shared elevated app-bar utility. |
| apps/dashboard/src/lib/features/tag/pages/tags-admin.svelte | Removes local select and popover z-index overrides now supplied by shared primitives. |

<sub>Reviews (1): Last reviewed commit: ["refactor: standardize z-index management..."](https://github.com/classroomio/classroomio/commit/e420a9d3d185a353505aa82ae693d6fb88ad6586) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52213821)</sub>

**Context used:**

- Knowledge Base — [Dashboard app (`apps/dashboard`)](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/dashboard-app.md)

<!-- /greptile_comment -->