### PR TITLE
fix: show correct publish status for cohort courses

### DIFF
--- a/apps/dashboard/src/routes/(app)/cohorts/[id]/courses/+page.svelte
+++ b/apps/dashboard/src/routes/(app)/cohorts/[id]/courses/+page.svelte
@@ -52,7 +52,7 @@
       description: item.course.description ?? '',
       lessonCount: 0,
       totalStudents: 0,
-      isPublished: item.course.status === 'ACTIVE',
+      isPublished: !!item.course.isPublished,
       tags: []
     }))
   );
@@ -161,7 +161,7 @@
                     <p>{item.course.description}</p>
                   </Table.Cell>
                   <Table.Cell>
-                    <CoursePublishBadge isPublished={item.course.status === 'ACTIVE'} />
+                    <CoursePublishBadge isPublished={!!item.course.isPublished} />
                   </Table.Cell>
                   <Table.Cell class="text-center">
                     <Button

--- a/packages/db/src/queries/cohort/cohort.ts
+++ b/packages/db/src/queries/cohort/cohort.ts
@@ -476,6 +476,7 @@ export async function getCoursesByCohort(
         coverImage: string | null;
         slug: string | null;
         status: string | null;
+        isPublished: boolean | null;
       };
     }
   >


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes cohort courses showing Published all the time even when not published

Fixes #860 

<!-- Please provide a screenshots or upload a video for visual changes to speed up reviews -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Create a cohort if you don't have one
- Create courses in the cohort 
_- Notice the published state for the course when you haven't published it and when you publish it 

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Course publication indicators in cohort views now accurately reflect each course’s publication status.
  * Updated course data ensures publication badges and card displays remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects cohort course publication badges by exposing the canonical `course.isPublished` database field and using it in both grid and list views.

- Adds `isPublished` to the `getCoursesByCohort` result.
- Replaces the course lifecycle-status proxy with the actual publication flag in the cohort UI.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The database query now carries the canonical publication field through the API response, and both cohort course views consume it consistently.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/routes/(app)/cohorts/[id]/courses/+page.svelte | Uses the canonical publication flag consistently for cohort course cards and list badges. |
| packages/db/src/queries/cohort/cohort.ts | Selects and returns the nullable `isPublished` field through the existing cohort-course query contract. |

<sub>Reviews (1): Last reviewed commit: ["changed the checked value from status to..."](https://github.com/classroomio/classroomio/commit/1cd4d48d83bd6c94f824f5140e8de26e8e3558bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52600849)</sub>

**Context used:**

- Knowledge Base — [Dashboard app (`apps/dashboard`)](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/dashboard-app.md)
- Knowledge Base — [Shared Database Package (`packages/db`)](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/db-package.md)

<!-- /greptile_comment -->