### PR TITLE
fix: translation issue in cohort goals widget

### DIFF
--- a/apps/dashboard/src/lib/features/cohort/components/goals/my-goals-widget.svelte
+++ b/apps/dashboard/src/lib/features/cohort/components/goals/my-goals-widget.svelte
@@ -28,7 +28,7 @@
     if (days === 0) return $t('cohorts.goals.lms.due_today');
     if (days === 1) return $t('cohorts.goals.lms.due_tomorrow');
 
-    return $t('cohorts.goals.lms.due_in_days').replace('{days}', String(days));
+    return $t('cohorts.goals.lms.due_in_days', { days: days });
   }
 
   function progressPct(assignment: (typeof cohortGoalApi.myGoals)[number]): number {


### PR DESCRIPTION
## What does this PR do?

This fixes a translation issue in the cohort `my-goals-widget.svelte` component that prevents the cohorts newsfeed page from loading.

Fixes #861

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Log in as a student in a cohort with active goals.
- Open the cohort newsfeed page.
- Confirm the goals display properly with their details.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved due-date messaging in the goals widget by correctly formatting the number of days remaining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the cohort goals widget’s due-date translation by using the translation library’s interpolation API instead of manually replacing the `{days}` placeholder.

- Passes the computed day count as interpolation data for `cohorts.goals.lms.due_in_days`.
- Leaves the existing today and tomorrow translations unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no blocking or non-blocking issues identified.

The focused change uses the translation function’s interpolation argument for the existing day count without altering goal calculation or rendering behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/cohort/components/goals/my-goals-widget.svelte | Replaces manual placeholder substitution with translation-library interpolation; no actionable issues identified. |

<sub>Reviews (1): Last reviewed commit: ["fix: translation issue in cohort goals w..."](https://github.com/classroomio/classroomio/commit/e6e9b55a4038bd392e07c08f064932ab3551d27d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52518449)</sub>

<!-- /greptile_comment -->