### PR TITLE
fix: missing import in cohort newsfeed

### DIFF
--- a/apps/dashboard/src/lib/features/cohort/api/newsfeed.svelte.ts
+++ b/apps/dashboard/src/lib/features/cohort/api/newsfeed.svelte.ts
@@ -24,7 +24,7 @@ import {
   ZUpdateCohortReaction
 } from '@cio/utils/validation/cohort';
 import { get } from 'svelte/store';
-import { isHtmlValueEmpty } from '$lib/utils/functions/toHtml';
+import { getTextFromHTML, isHtmlValueEmpty } from '$lib/utils/functions/toHtml';
 import { mapZodErrorsToTranslations } from '$lib/utils/validation';
 import { profile } from '$lib/utils/store/user';
 import { snackbar } from '$features/ui/snackbar/store';


### PR DESCRIPTION
## What does this PR do?

This change fixes the inability to create a comment under a cohost post. It fixes it explicitly for an admin. However, from a student's view, to even access the posts newsfeed, #861 has to be fixed.

Fixes #862

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Go to a cohort newsfeed as an admin.
- Write a comment under a post and click submit.
- Confirm the comment is created without an error.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for comments in the cohort newsfeed by correctly converting HTML content to plain text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes cohort newsfeed comment creation by importing the HTML-to-text helper already used by the comment validation path.
- Adds `getTextFromHTML` to the existing utility import in the cohort newsfeed API module.
- Resolves the missing runtime reference encountered when an administrator submits a comment.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and directly resolves the missing helper reference in cohort comment creation.

The imported symbol exists at the specified module and is reached through the browser-only comment submission interaction, with no changed validation, API payload, or authorization behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/cohort/api/newsfeed.svelte.ts | Adds the missing `getTextFromHTML` import from its existing utility module; no actionable regression was identified. |

<sub>Reviews (1): Last reviewed commit: ["fix: missing import in cohort newsfeed"](https://github.com/classroomio/classroomio/commit/a46a76e0040fbd202365fcb59461f652c77fd144) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52519794)</sub>

<!-- /greptile_comment -->