### PR TITLE
docs(prd): sign-in methods on member profiles

### DIFF
--- a/prd/sign-in-methods/README.md
+++ b/prd/sign-in-methods/README.md
@@ -1,0 +1,369 @@
+# Sign-in Methods PRD
+
+## Status
+
+- Draft
+
+## Prototypes — the UX source of truth
+
+**The UX of this feature must be taken from the prototype folder.** Interactive HTML prototypes for every surface live in [`prototypes/sign-in-methods/`](../../prototypes/sign-in-methods/) and are the approved design reference for layout, badge shape, states (single method / multiple methods / unknown / never signed in), copy, and navigation flow. When this document and a prototype disagree on a UI detail, the prototype wins.
+
+**Start here:**
+
+```
+prototypes/sign-in-methods/index.html
+```
+
+| Surface | Files |
+| --- | --- |
+| Audience member profile (primary) | `audience-profile.html` |
+| Audience list column | `audience-list.html` |
+| Settings → Team list | `settings-team.html` |
+| Own account settings | `account-settings.html` |
+| Shared tokens | `app-theme.css` |
+
+## Purpose
+
+An org admin looking at a member today cannot tell how that person gets into the product. Password, Google, and enterprise SSO all render identically — an email address and nothing else. This feature surfaces each member's connected sign-in methods, and the method they last used, on the four places admins already look. The reference experiences are the member detail panels in Okta, WorkOS Admin Portal, and Google Workspace Admin, which separate "identities this account can use" from "how they last authenticated" rather than collapsing the two.
+
+## Problem Statement
+
+- An admin who has rolled out SSO has no way to see who is actually using it and who is still signing in with a password. That is the single most common question after an SSO rollout, and today it is unanswerable inside the product.
+- Support cannot answer "why can't this user log in" without database access, because nothing in the UI says whether the user even has a password.
+- Compliance-driven customers (the audience for `compliance-training-platform`) are asked to evidence that privileged accounts authenticate through the IdP. There is no screen to screenshot.
+- `account.provider_id` has held this data since the Better Auth migration. The only code that reads it is `hasVerifiedEmailProvider()`. It is a fully populated column with no product on top of it.
+- Users cannot see their own connected identities anywhere, which is table stakes in every comparable product.
+
+## Confirmed Decisions
+
+1. **Surfaces in v1**: all four — audience member profile, audience list column, Settings → Team list, and the user's own account settings page.
+2. **Last-used tracking ships in v1**: the product records which method was used at each real sign-in, and the member profile shows "Last signed in with `<method>` · `<relative time>`".
+3. **Cross-tenant SSO is labelled generically**: when a member's SSO identity belongs to a different organization, the badge reads `SSO` with no name. A connection's `display_name` is only rendered to admins of the org that owns that connection.
+4. **Method kinds are a closed set**: `password`, `google`, `sso`, `token_auth`. Magic link is not a method — see Non-Goals.
+5. **Precedence for single-badge surfaces**: `sso` > `token_auth` > `google` > `password`. Lists show only the highest-precedence method; the member profile shows every method.
+6. **Badge bugs on the profile page are fixed in this PRD**: `user-analytics.svelte` passes `type=` to `Badge` where the prop is `variant=`, so the course filter badges never change state; and the course status badge uses raw color classes instead of the `success` / `warning` variants.
+7. **Own account settings is read-only in v1**: the user sees their connected identities and when each was connected. Linking and unlinking are deferred — see Non-Goals and Risks.
+
+## Current-State Audit
+
+| Capability | Current State | Notes |
+| --- | --- | --- |
+| Identity storage | `account` table (`packages/db/src/schema.ts:130`) with `provider_id`, `password`, `created_at` | Values in use: `'credential'`, `'google'`, per-org SSO provider ids |
+| SSO connection metadata | `organization_sso_config` (`packages/db/src/schema.ts:2580`) with `better_auth_provider_id`, `display_name`, `organization_id` (unique, one per org) | This is the join key from `account.provider_id` to a human label |
+| SSO provider id format | `` `org-${orgId.slice(0, 8)}-${provider.toLowerCase()}` `` — `generateProviderId()`, `apps/api/src/services/organization/sso.ts:33` | An implementation detail; must not be pattern-matched |
+| Any read of `provider_id` | `hasVerifiedEmailProvider()`, `packages/db/src/queries/auth/profile.ts:10` | Only consumer in the codebase |
+| Login recording | `trackLoginHook`, `packages/db/src/auth/hooks/track-login.ts:13` → `analytics_login_events` | `unique(user_id, logged_in_date)` + `onConflictDoNothing`: at most one row per user per day, and no provider column |
+| Session hooks | `databaseHooks.session.create.after` / `.update.after`, `packages/db/src/auth.ts:97-126` | Both call `trackLoginHook`; `update` fires on session refresh (`updateAge` = 1 day), which is not a sign-in |
+| Magic link (`login-link` plugin) | `packages/db/src/auth/plugins/login-link.ts:77` raw-inserts a session with `impersonatedBy: 'login-link'` | Creates no `account` row, and bypasses `databaseHooks` entirely. Only caller is `createViewAsStudentToken` |
+| Token auth (`token-exchange` plugin) | `packages/db/src/auth/plugins/token-exchange.ts:86` raw-inserts a session; for new users `packages/db/src/auth/token-exchange.ts:76` calls `signUpEmail` with a random password | Produces a `credential` account row for a user who can never use a password |
+| Member profile page | `/org/[slug]/audience/[profileId]` → `user-analytics.svelte`, header is `hero-profile-card.svelte` | Header shows avatar, name, email, last seen. No badges |
+| Audience list | `audience.svelte:44` header array + `audience-member-row.svelte` | Columns are positional; header and cell order kept in sync manually |
+| Team list | `settings/pages/teams.svelte:164-202` | `Field.Set` list, not a table. Role badge + "invite sent" badge already present |
+| Own account settings | `/org/[slug]/settings` → `settings/pages/profile.svelte` | Profile picture, name, username, email change, language. No password UI, no identity UI |
+| Account API | `apps/api/src/routes/account/account.ts` — `GET /`, `PUT /profile`, `GET /profile`, `POST /view-as-student-token` | No endpoint returns linked identities |
+| Badge component | `packages/ui/src/base/badge/badge.svelte` | Variants `default | secondary | destructive | warning | success | outline`; base styles already size an inline `svg` to `size-3` |
+
+## Data Sources Checked
+
+- `packages/db/src/schema.ts` — `account`, `session`, `profile`, `analytics_login_events`, `organization_sso_config` shapes
+- `packages/db/src/auth.ts` — plugin registration, `databaseHooks`, social provider config
+- `packages/db/src/auth/plugins/login-link.ts` and `plugins/token-exchange.ts` — the two session write paths that bypass Better Auth
+- `apps/api/src/services/organization/sso.ts` — provider id generation and Enterprise gating
+- `apps/api/src/services/organization.ts:834-901` — `getUserAnalytics` response shape
+- `packages/db/src/queries/organization/organization.ts` — `getOrganizationAudience`, `getOrganizationTeam`
+- `prd/enterprise-sso [DONE]/README.md` — shipped SSO model and terminology
+
+## Product Goals
+
+- An admin can tell, at a glance and for any member, which sign-in methods that member has and which one they last used.
+- An admin can scan the audience and team lists and spot the accounts that are not on SSO.
+- A user can see their own connected identities.
+- The data is honest: a method is shown only if the member can actually sign in with it.
+- No identity information crosses an org boundary.
+
+## Non-Goals (v1)
+
+- **Linking and unlinking identities.** Unlink needs last-method guards, re-authentication, and a "set a password first" flow. Read-only in v1.
+- **Magic link as a user-facing method.** The `login-link` plugin exists only to power "view as student"; there is no general magic-link login to report on. Impersonation sessions must not be recorded as sign-ins.
+- **A full sign-in audit log.** One last-used record per user, not a history. `prd/enterprise-sso [DONE]` owns audit/observability.
+- **Filtering or segmenting the audience by sign-in method.** The column ships; the filter does not.
+- **Admin-forced method changes** (revoke a password, force SSO for one user). `organization_auth_policy.force_sso` already covers the org-wide case.
+- **Backfilling last-used for historical logins.** Not recoverable; the field starts collecting at deploy.
+
+---
+
+## Functional Requirements
+
+### 1. Audience member profile — `/org/[slug]/audience/[profileId]`
+
+Prototype: `audience-profile.html`.
+
+- `hero-profile-card.svelte` gains a badge row in the existing metadata flex (`lines 24-37`), below the email / last-seen line.
+- The last-used line renders alongside the existing "Last seen" metadata: `Last signed in with Acme Okta · 3 days ago`. It uses the same `calDateDiff` helper as last seen.
+- A **Sign-in methods** section renders below the metric cards **only when the member has two or more methods**. One method needs no section; the header badge already says it.
+- The section lists each method as an `Item` row: icon, label, and `Connected <date>`.
+- States the prototype covers, all of which must be implemented:
+  - **Single method** — one header badge, no section.
+  - **Multiple methods** — header badge shows the highest-precedence method, section lists all.
+  - **Foreign SSO** — badge reads `SSO`, section row reads `SSO` with no connection name and no domain.
+  - **Never signed in since the feature shipped** — methods render, last-used line is omitted entirely. Do not render "Unknown" or an empty dash.
+  - **No methods at all** — an invited member who has never completed signup. Render nothing rather than an empty section.
+
+### 2. Audience list — `/org/[slug]/audience`
+
+Prototype: `audience-list.html`.
+
+- A `Sign-in method` column sits between `Status` and `Date joined`.
+- One badge per row, highest precedence only. A member with two methods shows one badge; the profile is where the full set lives.
+- Pending invitees (no `profileId`) render an empty cell, matching how the name cell already degrades for them.
+- The header array in `audience.svelte:44-49` and the cells in `audience-member-row.svelte` must be updated together — column order is positional.
+
+### 3. Settings → Team list — `/org/[slug]/settings/teams`
+
+Prototype: `settings-team.html`.
+
+- The badge slots into the existing left-hand flex row, immediately after the role badge, matching the `mr-3 text-xs` pattern already there.
+- Unverified members (invite sent, never signed in) keep only the existing "invite sent" badge and show no method badge.
+
+### 4. Own account settings — `/org/[slug]/settings`
+
+Prototype: `account-settings.html`.
+
+- A new **Sign-in methods** `Field.Set` is appended to `profile.svelte`, after "Personal information".
+- Each connected identity is one row: icon, label, and `Connected <date>`.
+- The user's own SSO connection is always labelled with its `display_name` — a user is entitled to see their own IdP.
+- Read-only. No unlink buttons, no "add method" affordance. A `Field.Description` explains that identities are managed by the organization.
+- **Empty state**: a user with no account rows (token-auth-only, pre-fix) sees a single row explaining their access is managed by their organization.
+
+### 5. Badge vocabulary (all surfaces)
+
+| Kind | Label | Icon | Variant |
+| --- | --- | --- | --- |
+| `sso` | connection `display_name`, else `SSO` | `ShieldCheck` | `secondary` |
+| `token_auth` | `Token auth` | `KeyRound` | `secondary` |
+| `google` | `Google` | inline Google mark | `outline` |
+| `password` | `Password` | `LockKeyhole` | `outline` |
+
+Managed identities (`sso`, `token_auth`) use `secondary` so they read as the stronger state; self-managed ones use `outline`.
+
+---
+
+## Technical Design
+
+### Data model (`packages/db/src/schema.ts`)
+
+Two changes. Neither adds a table.
+
+#### 1. Last-used columns on `profile`
+
+`analytics_login_events` is the wrong home: `unique(user_id, logged_in_date)` with `onConflictDoNothing` means only the day's *first* login is ever written, so a provider column there would silently record the wrong method for anyone who signs in twice a day by different routes. `profile` is 1:1 with `user` (created by `createProfileHook`) and is already joined by every surface in this PRD.
+
+```ts
+// profile
+lastSignInMethod: text('last_sign_in_method'),
+lastSignInProviderId: text('last_sign_in_provider_id'),
+lastSignInAt: timestamp('last_sign_in_at', { withTimezone: true, mode: 'string' })
+```
+
+`lastSignInProviderId` stores the raw `account.provider_id` so the SSO label can be resolved against `organization_sso_config` at render time, org-scoped, rather than being frozen into the row. This follows the repo rule that a persisted column stores the relationship, not a copied display value.
+
+#### 2. Stop token-exchange from minting fake password identities
+
+`packages/db/src/auth/token-exchange.ts:76` calls `signUpEmail` with a random password, producing an `account` row with `provider_id = 'credential'` for a user who has no password and can never use one. Left alone, every token-auth user would be badged `Password` — the exact opposite of the truth.
+
+Fix at the write site: after the sign-up completes, update the created row's `provider_id` to `'token-exchange'`. Better Auth only looks up `'credential'` when handling password sign-in, so retagging the row disables a path the user never had, and makes the column honest.
+
+No migration is authored here; schema edits stop at a passing `@cio/db` build.
+
+### Deriving available methods (query layer)
+
+```
+getSignInMethodsByUserIds(userIds, orgId):
+  rows = select account.userId, account.providerId, account.createdAt,
+                sso.displayName, sso.organizationId
+         from account
+         left join organization_sso_config sso
+           on sso.better_auth_provider_id = account.provider_id
+         where account.userId in userIds
+
+  for each row:
+    if providerId == 'credential'      -> { kind: 'password',   label: null }
+    else if providerId == 'google'     -> { kind: 'google',     label: null }
+    else if providerId == 'token-exchange' -> { kind: 'token_auth', label: null }
+    else                               -> { kind: 'sso',
+                                            label: sso.organizationId == orgId ? sso.displayName : null }
+
+  group by userId, sort by PRECEDENCE
+```
+
+Two rules that carry the security and correctness weight:
+
+- **Never pattern-match the provider id.** The `org-` prefix comes from `generateProviderId()` and is not a contract. Anything that is not a known literal and does not resolve through the join is still reported as `sso` with a null label — unknown-but-federated is the safe default.
+- **Label only same-org connections.** `account` is global to the user; a learner in three orgs carries all three SSO identities. Comparing `sso.organizationId` to the requesting `orgId` is what stops an Acme admin learning that a shared learner also belongs to Globex.
+
+The function takes an array of user ids and returns a `Map<userId, SignInMethod[]>` so the audience and team lists stay one round trip.
+
+### Recording the last-used method
+
+`databaseHooks.session.create.after` receives an optional second `context` argument. `ctx.path` identifies the route that produced the session, which is the only place the provider is knowable.
+
+```
+trackSignInMethodHook(session, ctx):
+  method, providerId = derive(ctx.path, ctx.params)
+    '/sign-in/email' | '/sign-up/email'   -> ('password', 'credential')
+    '/callback/:id'                       -> ('google', ctx.params.id)   // when id == 'google'
+    '/sign-in/sso' | '/sso/callback/:id'  -> ('sso', ctx.params.id)
+    anything else                         -> return   // do not write
+
+  update profile set last_sign_in_method, last_sign_in_provider_id, last_sign_in_at = now()
+  where user_id = session.userId
+```
+
+Three guards, each covering a trap found in the audit:
+
+- **Wire it to `session.create.after` only, never `session.update.after`.** The update hook fires on every session refresh (`updateAge` = 1 day). Recording there would make "last signed in" mean "last used the app", duplicating the existing last-seen field.
+- **`login-link` must not record.** It raw-inserts a session (`plugins/login-link.ts:77`) so no hook fires today, and that is the correct behavior: its only caller is "view as student". An admin impersonating a learner must not overwrite that learner's sign-in record.
+- **`token-exchange` must record explicitly.** It also raw-inserts (`plugins/token-exchange.ts:86`), so it calls the recorder directly with `('token_auth', 'token-exchange')` at that write site.
+
+### Shared types
+
+```ts
+// packages/utils/src/validation/account/sign-in-method.ts
+export const SIGN_IN_METHOD = {
+  PASSWORD: 'password',
+  GOOGLE: 'google',
+  SSO: 'sso',
+  TOKEN_AUTH: 'token_auth'
+} as const;
+
+export const ZSignInMethodKind = z.nativeEnum(SIGN_IN_METHOD);
+export type TSignInMethodKind = z.infer<typeof ZSignInMethodKind>;
+```
+
+Response shapes, defined once and reused by all four endpoints:
+
+```ts
+type SignInMethod = { kind: TSignInMethodKind; label: string | null; connectedAt: string };
+type LastSignIn = { kind: TSignInMethodKind; label: string | null; at: string } | null;
+```
+
+### API routes
+
+| Method | Path | Change | Guard |
+| --- | --- | --- | --- |
+| GET | `/organization/audience/:userId/analytics` | Add `user.signInMethods: SignInMethod[]` and `user.lastSignIn: LastSignIn` | `authMiddleware`, `orgTeamMemberMiddleware` |
+| GET | `/organization/audience` | Add `signInMethod: SignInMethod \| null` per row (highest precedence) | `authMiddleware`, `orgTeamMemberMiddleware` |
+| GET | `/organization/team` | Add `signInMethod: SignInMethod \| null` per member | `authMiddleware`, `orgTeamMemberMiddleware` |
+| GET | `/account/identities` | New. Returns `{ methods: SignInMethod[]; lastSignIn: LastSignIn }` for the caller | `authMiddleware` |
+
+`/account/identities` resolves SSO labels against the caller's own connection rather than a requesting org, since a user always may see their own IdP.
+
+Each route returns a single type, per the routing rules in `CLAUDE.md`.
+
+### Frontend plan (dashboard)
+
+Layering follows `CLAUDE.md`: validation → queries → services → routes → feature types → API class → component.
+
+| Layer | File | Change |
+| --- | --- | --- |
+| Query | `packages/db/src/queries/auth/sign-in-methods.ts` | New. `getSignInMethodsByUserIds`, `recordSignInMethod` |
+| Hook | `packages/db/src/auth/hooks/track-sign-in-method.ts` | New. `trackSignInMethodHook(session, ctx)` |
+| Service | `apps/api/src/services/organization.ts` | `getUserAnalytics`, `getOrgAudience`, `getOrgTeam` attach methods |
+| Service | `apps/api/src/services/account.ts` | `getAccountIdentities(userId)` |
+| Types | `apps/dashboard/src/lib/features/audience/utils/types.ts` | Inferred from the API, per repo rules |
+| Utils | `apps/dashboard/src/lib/features/audience/utils/audience-utils.ts` | `signInMethodBadgeVariant`, `signInMethodLabelKey` — mirrors the existing `statusBadgeVariant` / `statusLabelKey` pair |
+| Component | `apps/dashboard/src/lib/features/ui/sign-in-method-badge.svelte` | New. Props `kind`, `label`. Used by all four surfaces |
+| Surfaces | `hero-profile-card.svelte`, `user-analytics.svelte`, `audience.svelte`, `audience-member-row.svelte`, `teams.svelte`, `settings/pages/profile.svelte` | Render the badge |
+| i18n | `apps/dashboard/src/lib/utils/translations/en.json` + `pnpm translate` | `sign_in_method.*` keys |
+
+The badge is a dashboard feature component, not a `packages/ui` primitive — it encodes product vocabulary, not a reusable visual pattern.
+
+### Build verification
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH"
+pnpm --filter @cio/db build
+pnpm --filter @cio/api^... build && pnpm --filter @cio/api build
+test -f apps/dashboard/.env || cp apps/dashboard/.env.example apps/dashboard/.env
+pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build
+pnpm format:check
+```
+
+## Implementation Order
+
+### Phase 1: Schema and constants
+
+1. Add `lastSignInMethod`, `lastSignInProviderId`, `lastSignInAt` to `profile` in `packages/db/src/schema.ts`.
+2. Add `SIGN_IN_METHOD` and `ZSignInMethodKind` to `packages/utils/src/validation/account/sign-in-method.ts`.
+3. `pnpm --filter @cio/db build`.
+
+### Phase 2: Recording
+
+4. Add `recordSignInMethod` to the new query file.
+5. Add `trackSignInMethodHook`; wire it into `databaseHooks.session.create.after` only.
+6. Retag the token-exchange `credential` row to `'token-exchange'` at `packages/db/src/auth/token-exchange.ts`, and call the recorder from the plugin's session write site.
+7. Confirm `login-link` still records nothing.
+
+### Phase 3: Query layer
+
+8. `getSignInMethodsByUserIds(userIds, orgId)` with the `organization_sso_config` left join and the org-scoped label rule.
+9. Precedence sort helper.
+
+### Phase 4: Services and routes
+
+10. Attach methods in `getUserAnalytics`, `getOrgAudience`, `getOrgTeam`.
+11. Add `getAccountIdentities` and `GET /account/identities`.
+12. `pnpm --filter @cio/api build`.
+
+### Phase 5: Dashboard
+
+13. `sign-in-method-badge.svelte` plus the badge-variant/label helpers.
+14. Member profile: header badges, last-used line, Sign-in methods section.
+15. Audience list column (header array + row cell together).
+16. Team list badge.
+17. Own account settings section.
+18. Translation keys, then `cd apps/dashboard && pnpm translate`.
+
+### Phase 6: Bug fixes and verification
+
+19. `user-analytics.svelte`: `type=` → `variant=` on the filter badges; course status badge to `success` / `warning` variants.
+20. Run the full build verification block.
+
+## Acceptance Criteria
+
+1. A member with only a password shows one `Password` badge on their profile, and no Sign-in methods section.
+2. A member with Google and password shows a `Google` badge in the header (precedence) and a section listing both, each with its connected date.
+3. A member who signed in through their own org's SSO shows a badge carrying the connection's `display_name`.
+4. A member whose only SSO identity belongs to another organization shows `SSO` with no name, and the other org's `display_name` appears nowhere in the API response.
+5. The audience list shows exactly one badge per member, the highest-precedence one, and an empty cell for pending invitees.
+6. The team list shows the badge after the role badge, and shows no badge for unverified invitees.
+7. A user visiting their own settings sees every identity they can sign in with, labelled with their own IdP name where applicable.
+8. Signing in with email and password sets `last_sign_in_method = 'password'`; signing in with Google sets `'google'`; signing in through SSO sets `'sso'`.
+9. A session refresh 24 hours after sign-in does not change `last_sign_in_at`.
+10. Using "view as student" does not change the target learner's last-used record.
+11. A user created through token exchange is badged `Token auth`, never `Password`.
+12. A member who has not signed in since deploy renders their methods with no last-used line, and no placeholder text.
+13. Loading the audience list for 50 members issues one sign-in-method query, not 50.
+14. The course filter badges on the member profile visibly change state when clicked.
+15. Existing audience, team, profile, and analytics behavior continues to work exactly as today (zero regression).
+16. All user-facing strings use translation keys, and every locale file is regenerated.
+17. `pnpm --filter @cio/db build`, `pnpm --filter @cio/api build`, `pnpm --filter @cio/dashboard build`, and `pnpm format:check` all pass.
+
+---
+
+## Risks and Mitigations
+
+- **Risk**: Token-auth users created *before* this change already have `credential` account rows that are indistinguishable from real password users, and will be badged `Password`.
+  - **Mitigation**: The retag fixes all new rows. For existing ones, ship a targeted script that retags `credential` rows belonging to users who are members only of orgs with token auth configured and who have no other account row. Users outside that intersection are genuinely ambiguous; leave them and document the limitation.
+- **Risk**: `ctx.path` is a Better Auth internal shape, so a library upgrade could silently change the strings and stop recording.
+  - **Mitigation**: `derive()` returns early on anything unrecognized, so an upgrade degrades to "no last-used line" rather than wrong data. Add unit tests over the path strings so the break is loud at CI time, not in production.
+- **Risk**: `last_sign_in_*` is null for the entire user base on deploy day, making the feature look broken.
+  - **Mitigation**: The last-used line is omitted rather than showing a placeholder, and the methods badges — which are fully retroactive from `account` — carry the feature on their own from minute one.
+- **Risk**: A member's SSO identity leaks another org's connection name.
+  - **Mitigation**: The label is resolved by comparing `organization_sso_config.organization_id` to the requesting org, in the query layer rather than at render time, so no route can opt out. Acceptance criterion 4 tests the response body, not just the UI.
+- **Risk**: Adding methods to the audience list introduces an N+1 across a paginated list.
+  - **Mitigation**: The query is batched by `inArray(userIds)` and returns a map, mirroring the existing batched last-seen lookup in `packages/db/src/queries/analytics/analytics.ts:90`. Acceptance criterion 13 covers it.
+- **Risk**: Read-only identities invite the immediate follow-up "let me unlink Google", and shipping that carelessly locks users out.
+  - **Mitigation**: Explicitly a non-goal. When it is picked up it needs a last-method guard, a set-a-password step, and re-authentication — a PRD of its own.
+- **Risk**: Rendering the Google brand mark inline pulls a third-party logo into the design system.
+  - **Mitigation**: Inline the mark in the feature component only, sized by the existing `[&>svg]:size-3` badge rule. It does not enter `packages/ui`.

--- a/prd/sign-in-methods/README.md
+++ b/prd/sign-in-methods/README.md
@@ -55,13 +55,13 @@ An org admin looking at a member today cannot tell how that person gets into the
 | Login recording | `trackLoginHook`, `packages/db/src/auth/hooks/track-login.ts:13` → `analytics_login_events` | `unique(user_id, logged_in_date)` + `onConflictDoNothing`: at most one row per user per day, and no provider column |
 | Session hooks | `databaseHooks.session.create.after` / `.update.after`, `packages/db/src/auth.ts:97-126` | Both call `trackLoginHook`; `update` fires on session refresh (`updateAge` = 1 day), which is not a sign-in |
 | Magic link (`login-link` plugin) | `packages/db/src/auth/plugins/login-link.ts:77` raw-inserts a session with `impersonatedBy: 'login-link'` | Creates no `account` row, and bypasses `databaseHooks` entirely. Only caller is `createViewAsStudentToken` |
-| Token auth (`token-exchange` plugin) | `packages/db/src/auth/plugins/token-exchange.ts:86` raw-inserts a session; for new users `packages/db/src/auth/token-exchange.ts:76` calls `signUpEmail` with a random password | Produces a `credential` account row for a user who can never use a password |
+| Token auth (`token-exchange` plugin) | `packages/db/src/auth/plugins/token-exchange.ts:86` raw-inserts a session. `packages/db/src/auth/token-exchange.ts:73-86` branches: existing users are reused as-is, new users go through `signUpEmail` with a random password | New users get a `credential` row they can never use; existing users get no identity row at all. Neither branch records token auth |
 | Member profile page | `/org/[slug]/audience/[profileId]` → `user-analytics.svelte`, header is `hero-profile-card.svelte` | Header shows avatar, name, email, last seen. No badges |
 | Audience list | `audience.svelte:44` header array + `audience-member-row.svelte` | Columns are positional; header and cell order kept in sync manually |
 | Team list | `settings/pages/teams.svelte:164-202` | `Field.Set` list, not a table. Role badge + "invite sent" badge already present |
 | Own account settings | `/org/[slug]/settings` → `settings/pages/profile.svelte` | Profile picture, name, username, email change, language. No password UI, no identity UI |
 | Account API | `apps/api/src/routes/account/account.ts` — `GET /`, `PUT /profile`, `GET /profile`, `POST /view-as-student-token` | No endpoint returns linked identities |
-| Badge component | `packages/ui/src/base/badge/badge.svelte` | Variants `default | secondary | destructive | warning | success | outline`; base styles already size an inline `svg` to `size-3` |
+| Badge component | `packages/ui/src/base/badge/badge.svelte` | Variants `default`, `secondary`, `destructive`, `warning`, `success`, `outline`; base styles already size an inline `svg` to `size-3` |
 
 ## Data Sources Checked
 
@@ -98,13 +98,13 @@ An org admin looking at a member today cannot tell how that person gets into the
 
 Prototype: `audience-profile.html`.
 
-- `hero-profile-card.svelte` gains a badge row in the existing metadata flex (`lines 24-37`), below the email / last-seen line.
+- `hero-profile-card.svelte` gains a badge row in the existing metadata flex (`lines 24-37`), below the email / last-seen line. **The profile header shows every method the member has**, in precedence order — precedence only decides ordering here, not what is dropped. Single-badge behavior belongs to the list surfaces (§2, §3), where there is one cell to fill.
 - The last-used line renders alongside the existing "Last seen" metadata: `Last signed in with Acme Okta · 3 days ago`. It uses the same `calDateDiff` helper as last seen.
 - A **Sign-in methods** section renders below the metric cards **only when the member has two or more methods**. One method needs no section; the header badge already says it.
 - The section lists each method as an `Item` row: icon, label, and `Connected <date>`.
 - States the prototype covers, all of which must be implemented:
   - **Single method** — one header badge, no section.
-  - **Multiple methods** — header badge shows the highest-precedence method, section lists all.
+  - **Multiple methods** — every method badged in the header, section lists all with their connected dates.
   - **Foreign SSO** — badge reads `SSO`, section row reads `SSO` with no connection name and no domain.
   - **Never signed in since the feature shipped** — methods render, last-used line is omitted entirely. Do not render "Unknown" or an empty dash.
   - **No methods at all** — an invited member who has never completed signup. Render nothing rather than an empty section.
@@ -167,13 +167,29 @@ lastSignInAt: timestamp('last_sign_in_at', { withTimezone: true, mode: 'string' 
 
 `lastSignInProviderId` stores the raw `account.provider_id` so the SSO label can be resolved against `organization_sso_config` at render time, org-scoped, rather than being frozen into the row. This follows the repo rule that a persisted column stores the relationship, not a copied display value.
 
-#### 2. Stop token-exchange from minting fake password identities
+#### 2. Give token-exchange a real identity, and stop it minting fake password ones
 
-`packages/db/src/auth/token-exchange.ts:76` calls `signUpEmail` with a random password, producing an `account` row with `provider_id = 'credential'` for a user who has no password and can never use one. Left alone, every token-auth user would be badged `Password` — the exact opposite of the truth.
+`packages/db/src/auth/token-exchange.ts` has two branches, and both are wrong for this feature in different ways:
 
-Fix at the write site: after the sign-up completes, update the created row's `provider_id` to `'token-exchange'`. Better Auth only looks up `'credential'` when handling password sign-in, so retagging the row disables a path the user never had, and makes the column honest.
+- **New user** (`:75-86`) — calls `signUpEmail` with a random password, producing an `account` row with `provider_id = 'credential'` for someone who has no password and can never use one. Left alone, these users are badged `Password`, the exact opposite of the truth.
+- **Existing user** (`:73-74`) — reuses the row and calls nothing. No account row is written at all, so a user who authenticates by token exchange but also has, say, a password would be badged `Password` with no sign that partner token access exists.
 
-No migration is authored here; schema edits stop at a passing `@cio/db` build.
+One helper fixes both, called once after `ensureOrgMembership` so it covers every successful exchange rather than only first-time signups:
+
+```
+ensureTokenAuthIdentity(userId, orgId):
+  insert into account (user_id, provider_id, account_id)
+  values (userId, 'token-exchange', orgId)
+  on conflict (user_id, provider_id, account_id) do nothing
+```
+
+`account_id` holds the org id because the org's token issuer *is* the external identity provider here. It is a scoping key, not a foreign key — `account` has no org relationship and none is being invented — and it gives natural per-org dedup for a user who reaches the product through two different partner orgs.
+
+In the new-user branch only, delete the synthetic `credential` row after sign-up. Deleting rather than retagging keeps `account_id` meaningful and drops a bcrypt hash of a random password that nothing can ever verify. Better Auth only looks up `'credential'` for password sign-in, so removing it closes a path the user never had. Note the side effect, which is correct: `hasVerifiedEmailProvider()` starts returning true for these users, because a partner-issued token *is* proof of the email.
+
+#### Migrations
+
+Both changes need a real migration against deployed databases — the `profile` columns, and a backfill pass for token-auth users. Following repo convention, no migration is authored in this PRD; generation and review happen in the normal migration workflow. It must be deployed **before** the application code, since the recorder writes `last_sign_in_*` on the first sign-in after rollout. Rollback is safe in either order: the columns are nullable and every read treats null as "no last-used line", so reverting the app while leaving the columns in place is a no-op.
 
 ### Deriving available methods (query layer)
 
@@ -207,8 +223,10 @@ The function takes an array of user ids and returns a `Map<userId, SignInMethod[
 
 `databaseHooks.session.create.after` receives an optional second `context` argument. `ctx.path` identifies the route that produced the session, which is the only place the provider is knowable.
 
-```
+```text
 trackSignInMethodHook(session, ctx):
+  if not ctx or not session?.userId: return   // context is optional in the hook signature
+
   method, providerId = derive(ctx.path, ctx.params)
     '/sign-in/email' | '/sign-up/email'   -> ('password', 'credential')
     '/callback/:id'                       -> ('google', ctx.params.id)   // when id == 'google'
@@ -301,7 +319,7 @@ pnpm format:check
 
 4. Add `recordSignInMethod` to the new query file.
 5. Add `trackSignInMethodHook`; wire it into `databaseHooks.session.create.after` only.
-6. Retag the token-exchange `credential` row to `'token-exchange'` at `packages/db/src/auth/token-exchange.ts`, and call the recorder from the plugin's session write site.
+6. Add `ensureTokenAuthIdentity(userId, orgId)` and call it after `ensureOrgMembership` in `packages/db/src/auth/token-exchange.ts`, so both the new-user and existing-user branches are covered. Delete the synthetic `credential` row in the new-user branch. Call the recorder from the plugin's session write site.
 7. Confirm `login-link` still records nothing.
 
 ### Phase 3: Query layer
@@ -332,7 +350,7 @@ pnpm format:check
 ## Acceptance Criteria
 
 1. A member with only a password shows one `Password` badge on their profile, and no Sign-in methods section.
-2. A member with Google and password shows a `Google` badge in the header (precedence) and a section listing both, each with its connected date.
+2. A member with Google and password shows both badges in the profile header, ordered by precedence, and a section listing both with their connected dates.
 3. A member who signed in through their own org's SSO shows a badge carrying the connection's `display_name`.
 4. A member whose only SSO identity belongs to another organization shows `SSO` with no name, and the other org's `display_name` appears nowhere in the API response.
 5. The audience list shows exactly one badge per member, the highest-precedence one, and an empty cell for pending invitees.
@@ -342,19 +360,20 @@ pnpm format:check
 9. A session refresh 24 hours after sign-in does not change `last_sign_in_at`.
 10. Using "view as student" does not change the target learner's last-used record.
 11. A user created through token exchange is badged `Token auth`, never `Password`.
-12. A member who has not signed in since deploy renders their methods with no last-used line, and no placeholder text.
-13. Loading the audience list for 50 members issues one sign-in-method query, not 50.
-14. The course filter badges on the member profile visibly change state when clicked.
-15. Existing audience, team, profile, and analytics behavior continues to work exactly as today (zero regression).
-16. All user-facing strings use translation keys, and every locale file is regenerated.
-17. `pnpm --filter @cio/db build`, `pnpm --filter @cio/api build`, `pnpm --filter @cio/dashboard build`, and `pnpm format:check` all pass.
+12. An **existing** user who authenticates through token exchange for the first time gains a `Token auth` badge, and reaching the product a second time through the same org creates no duplicate identity.
+13. A member who has not signed in since deploy renders their methods with no last-used line, and no placeholder text.
+14. Loading the audience list for 50 members issues one sign-in-method query, not 50.
+15. The course filter badges on the member profile visibly change state when clicked.
+16. Existing audience, team, profile, and analytics behavior continues to work exactly as today (zero regression).
+17. All user-facing strings use translation keys, and every locale file is regenerated.
+18. `pnpm --filter @cio/db build`, `pnpm --filter @cio/api build`, `pnpm --filter @cio/dashboard build`, and `pnpm format:check` all pass.
 
 ---
 
 ## Risks and Mitigations
 
 - **Risk**: Token-auth users created *before* this change already have `credential` account rows that are indistinguishable from real password users, and will be badged `Password`.
-  - **Mitigation**: The retag fixes all new rows. For existing ones, ship a targeted script that retags `credential` rows belonging to users who are members only of orgs with token auth configured and who have no other account row. Users outside that intersection are genuinely ambiguous; leave them and document the limitation.
+  - **Mitigation**: `ensureTokenAuthIdentity` self-heals going forward — the next exchange any such user performs writes the correct identity, whichever branch they hit. For users who never come back, ship a targeted backfill that deletes `credential` rows belonging to users who are members only of orgs with token auth configured and who have no other account row, inserting the token-auth identity in their place. Users outside that intersection are genuinely ambiguous; leave them and document the limitation.
 - **Risk**: `ctx.path` is a Better Auth internal shape, so a library upgrade could silently change the strings and stop recording.
   - **Mitigation**: `derive()` returns early on anything unrecognized, so an upgrade degrades to "no last-used line" rather than wrong data. Add unit tests over the path strings so the break is loud at CI time, not in production.
 - **Risk**: `last_sign_in_*` is null for the entire user base on deploy day, making the feature look broken.

--- a/prototypes/sign-in-methods/account-settings.html
+++ b/prototypes/sign-in-methods/account-settings.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>My Account · Sign-in Methods · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .fset { border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 20px; background: var(--card); margin-bottom: 18px; }
+      .legend { font-size: 15px; font-weight: 600; letter-spacing: -0.01em; margin: 0 0 4px; }
+      .fdesc { font-size: 13px; color: var(--muted-foreground); margin: 0 0 16px; line-height: 1.6; }
+      .two { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+      .m-ico { width: 34px; height: 34px; border-radius: var(--radius-md); border: 1px solid var(--border); background: var(--background); display: grid; place-items: center; flex-shrink: 0; }
+      .m-ico svg { width: 16px; height: 16px; stroke-width: 1.9; color: var(--muted-foreground); }
+      .m-ico svg.brand { stroke: none; }
+      .m-ico.managed { background: color-mix(in oklab, var(--primary) 10%, transparent); border-color: color-mix(in oklab, var(--primary) 22%, transparent); }
+      .m-ico.managed svg { color: var(--primary); }
+      .methods { display: grid; gap: 8px; }
+      .avatar-lg { width: 60px; height: 60px; border-radius: 999px; background: color-mix(in oklab, var(--primary) 12%, transparent); color: var(--primary); display: grid; place-items: center; font-size: 21px; font-weight: 600; }
+      .badge svg.brand { stroke: none; }
+      .v-case { border: 1px dashed var(--border); border-radius: var(--radius-lg); padding: 14px 16px; margin-top: 10px; }
+      .v-case .lbl { font-size: 11px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted-foreground); margin-bottom: 9px; }
+      @media (max-width: 760px) { .two { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="brand"><div class="brand-mark">A</div><div class="brand-name">Acme Training</div></div>
+        <div class="nav-label">Organization</div>
+        <a class="nav-item" href="index.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Dashboard</a>
+        <a class="nav-item" href="index.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Courses<span class="nav-tail tnum">12</span></a>
+        <a class="nav-item" href="audience-list.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/></svg>Audience<span class="nav-tail tnum">248</span></a>
+        <a class="nav-item" href="index.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>Analytics</a>
+        <div class="nav-label">Settings</div>
+        <a class="nav-item active" href="account-settings.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>My account</a>
+        <a class="nav-item" href="settings-team.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/></svg>Team</a>
+        <div class="sidebar-foot"><div class="avatar">JD</div><div class="who"><div class="nm">Jordan Diallo</div><div class="rl">Admin</div></div></div>
+      </aside>
+
+      <div class="main">
+        <header class="topbar">
+          <nav class="crumbs"><a href="index.html">Settings</a><span class="sep">/</span><span class="here">My account</span></nav>
+          <div class="top-actions">
+            <a class="btn btn-sm btn-outline" href="index.html">Prototype map</a>
+            <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+          </div>
+        </header>
+
+        <main class="content">
+          <div class="wrap-narrow">
+            <div class="page-head"><div><h1 class="page-title">My account</h1><p class="page-sub">Your profile and how you sign in.</p></div></div>
+
+            <div class="fset">
+              <p class="legend">Profile picture</p>
+              <div style="display: flex; align-items: center; gap: 16px">
+                <div class="avatar-lg">JD</div>
+                <button class="btn btn-outline btn-sm">Change picture</button>
+              </div>
+            </div>
+
+            <div class="fset">
+              <p class="legend">Personal information</p>
+              <p class="fdesc">This is how you appear to learners in your organization.</p>
+              <div class="two">
+                <div class="field"><label class="label">Full name</label><input class="input" value="Jordan Diallo" /></div>
+                <div class="field"><label class="label">Username</label><input class="input" value="jordan" /></div>
+              </div>
+              <div class="field"><label class="label">Email</label><input class="input" value="jordan.diallo@acme.com" /></div>
+              <div class="field"><label class="label">Language</label><select class="select"><option>English</option><option>Français</option></select></div>
+            </div>
+
+            <!-- NEW SECTION -->
+            <div class="fset">
+              <p class="legend">Sign-in methods</p>
+              <p class="fdesc">The ways you can get into your account. These are managed by your organization — contact an admin to change them.</p>
+
+              <div class="methods">
+                <div class="item">
+                  <div class="m-ico managed"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg></div>
+                  <div class="item-content">
+                    <div class="item-title">Acme Okta</div>
+                    <div class="item-desc">Single sign-on · connected 14 Feb 2026</div>
+                  </div>
+                  <div class="item-actions"><span class="badge badge-success-soft">Last used · 2 hours ago</span></div>
+                </div>
+                <div class="item">
+                  <div class="m-ico"><svg class="brand" viewBox="0 0 24 24"><path fill="#4285F4" d="M23.5 12.3c0-.8-.1-1.6-.2-2.3H12v4.5h6.5a5.6 5.6 0 0 1-2.4 3.6v3h3.9c2.3-2.1 3.5-5.2 3.5-8.8z"/><path fill="#34A853" d="M12 24c3.2 0 5.9-1.1 7.9-2.9l-3.9-3a7.2 7.2 0 0 1-10.7-3.8h-4v3.1A12 12 0 0 0 12 24z"/><path fill="#FBBC05" d="M5.3 14.3a7.1 7.1 0 0 1 0-4.6v-3h-4a12 12 0 0 0 0 10.7l4-3.1z"/><path fill="#EA4335" d="M12 4.8c1.8 0 3.4.6 4.6 1.8l3.5-3.5A12 12 0 0 0 1.3 6.7l4 3.1A7.2 7.2 0 0 1 12 4.8z"/></svg></div>
+                  <div class="item-content">
+                    <div class="item-title">Google</div>
+                    <div class="item-desc">jordan.diallo@acme.com · connected 3 Nov 2025</div>
+                  </div>
+                </div>
+                <div class="item">
+                  <div class="m-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div>
+                  <div class="item-content">
+                    <div class="item-title">Password</div>
+                    <div class="item-desc">Connected 3 Nov 2025</div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="v-case">
+                <div class="lbl">Empty state — access managed entirely by the organization</div>
+                <div class="item item-dashed">
+                  <div class="m-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 21h18M5 21V7l7-4 7 4v14M9 9h1M14 9h1M9 13h1M14 13h1M9 17h1M14 17h1"/></svg></div>
+                  <div class="item-content">
+                    <div class="item-title">Managed by your organization</div>
+                    <div class="item-desc">You sign in through Acme Training. There is nothing to manage here.</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <p class="hint">Read-only in v1. Linking and unlinking need a last-method guard, a set-a-password step, and re-authentication — deferred deliberately.</p>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <script>
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>

--- a/prototypes/sign-in-methods/app-theme.css
+++ b/prototypes/sign-in-methods/app-theme.css
@@ -1,0 +1,1178 @@
+/*
+ * app-theme.css — shared theme for the learning-paths prototypes.
+ *
+ * Tokens mirror packages/ui/src/index.css (shadcn-svelte) exactly:
+ * OKLCH palette, Geist, --radius: 0.625rem, shadow-2xs, and the component
+ * recipes from @cio/ui base components (Button, Badge, Item, Progress, Sidebar).
+ * Dark mode uses the same `.dark` class convention as the app.
+ */
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.488 0.243 264.376);
+  --primary-foreground: oklch(0.97 0.014 254.604);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+
+  /* Semantic states from @cio/ui Badge variants (emerald / amber) */
+  --success: oklch(0.596 0.145 163.225); /* emerald-600 */
+  --success-foreground: #fff;
+  --success-soft: oklch(0.596 0.145 163.225 / 0.12);
+  --warning: oklch(0.666 0.179 58.318); /* amber-600 */
+  --warning-foreground: #fff;
+  --warning-soft: oklch(0.666 0.179 58.318 / 0.14);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  --shadow-2xs: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.424 0.199 265.638);
+  --primary-foreground: oklch(0.97 0.014 254.604);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+
+  --success: oklch(0.696 0.17 162.48); /* emerald-500 */
+  --success-foreground: oklch(0.262 0.051 172.552); /* emerald-950 */
+  --success-soft: oklch(0.696 0.17 162.48 / 0.16);
+  --warning: oklch(0.769 0.188 70.08); /* amber-500 */
+  --warning-foreground: oklch(0.279 0.077 45.635); /* amber-950 */
+  --warning-soft: oklch(0.769 0.188 70.08 / 0.16);
+}
+
+/* ============ base ============ */
+* {
+  box-sizing: border-box;
+  border-color: var(--border);
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+body {
+  font-family:
+    'Geist',
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+  background: var(--background);
+  color: var(--foreground);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+button {
+  font: inherit;
+}
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+.text-muted {
+  color: var(--muted-foreground);
+}
+.text-primary {
+  color: var(--primary);
+}
+
+/* ============ app shell ============ */
+.app {
+  display: grid;
+  grid-template-columns: 256px 1fr;
+  min-height: 100vh;
+}
+.main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.content {
+  padding: 28px 28px 64px;
+}
+.wrap {
+  max-width: 960px;
+  margin: 0 auto;
+}
+.wrap-narrow {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+/* sidebar (mirrors @cio/ui base/sidebar) */
+.sidebar {
+  background: var(--sidebar);
+  border-right: 1px solid var(--sidebar-border);
+  padding: 16px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px 14px;
+}
+.brand-mark {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-md);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 14px;
+}
+.brand-name {
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: -0.01em;
+}
+.nav-label {
+  font-size: 11px;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  padding: 12px 8px 4px;
+}
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px;
+  border-radius: var(--radius-md);
+  color: var(--sidebar-foreground);
+  font-weight: 400;
+  font-size: 14px;
+  transition: background 0.1s;
+}
+.nav-item svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+  color: var(--muted-foreground);
+  flex-shrink: 0;
+}
+.nav-item:hover {
+  background: var(--sidebar-accent);
+}
+.nav-item.active {
+  background: var(--sidebar-accent);
+  color: var(--sidebar-accent-foreground);
+  font-weight: 500;
+}
+.nav-item.active svg {
+  color: var(--sidebar-accent-foreground);
+}
+.nav-tail {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+.nav-badge {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+.sidebar-foot {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px;
+  border-top: 1px solid var(--sidebar-border);
+}
+.avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.who {
+  min-width: 0;
+}
+.who .nm {
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.who .rl {
+  font-size: 11.5px;
+  color: var(--muted-foreground);
+}
+
+/* path identity block (teacher path sidebar) */
+.back-link {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--muted-foreground);
+  padding: 6px 8px;
+  border-radius: var(--radius-md);
+  margin-bottom: 4px;
+}
+.back-link:hover {
+  background: var(--sidebar-accent);
+  color: var(--foreground);
+}
+.back-link svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+}
+.path-id {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 8px 14px;
+  border-bottom: 1px solid var(--sidebar-border);
+  margin-bottom: 6px;
+}
+.path-id .ico {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.path-id .ico svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+}
+.path-id .nm {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+.path-id .st {
+  font-size: 11.5px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 2px;
+}
+.path-id .st .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+}
+.st-active {
+  color: var(--success);
+}
+.st-active .dot {
+  background: var(--success);
+}
+.st-draft {
+  color: var(--warning);
+}
+.st-draft .dot {
+  background: var(--warning);
+}
+
+/* topbar */
+.topbar {
+  height: 56px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in oklab, var(--background) 90%, transparent);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 24px;
+}
+.crumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13.5px;
+  color: var(--muted-foreground);
+  min-width: 0;
+}
+.crumbs a:hover {
+  color: var(--foreground);
+}
+.crumbs .sep {
+  color: var(--border);
+}
+.crumbs .here {
+  color: var(--foreground);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.top-title {
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+.top-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ============ buttons (mirrors @cio/ui base/button) ============ */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: var(--radius-md);
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  height: 36px;
+  padding: 0 16px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    border-color 0.12s,
+    color 0.12s;
+  box-shadow: var(--shadow-2xs);
+  user-select: none;
+}
+.btn svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+  flex-shrink: 0;
+}
+.btn-primary {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+.btn-primary:hover {
+  background: color-mix(in oklab, var(--primary) 90%, transparent);
+}
+.btn-outline {
+  background: var(--background);
+  border-color: var(--input);
+  color: var(--foreground);
+}
+.btn-outline:hover {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+.btn-secondary {
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+}
+.btn-secondary:hover {
+  background: color-mix(in oklab, var(--secondary) 80%, transparent);
+}
+.btn-ghost {
+  background: transparent;
+  box-shadow: none;
+  color: var(--foreground);
+}
+.btn-ghost:hover {
+  background: var(--accent);
+}
+.btn-destructive {
+  background: var(--destructive);
+  color: #fff;
+}
+.btn-success {
+  background: var(--success);
+  color: var(--success-foreground);
+}
+.btn-sm {
+  height: 32px;
+  padding: 0 12px;
+  font-size: 13px;
+  gap: 6px;
+}
+.btn-sm svg {
+  width: 15px;
+  height: 15px;
+}
+.btn-lg {
+  height: 40px;
+  padding: 0 24px;
+}
+.btn[disabled],
+.btn.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+.btn-icon {
+  width: 36px;
+  padding: 0;
+}
+.btn-icon.btn-sm {
+  width: 32px;
+}
+
+/* ============ badges (mirrors @cio/ui base/badge) ============ */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: fit-content;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.badge svg {
+  width: 12px;
+  height: 12px;
+  stroke-width: 2.4;
+}
+.badge-default {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+.badge-secondary {
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+}
+.badge-success {
+  background: var(--success);
+  color: var(--success-foreground);
+}
+.badge-warning {
+  background: var(--warning);
+  color: var(--warning-foreground);
+}
+.badge-outline {
+  border-color: var(--border);
+  color: var(--foreground);
+  background: transparent;
+}
+.badge-success-soft {
+  background: var(--success-soft);
+  color: var(--success);
+}
+.badge-primary-soft {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+  color: var(--primary);
+}
+.badge-muted {
+  background: var(--muted);
+  color: var(--muted-foreground);
+}
+
+/* ============ cards ============ */
+.card {
+  background: var(--card);
+  color: var(--card-foreground);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-2xs);
+}
+.card-pad {
+  padding: 20px;
+}
+
+/* ============ item rows (mirrors @cio/ui base/item) ============ */
+.item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  padding: 16px;
+  font-size: 14px;
+  transition:
+    background 0.1s,
+    border-color 0.1s;
+}
+.item-muted {
+  background: color-mix(in oklab, var(--muted) 50%, transparent);
+}
+.item-outline {
+  border-color: var(--border);
+}
+.item-done {
+  opacity: 0.6;
+}
+.item-done .item-title,
+.item-done .item-desc {
+  color: var(--muted-foreground);
+  text-decoration: line-through;
+}
+.item-current {
+  background: var(--card);
+  border-color: var(--primary);
+  box-shadow: var(--shadow-sm);
+}
+.item-dashed {
+  border: 1px dashed var(--border);
+  background: transparent;
+}
+a.item:hover {
+  background: color-mix(in oklab, var(--accent) 50%, transparent);
+}
+
+.item-media-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  background: var(--muted);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin-top: 2px;
+  color: var(--muted-foreground);
+}
+.item-media-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+}
+.item-media-icon.is-done {
+  background: var(--success);
+  border-color: var(--success);
+  color: var(--success-foreground);
+}
+.item-media-icon.is-current {
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  border-color: color-mix(in oklab, var(--primary) 30%, transparent);
+  color: var(--primary);
+}
+.item-media-lg {
+  width: 40px;
+  height: 40px;
+}
+.item-media-lg svg {
+  width: 19px;
+  height: 19px;
+}
+.item-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.item-title {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+}
+.item-title-lg {
+  font-size: 15px;
+  font-weight: 600;
+}
+.item-desc {
+  font-size: 13px;
+  color: var(--muted-foreground);
+  line-height: 1.45;
+}
+.item-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.item-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+
+/* ============ progress (mirrors @cio/ui base/progress) ============ */
+.progress {
+  height: 8px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: color-mix(in oklab, var(--primary) 20%, transparent);
+  flex: 1;
+}
+.progress > span {
+  display: block;
+  height: 100%;
+  background: var(--primary);
+  border-radius: var(--radius-md);
+  transition: width 0.3s;
+}
+.progress-success > span {
+  background: var(--success);
+}
+.progress-thin {
+  height: 6px;
+}
+
+/* progress ring (mirrors @cio/ui custom/percent-ring-progress) */
+.ring {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  flex-shrink: 0;
+}
+.ring-sm {
+  width: 40px;
+  height: 40px;
+}
+.ring svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+  display: block;
+}
+.ring .track {
+  stroke: var(--border);
+}
+.ring .arc {
+  stroke: var(--success);
+  transition: stroke-dashoffset 0.7s ease-out;
+}
+.ring .lbl {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--foreground);
+}
+.ring-sm .lbl {
+  font-size: 10px;
+}
+
+/* completion dots (setup page pattern) */
+.dots {
+  display: flex;
+  gap: 4px;
+}
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--border);
+}
+.dot.on {
+  background: var(--success);
+}
+
+/* ============ forms ============ */
+.input,
+.textarea,
+.select {
+  width: 100%;
+  font: inherit;
+  font-size: 14px;
+  color: var(--foreground);
+  background: transparent;
+  border: 1px solid var(--input);
+  border-radius: var(--radius-md);
+  padding: 7px 12px;
+  outline: none;
+  box-shadow: var(--shadow-2xs);
+  transition:
+    border-color 0.12s,
+    box-shadow 0.12s;
+}
+.input:focus,
+.textarea:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 50%, transparent);
+}
+.textarea {
+  resize: vertical;
+  min-height: 76px;
+  line-height: 1.55;
+}
+.label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+.hint {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  margin-top: 5px;
+}
+.field {
+  margin-bottom: 18px;
+}
+.field:last-child {
+  margin-bottom: 0;
+}
+
+/* switch */
+.switch {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  flex-shrink: 0;
+  cursor: pointer;
+  display: inline-block;
+}
+.switch input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  margin: 0;
+  cursor: pointer;
+  z-index: 1;
+}
+.switch .track {
+  position: absolute;
+  inset: 0;
+  background: var(--input);
+  border-radius: 999px;
+  transition: background 0.15s;
+}
+.switch .knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--background);
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.15s;
+}
+.switch input:checked + .track {
+  background: var(--primary);
+}
+.switch input:checked ~ .knob {
+  transform: translateX(16px);
+}
+
+/* ============ tables ============ */
+.thead,
+.trow {
+  display: grid;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 16px;
+}
+.thead {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  border-bottom: 1px solid var(--border);
+}
+.trow {
+  border-bottom: 1px solid var(--border);
+  font-size: 14px;
+}
+.trow:last-child {
+  border-bottom: none;
+}
+a.trow:hover {
+  background: color-mix(in oklab, var(--accent) 50%, transparent);
+}
+
+/* ============ misc components ============ */
+.icon-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--input);
+  background: var(--background);
+  display: grid;
+  place-items: center;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  box-shadow: var(--shadow-2xs);
+}
+.icon-btn:hover {
+  color: var(--foreground);
+  background: var(--accent);
+}
+.icon-btn svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+}
+
+.seg-toggle {
+  display: inline-flex;
+  padding: 3px;
+  background: var(--muted);
+  border-radius: var(--radius-lg);
+  gap: 2px;
+}
+.seg-toggle a,
+.seg-toggle button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: var(--radius-md);
+  border: none;
+  background: transparent;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+.seg-toggle .on {
+  background: var(--background);
+  color: var(--foreground);
+  box-shadow: var(--shadow-2xs);
+}
+.seg-toggle svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2;
+}
+
+.stat-card {
+  padding: 16px 18px;
+}
+.stat-card .k {
+  font-size: 13px;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.stat-card .k svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+}
+.stat-card .v {
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin-top: 4px;
+}
+.stat-card .s {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  margin-top: 2px;
+}
+
+/* page headers */
+.page-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin: 8px 0 20px;
+}
+.page-title {
+  font-size: 24px;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+  margin: 0 0 4px;
+}
+.page-sub {
+  color: var(--muted-foreground);
+  font-size: 14px;
+  margin: 0;
+}
+.sec-title {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+.sec-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 28px 0 14px;
+}
+.sec-head .count {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  background: var(--muted);
+  padding: 1px 8px;
+  border-radius: 999px;
+}
+.sec-head .more {
+  margin-left: auto;
+  font-size: 13.5px;
+  color: var(--primary);
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.sec-head .more svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2;
+}
+
+/* segmented path progress (course-count segments) */
+.segs {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+}
+.seg {
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--primary) 15%, transparent);
+  position: relative;
+  overflow: hidden;
+}
+.seg.done {
+  background: var(--success);
+}
+.seg.half::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: 45%;
+  background: var(--primary);
+  border-radius: 999px;
+}
+
+/* lock veil for thumbnails */
+.lock-veil {
+  position: absolute;
+  inset: 0;
+  background: oklch(0.145 0 0 / 0.35);
+  display: grid;
+  place-items: center;
+}
+.lock-veil svg {
+  width: 18px;
+  height: 18px;
+  color: #fff;
+  stroke-width: 2.2;
+}
+
+/* ============ journey spine (learner path detail) ============ */
+.journey {
+  position: relative;
+  margin-top: 16px;
+}
+.step {
+  position: relative;
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 16px;
+  padding-bottom: 16px;
+}
+.step:last-child {
+  padding-bottom: 0;
+}
+.rail {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+.rail::before {
+  content: '';
+  position: absolute;
+  top: 38px;
+  bottom: -16px;
+  width: 2px;
+  background: var(--border);
+  border-radius: 2px;
+}
+.step:last-child .rail::before,
+.step.no-rail .rail::before {
+  display: none;
+}
+.step.s-done .rail::before {
+  background: var(--success);
+}
+.step.s-current .rail::before {
+  background: linear-gradient(180deg, var(--success) 0%, var(--border) 70%);
+}
+.node {
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 13px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  border: 1px solid var(--border);
+}
+.node svg {
+  width: 17px;
+  height: 17px;
+  stroke-width: 2.4;
+}
+.step.s-done .node {
+  background: var(--success);
+  border-color: var(--success);
+  color: var(--success-foreground);
+}
+.step.s-current .node {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+  box-shadow: 0 0 0 4px color-mix(in oklab, var(--primary) 15%, transparent);
+}
+
+/* horizontal stepper (in-course ribbon) */
+.stepper {
+  display: flex;
+  align-items: center;
+}
+.snode {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  width: 110px;
+  text-align: center;
+}
+.sdot {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 12px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  border: 1px solid var(--border);
+}
+.sdot svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2.6;
+}
+.snode.done .sdot {
+  background: var(--success);
+  border-color: var(--success);
+  color: var(--success-foreground);
+}
+.snode.current .sdot {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--primary) 15%, transparent);
+}
+.slabel {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  line-height: 1.25;
+}
+.snode.current .slabel {
+  color: var(--foreground);
+  font-weight: 600;
+}
+.sbar {
+  flex: 1;
+  height: 2px;
+  background: var(--border);
+  min-width: 12px;
+  margin: 0 -14px 18px;
+}
+.sbar.filled {
+  background: var(--success);
+}
+
+/* ============ responsive ============ */
+@media (max-width: 860px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+  .sidebar {
+    display: none;
+  }
+  .item {
+    flex-wrap: wrap;
+  }
+  .item-actions {
+    width: 100%;
+  }
+  .item-actions .btn {
+    flex: 1;
+  }
+}

--- a/prototypes/sign-in-methods/app-theme.css
+++ b/prototypes/sign-in-methods/app-theme.css
@@ -1,5 +1,5 @@
 /*
- * app-theme.css — shared theme for the learning-paths prototypes.
+ * app-theme.css — shared theme for the sign-in-methods prototypes.
  *
  * Tokens mirror packages/ui/src/index.css (shadcn-svelte) exactly:
  * OKLCH palette, Geist, --radius: 0.625rem, shadow-2xs, and the component

--- a/prototypes/sign-in-methods/audience-list.html
+++ b/prototypes/sign-in-methods/audience-list.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Audience · Sign-in Methods · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .toolbar { display: flex; gap: 10px; margin-bottom: 16px; flex-wrap: wrap; }
+      .toolbar .input { max-width: 280px; }
+      .grid-cols { grid-template-columns: 24px 1.6fr 1.5fr 0.9fr 1.1fr 0.8fr 36px; }
+      .person { display: flex; align-items: center; gap: 10px; min-width: 0; }
+      .person .nm { font-size: 14px; font-weight: 500; }
+      .person .avatar { width: 26px; height: 26px; font-size: 10.5px; }
+      .em { font-size: 13px; color: var(--muted-foreground); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .badge svg.brand { stroke: none; }
+      .mini { width: 30px; height: 30px; border-radius: var(--radius-md); border: none; background: transparent; display: grid; place-items: center; color: var(--muted-foreground); cursor: pointer; }
+      .mini:hover { background: var(--accent); color: var(--foreground); }
+      .mini svg { width: 15px; height: 15px; stroke-width: 2; }
+      .cbx { width: 15px; height: 15px; border-radius: 4px; border: 1px solid var(--input); background: var(--background); }
+      .cbx.off { opacity: 0.4; }
+      .note-banner { display: flex; align-items: center; gap: 10px; padding: 11px 14px; border-radius: var(--radius-md); background: color-mix(in oklab, var(--primary) 7%, transparent); border: 1px solid color-mix(in oklab, var(--primary) 20%, transparent); font-size: 13px; margin-bottom: 16px; }
+      .note-banner svg { width: 15px; height: 15px; stroke-width: 2; color: var(--primary); flex-shrink: 0; }
+      @media (max-width: 1000px) { .thead { display: none; } .trow.grid-cols { grid-template-columns: 1fr auto; } }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="brand"><div class="brand-mark">A</div><div class="brand-name">Acme Training</div></div>
+        <div class="nav-label">Organization</div>
+        <a class="nav-item" href="index.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Dashboard</a>
+        <a class="nav-item" href="index.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Courses<span class="nav-tail tnum">12</span></a>
+        <a class="nav-item active" href="audience-list.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/></svg>Audience<span class="nav-tail tnum">248</span></a>
+        <a class="nav-item" href="index.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>Analytics</a>
+        <div class="nav-label">Settings</div>
+        <a class="nav-item" href="account-settings.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>My account</a>
+        <a class="nav-item" href="settings-team.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/></svg>Team</a>
+        <div class="sidebar-foot"><div class="avatar">JD</div><div class="who"><div class="nm">Jordan Diallo</div><div class="rl">Admin</div></div></div>
+      </aside>
+
+      <div class="main">
+        <header class="topbar">
+          <nav class="crumbs"><span class="here">Audience</span></nav>
+          <div class="top-actions">
+            <a class="btn btn-sm btn-outline" href="index.html">Prototype map</a>
+            <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+          </div>
+        </header>
+
+        <main class="content">
+          <div class="wrap" style="max-width: 1080px">
+            <div class="page-head">
+              <div>
+                <h1 class="page-title">Audience</h1>
+                <p class="page-sub">248 people across your organization.</p>
+              </div>
+              <a class="btn btn-primary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M19 8v6M22 11h-6"/></svg>Invite people</a>
+            </div>
+
+            <div class="note-banner">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/></svg>
+              One badge per row — the highest-precedence method. Open a member to see every method they have.
+            </div>
+
+            <div class="toolbar">
+              <input class="input" placeholder="Search by name or email…" />
+              <select class="select" style="max-width: 160px"><option>All statuses</option><option>Active</option><option>Pending</option></select>
+            </div>
+
+            <div class="card" style="overflow: hidden">
+              <div class="thead grid-cols">
+                <span><span class="cbx"></span></span><span>Name</span><span>Email</span><span>Status</span><span>Sign-in method</span><span>Date joined</span><span></span>
+              </div>
+
+              <a class="trow grid-cols" href="audience-profile.html">
+                <span><span class="cbx"></span></span>
+                <div class="person"><span class="avatar">AO</span><span class="nm">Ada Okafor</span></div>
+                <span class="em">ada.okafor@acme.com</span>
+                <span><span class="badge badge-secondary">Active</span></span>
+                <span><span class="badge badge-secondary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>Acme Okta</span></span>
+                <span class="em tnum">14 Feb 2026</span>
+                <button class="mini"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+              </a>
+
+              <a class="trow grid-cols" href="audience-profile.html">
+                <span><span class="cbx"></span></span>
+                <div class="person"><span class="avatar">CE</span><span class="nm">Chidi Eze</span></div>
+                <span class="em">chidi.eze@acme.com</span>
+                <span><span class="badge badge-secondary">Active</span></span>
+                <span><span class="badge badge-secondary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>Acme Okta</span></span>
+                <span class="em tnum">14 Feb 2026</span>
+                <button class="mini"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+              </a>
+
+              <a class="trow grid-cols" href="audience-profile.html">
+                <span><span class="cbx"></span></span>
+                <div class="person"><span class="avatar">TB</span><span class="nm">Tunde Bello</span></div>
+                <span class="em">tunde.bello@gmail.com</span>
+                <span><span class="badge badge-secondary">Active</span></span>
+                <span><span class="badge badge-outline"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>Password</span></span>
+                <span class="em tnum">2 Nov 2025</span>
+                <button class="mini"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+              </a>
+
+              <a class="trow grid-cols" href="audience-profile.html">
+                <span><span class="cbx"></span></span>
+                <div class="person"><span class="avatar">FA</span><span class="nm">Femi Adeyemi</span></div>
+                <span class="em">femi@gmail.com</span>
+                <span><span class="badge badge-secondary">Active</span></span>
+                <span><span class="badge badge-outline"><svg class="brand" viewBox="0 0 24 24"><path fill="#4285F4" d="M23.5 12.3c0-.8-.1-1.6-.2-2.3H12v4.5h6.5a5.6 5.6 0 0 1-2.4 3.6v3h3.9c2.3-2.1 3.5-5.2 3.5-8.8z"/><path fill="#34A853" d="M12 24c3.2 0 5.9-1.1 7.9-2.9l-3.9-3a7.2 7.2 0 0 1-10.7-3.8h-4v3.1A12 12 0 0 0 12 24z"/><path fill="#FBBC05" d="M5.3 14.3a7.1 7.1 0 0 1 0-4.6v-3h-4a12 12 0 0 0 0 10.7l4-3.1z"/><path fill="#EA4335" d="M12 4.8c1.8 0 3.4.6 4.6 1.8l3.5-3.5A12 12 0 0 0 1.3 6.7l4 3.1A7.2 7.2 0 0 1 12 4.8z"/></svg>Google</span></span>
+                <span class="em tnum">18 Jan 2026</span>
+                <button class="mini"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+              </a>
+
+              <a class="trow grid-cols" href="audience-profile.html">
+                <span><span class="cbx"></span></span>
+                <div class="person"><span class="avatar">MK</span><span class="nm">Mariam Kone</span></div>
+                <span class="em">mariam@globex.io</span>
+                <span><span class="badge badge-secondary">Active</span></span>
+                <span><span class="badge badge-secondary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>SSO</span></span>
+                <span class="em tnum">6 Mar 2026</span>
+                <button class="mini"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+              </a>
+
+              <a class="trow grid-cols" href="audience-profile.html">
+                <span><span class="cbx"></span></span>
+                <div class="person"><span class="avatar">SD</span><span class="nm">Sam Diallo</span></div>
+                <span class="em">sam@partner.dev</span>
+                <span><span class="badge badge-secondary">Active</span></span>
+                <span><span class="badge badge-secondary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="7.5" cy="15.5" r="4.5"/><path d="m10.7 12.3 8.8-8.8M17 6l3 3M14 9l3 3"/></svg>Token auth</span></span>
+                <span class="em tnum">21 Apr 2026</span>
+                <button class="mini"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+              </a>
+
+              <div class="trow grid-cols">
+                <span><span class="cbx off"></span></span>
+                <div class="person"><span class="avatar" style="background: var(--muted); color: var(--muted-foreground)">?</span><span class="nm text-muted">—</span></div>
+                <span class="em">pending@acme.com</span>
+                <span><span class="badge badge-outline">Pending</span></span>
+                <span></span>
+                <span class="em tnum">10 Aug 2026</span>
+                <button class="mini"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+              </div>
+
+              <div class="trow grid-cols">
+                <span><span class="cbx off"></span></span>
+                <div class="person"><span class="avatar" style="background: var(--muted); color: var(--muted-foreground)">?</span><span class="nm text-muted">—</span></div>
+                <span class="em">newhire@acme.com</span>
+                <span><span class="badge badge-destructive" style="background: var(--destructive); color: #fff; border-color: transparent">Expired</span></span>
+                <span></span>
+                <span class="em tnum">4 Jul 2026</span>
+                <button class="mini"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+              </div>
+            </div>
+
+            <p class="hint" style="margin-top: 12px">Pending and expired invitees have no identity yet, so the method cell stays empty rather than showing a placeholder.</p>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <script>
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>

--- a/prototypes/sign-in-methods/audience-profile.html
+++ b/prototypes/sign-in-methods/audience-profile.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Member Profile · Sign-in Methods · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .hero { display: flex; gap: 18px; align-items: flex-start; border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 20px; background: var(--card); }
+      .hero .av { width: 64px; height: 64px; border-radius: 999px; background: color-mix(in oklab, var(--primary) 12%, transparent); color: var(--primary); display: grid; place-items: center; font-size: 22px; font-weight: 600; flex-shrink: 0; }
+      .hero h1 { font-size: 24px; font-weight: 400; letter-spacing: -0.025em; margin: 0 0 8px; }
+      .meta { display: flex; flex-wrap: wrap; gap: 8px 20px; color: var(--muted-foreground); font-size: 13.5px; }
+      .meta span { display: inline-flex; align-items: center; gap: 6px; }
+      .meta svg { width: 14px; height: 14px; stroke-width: 2; }
+      .badge-row { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 12px; }
+      .badge svg.brand { stroke: none; }
+      .cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin: 18px 0 8px; }
+      .stat { border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 16px; background: var(--card); }
+      .stat .k { font-size: 12.5px; color: var(--muted-foreground); margin-bottom: 6px; }
+      .stat .v { font-size: 26px; font-weight: 500; letter-spacing: -0.02em; }
+      .methods { display: grid; gap: 8px; }
+      .m-ico { width: 34px; height: 34px; border-radius: var(--radius-md); border: 1px solid var(--border); background: var(--background); display: grid; place-items: center; flex-shrink: 0; }
+      .m-ico svg { width: 16px; height: 16px; stroke-width: 1.9; color: var(--muted-foreground); }
+      .m-ico svg.brand { stroke: none; }
+      .m-ico.managed { background: color-mix(in oklab, var(--primary) 10%, transparent); border-color: color-mix(in oklab, var(--primary) 22%, transparent); }
+      .m-ico.managed svg { color: var(--primary); }
+      .variants { margin-top: 34px; }
+      .v-note { font-size: 12.5px; color: var(--muted-foreground); margin: 0 0 10px; line-height: 1.6; }
+      .v-case { border: 1px dashed var(--border); border-radius: var(--radius-lg); padding: 14px 16px; margin-bottom: 10px; }
+      .v-case .lbl { font-size: 11px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted-foreground); margin-bottom: 9px; }
+      .v-hero { display: flex; align-items: center; gap: 12px; }
+      .v-hero .av { width: 36px; height: 36px; font-size: 13px; }
+      .v-hero .nm { font-size: 14px; font-weight: 500; }
+      .v-hero .em { font-size: 12px; color: var(--muted-foreground); }
+      .course-row { display: flex; align-items: center; gap: 12px; }
+      .course-row .thumb { width: 52px; height: 36px; border-radius: var(--radius-sm); background: linear-gradient(135deg, oklch(0.623 0.214 259.815), oklch(0.488 0.243 264.376)); flex-shrink: 0; }
+      .filters { display: flex; gap: 6px; margin-left: auto; }
+      @media (max-width: 900px) { .cards { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="brand"><div class="brand-mark">A</div><div class="brand-name">Acme Training</div></div>
+        <div class="nav-label">Organization</div>
+        <a class="nav-item" href="index.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Dashboard</a>
+        <a class="nav-item" href="index.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Courses<span class="nav-tail tnum">12</span></a>
+        <a class="nav-item active" href="audience-list.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/></svg>Audience<span class="nav-tail tnum">248</span></a>
+        <a class="nav-item" href="index.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>Analytics</a>
+        <div class="nav-label">Settings</div>
+        <a class="nav-item" href="account-settings.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>My account</a>
+        <a class="nav-item" href="settings-team.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/></svg>Team</a>
+        <div class="sidebar-foot"><div class="avatar">JD</div><div class="who"><div class="nm">Jordan Diallo</div><div class="rl">Admin</div></div></div>
+      </aside>
+
+      <div class="main">
+        <header class="topbar">
+          <nav class="crumbs">
+            <a href="audience-list.html">Audience</a><span class="sep">/</span>
+            <span class="here">Ada Okafor</span>
+          </nav>
+          <div class="top-actions">
+            <a class="btn btn-sm btn-outline" href="index.html">Prototype map</a>
+            <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+          </div>
+        </header>
+
+        <main class="content">
+          <div class="wrap" style="max-width: 900px">
+            <a class="back-link" href="audience-list.html" style="margin-bottom: 14px"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>Audience</a>
+
+            <!-- HERO — the primary surface -->
+            <div class="hero">
+              <div class="av">AO</div>
+              <div style="min-width: 0; flex: 1">
+                <h1>Ada Okafor</h1>
+                <div class="meta">
+                  <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-10 6L2 7"/></svg>ada.okafor@acme.com</span>
+                  <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="13" r="8"/><path d="M12 9v4l2 2M5 3 2 6M22 6l-3-3"/></svg>Last seen 2 hours ago</span>
+                  <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>Last signed in with Acme Okta · 3 days ago</span>
+                </div>
+                <div class="badge-row">
+                  <span class="badge badge-secondary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>Acme Okta</span>
+                  <span class="badge badge-outline"><svg class="brand" viewBox="0 0 24 24"><path fill="#4285F4" d="M23.5 12.3c0-.8-.1-1.6-.2-2.3H12v4.5h6.5a5.6 5.6 0 0 1-2.4 3.6v3h3.9c2.3-2.1 3.5-5.2 3.5-8.8z"/><path fill="#34A853" d="M12 24c3.2 0 5.9-1.1 7.9-2.9l-3.9-3a7.2 7.2 0 0 1-10.7-3.8h-4v3.1A12 12 0 0 0 12 24z"/><path fill="#FBBC05" d="M5.3 14.3a7.1 7.1 0 0 1 0-4.6v-3h-4a12 12 0 0 0 0 10.7l4-3.1z"/><path fill="#EA4335" d="M12 4.8c1.8 0 3.4.6 4.6 1.8l3.5-3.5A12 12 0 0 0 1.3 6.7l4 3.1A7.2 7.2 0 0 1 12 4.8z"/></svg>Google</span>
+                  <span class="badge badge-outline"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>Password</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="cards">
+              <div class="stat"><div class="k">Enrolled courses</div><div class="v tnum">6</div></div>
+              <div class="stat"><div class="k">Overall progress</div><div class="v tnum">72%</div></div>
+              <div class="stat"><div class="k">Average grade</div><div class="v tnum">88%</div></div>
+            </div>
+
+            <!-- SIGN-IN METHODS SECTION — only renders at 2+ methods -->
+            <div class="sec-head"><div class="sec-title">Sign-in methods</div><span class="count tnum">3</span></div>
+            <div class="methods">
+              <div class="item">
+                <div class="m-ico managed"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg></div>
+                <div class="item-content">
+                  <div class="item-title">Acme Okta</div>
+                  <div class="item-desc">Single sign-on · connected 14 Feb 2026</div>
+                </div>
+                <div class="item-actions"><span class="badge badge-success-soft">Last used</span></div>
+              </div>
+              <div class="item">
+                <div class="m-ico"><svg class="brand" viewBox="0 0 24 24"><path fill="#4285F4" d="M23.5 12.3c0-.8-.1-1.6-.2-2.3H12v4.5h6.5a5.6 5.6 0 0 1-2.4 3.6v3h3.9c2.3-2.1 3.5-5.2 3.5-8.8z"/><path fill="#34A853" d="M12 24c3.2 0 5.9-1.1 7.9-2.9l-3.9-3a7.2 7.2 0 0 1-10.7-3.8h-4v3.1A12 12 0 0 0 12 24z"/><path fill="#FBBC05" d="M5.3 14.3a7.1 7.1 0 0 1 0-4.6v-3h-4a12 12 0 0 0 0 10.7l4-3.1z"/><path fill="#EA4335" d="M12 4.8c1.8 0 3.4.6 4.6 1.8l3.5-3.5A12 12 0 0 0 1.3 6.7l4 3.1A7.2 7.2 0 0 1 12 4.8z"/></svg></div>
+                <div class="item-content">
+                  <div class="item-title">Google</div>
+                  <div class="item-desc">Connected 3 Nov 2025</div>
+                </div>
+              </div>
+              <div class="item">
+                <div class="m-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div>
+                <div class="item-content">
+                  <div class="item-title">Password</div>
+                  <div class="item-desc">Connected 3 Nov 2025</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- COURSES — existing section, unchanged except the badge-variant fix -->
+            <div class="sec-head">
+              <div class="sec-title">Courses</div><span class="count tnum">6</span>
+              <div class="filters">
+                <button class="badge badge-secondary" style="cursor: pointer">In progress</button>
+                <button class="badge badge-outline" style="cursor: pointer">Completed</button>
+              </div>
+            </div>
+            <div class="methods">
+              <div class="item">
+                <div class="course-row" style="flex: 1; min-width: 0">
+                  <div class="thumb"></div>
+                  <div class="item-content">
+                    <div class="item-title">HIPAA Awareness 2026</div>
+                    <div class="item-desc">Annual privacy and security refresher for all staff.</div>
+                  </div>
+                </div>
+                <span class="badge badge-success">Completed</span>
+                <div style="display: flex; align-items: center; gap: 10px; min-width: 120px">
+                  <div class="progress progress-thin progress-success"><span style="width: 100%"></span></div>
+                  <span class="tnum" style="font-size: 12.5px; font-weight: 600">100%</span>
+                </div>
+              </div>
+              <div class="item">
+                <div class="course-row" style="flex: 1; min-width: 0">
+                  <div class="thumb" style="background: linear-gradient(135deg, oklch(0.696 0.17 162.48), oklch(0.596 0.145 163.225))"></div>
+                  <div class="item-content">
+                    <div class="item-title">SOC 2 Security Basics</div>
+                    <div class="item-desc">What every employee needs to know before an audit.</div>
+                  </div>
+                </div>
+                <span class="badge badge-warning">In progress</span>
+                <div style="display: flex; align-items: center; gap: 10px; min-width: 120px">
+                  <div class="progress progress-thin"><span style="width: 44%"></span></div>
+                  <span class="tnum" style="font-size: 12.5px; font-weight: 600">44%</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- STATE VARIANTS -->
+            <div class="variants">
+              <div class="sec-head"><div class="sec-title">Header states</div></div>
+              <p class="v-note">Every state the header must handle. These are reference renderings, not a real screen — in the app only one applies per member.</p>
+
+              <div class="v-case">
+                <div class="lbl">Single method — no Sign-in methods section is rendered</div>
+                <div class="v-hero">
+                  <div class="av">TB</div>
+                  <div style="flex: 1"><div class="nm">Tunde Bello</div><div class="em">tunde@gmail.com · Last signed in with Password · 6 hours ago</div></div>
+                  <span class="badge badge-outline"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>Password</span>
+                </div>
+              </div>
+
+              <div class="v-case">
+                <div class="lbl">SSO belonging to another organization — generic label, no connection name</div>
+                <div class="v-hero">
+                  <div class="av">MK</div>
+                  <div style="flex: 1"><div class="nm">Mariam Kone</div><div class="em">mariam@globex.io · Last signed in with SSO · yesterday</div></div>
+                  <span class="badge badge-secondary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>SSO</span>
+                </div>
+              </div>
+
+              <div class="v-case">
+                <div class="lbl">Token auth — embedded partner access, never badged as Password</div>
+                <div class="v-hero">
+                  <div class="av">SD</div>
+                  <div style="flex: 1"><div class="nm">Sam Diallo</div><div class="em">sam@partner.dev · Last signed in with Token auth · 4 days ago</div></div>
+                  <span class="badge badge-secondary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="7.5" cy="15.5" r="4.5"/><path d="m10.7 12.3 8.8-8.8M17 6l3 3M14 9l3 3"/></svg>Token auth</span>
+                </div>
+              </div>
+
+              <div class="v-case">
+                <div class="lbl">Never signed in since launch — methods show, last-used line is omitted entirely</div>
+                <div class="v-hero">
+                  <div class="av">RN</div>
+                  <div style="flex: 1"><div class="nm">Rita Nwosu</div><div class="em">rita@acme.com · Last seen a while ago</div></div>
+                  <span class="badge badge-outline"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>Password</span>
+                </div>
+              </div>
+
+              <div class="v-case">
+                <div class="lbl">Invited, never completed signup — no methods, no badge, no empty section</div>
+                <div class="v-hero">
+                  <div class="av" style="background: var(--muted); color: var(--muted-foreground)">?</div>
+                  <div style="flex: 1"><div class="nm">pending@acme.com</div><div class="em">Invite sent 2 days ago</div></div>
+                  <span class="badge badge-outline">Pending</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <script>
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+      document.querySelectorAll('.filters button').forEach((b) => {
+        b.onclick = () => {
+          document.querySelectorAll('.filters button').forEach((x) => (x.className = 'badge badge-outline'));
+          b.className = 'badge badge-secondary';
+        };
+      });
+    </script>
+  </body>
+</html>

--- a/prototypes/sign-in-methods/index.html
+++ b/prototypes/sign-in-methods/index.html
@@ -101,8 +101,8 @@
 
       <div class="foot">
         <b>Three traps the PRD is built around.</b><br />
-        Token-auth signup mints a real <code>credential</code> account row with a random password, so those users would be badged
-        <b>Password</b> unless the row is retagged at the write site.<br />
+        Token exchange records no usable identity either way: new users get a real <code>credential</code> row from a random password,
+        so they would be badged <b>Password</b>; existing users get no account row at all, so token access would be invisible.<br />
         The <code>login-link</code> and <code>token-exchange</code> plugins raw-insert sessions, so Better Auth's
         <code>databaseHooks</code> never fire for them — and "view as student" must never overwrite the learner's record.<br />
         <code>analytics_login_events</code> is unique per user per day with <code>onConflictDoNothing</code>, so it can only ever hold the

--- a/prototypes/sign-in-methods/index.html
+++ b/prototypes/sign-in-methods/index.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sign-in Methods — Prototype Map</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .page { max-width: 980px; margin: 0 auto; padding: 56px 24px 80px; }
+      h1 { font-size: 32px; font-weight: 600; letter-spacing: -0.03em; margin: 8px 0 8px; }
+      .lead { color: var(--muted-foreground); font-size: 15px; max-width: 70ch; margin: 0 0 12px; line-height: 1.65; }
+      .eyebrow { font-size: 12px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: var(--primary); }
+      .sec { font-size: 13px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted-foreground); margin: 36px 0 14px; display: flex; align-items: center; gap: 10px; }
+      .sec::after { content: ''; flex: 1; height: 1px; background: var(--border); }
+      .grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
+      .shot { overflow: hidden; display: flex; flex-direction: column; transition: border-color 0.15s, box-shadow 0.15s; }
+      .shot:hover { border-color: var(--ring); box-shadow: var(--shadow-md); }
+      .shot .cover { height: 72px; display: grid; place-items: center; color: #fff; }
+      .shot .cover svg { width: 26px; height: 26px; stroke-width: 1.8; }
+      .shot .b { padding: 13px 15px 15px; }
+      .shot .n { font-size: 11px; font-weight: 600; color: var(--muted-foreground); letter-spacing: 0.05em; text-transform: uppercase; }
+      .shot .t { font-size: 14.5px; font-weight: 600; letter-spacing: -0.01em; margin: 3px 0 4px; }
+      .shot .d { font-size: 12.5px; color: var(--muted-foreground); margin: 0; line-height: 1.5; }
+      .vocab { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin-top: 4px; }
+      .vc { border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 14px; text-align: center; background: var(--card); }
+      .vc .badge { margin-bottom: 8px; }
+      .vc .badge svg.brand { stroke: none; }
+      .vc p { font-size: 12px; color: var(--muted-foreground); margin: 0; line-height: 1.5; }
+      .theme-btn { position: fixed; top: 20px; right: 20px; }
+      .foot { margin-top: 44px; padding-top: 20px; border-top: 1px solid var(--border); color: var(--muted-foreground); font-size: 13.5px; line-height: 1.75; }
+      .foot b { color: var(--foreground); font-weight: 500; }
+      .foot code { background: var(--muted); padding: 1px 6px; border-radius: 4px; font-size: 12.5px; }
+      @media (max-width: 860px) { .grid, .vocab { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <button class="icon-btn theme-btn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+
+    <div class="page">
+      <span class="eyebrow">ClassroomIO · Prototype + PRD handoff</span>
+      <h1>Sign-in Methods</h1>
+      <p class="lead">
+        Every member already has a <b style="color: var(--foreground)">sign-in method</b> recorded — password, Google, enterprise SSO, or
+        token auth — but nothing in the product shows it. These screens surface it on the four places admins already look, plus the
+        member's own account page. Built on the real <code>packages/ui</code> tokens. The engineering PRD lives at
+        <code>prd/sign-in-methods/README.md</code>.
+      </p>
+      <p class="lead" style="font-size: 13.5px">Every page has a theme toggle and cross-links, so you can click through the whole flow.</p>
+
+      <div class="sec">Badge vocabulary</div>
+      <div class="vocab">
+        <div class="vc">
+          <span class="badge badge-secondary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>Acme Okta</span>
+          <p>SSO. Named when the connection belongs to your org, generic <b>SSO</b> when it does not.</p>
+        </div>
+        <div class="vc">
+          <span class="badge badge-secondary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="7.5" cy="15.5" r="4.5"/><path d="m10.7 12.3 8.8-8.8M17 6l3 3M14 9l3 3"/></svg>Token auth</span>
+          <p>Embedded partner access. Today these users are wrongly stored as password accounts.</p>
+        </div>
+        <div class="vc">
+          <span class="badge badge-outline"><svg class="brand" viewBox="0 0 24 24"><path fill="#4285F4" d="M23.5 12.3c0-.8-.1-1.6-.2-2.3H12v4.5h6.5a5.6 5.6 0 0 1-2.4 3.6v3h3.9c2.3-2.1 3.5-5.2 3.5-8.8z"/><path fill="#34A853" d="M12 24c3.2 0 5.9-1.1 7.9-2.9l-3.9-3a7.2 7.2 0 0 1-10.7-3.8h-4v3.1A12 12 0 0 0 12 24z"/><path fill="#FBBC05" d="M5.3 14.3a7.1 7.1 0 0 1 0-4.6v-3h-4a12 12 0 0 0 0 10.7l4-3.1z"/><path fill="#EA4335" d="M12 4.8c1.8 0 3.4.6 4.6 1.8l3.5-3.5A12 12 0 0 0 1.3 6.7l4 3.1A7.2 7.2 0 0 1 12 4.8z"/></svg>Google</span>
+          <p>Google OAuth. Outlined, because the user manages it themselves.</p>
+        </div>
+        <div class="vc">
+          <span class="badge badge-outline"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>Password</span>
+          <p>Email and password. The one admins are usually hunting for after an SSO rollout.</p>
+        </div>
+      </div>
+      <p class="lead" style="font-size: 13px; margin-top: 12px">
+        Lists show one badge — precedence <b style="color: var(--foreground)">SSO › Token auth › Google › Password</b>. The member profile shows every method.
+      </p>
+
+      <div class="sec">1 · Admin — the primary surface</div>
+      <div class="grid">
+        <a class="card shot" href="audience-profile.html">
+          <div class="cover" style="background: linear-gradient(135deg, oklch(0.488 0.243 264.376), oklch(0.623 0.214 259.815))"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></div>
+          <div class="b"><div class="n">Start here</div><div class="t">Audience member profile</div><p class="d">Badge row in the hero, a last-signed-in line, and a Sign-in methods section. Five header states at the bottom of the page: single method, foreign SSO, token auth, never-signed-in, and pending invite.</p></div>
+        </a>
+        <a class="card shot" href="audience-list.html">
+          <div class="cover" style="background: linear-gradient(135deg, oklch(0.546 0.245 262.881), oklch(0.424 0.199 265.638))"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/></svg></div>
+          <div class="b"><div class="n">Scan</div><div class="t">Audience list</div><p class="d">A Sign-in method column between Status and Date joined. One badge per row. Pending and expired invitees leave the cell empty.</p></div>
+        </a>
+      </div>
+
+      <div class="sec">2 · Admin — privileged accounts</div>
+      <div class="grid">
+        <a class="card shot" href="settings-team.html">
+          <div class="cover" style="background: linear-gradient(135deg, oklch(0.596 0.145 163.225), oklch(0.696 0.17 162.48))"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.1a4 4 0 0 1 0 7.8"/></svg></div>
+          <div class="b"><div class="n">Settings → Team</div><div class="t">Team list</div><p class="d">The badge sits right after the role badge in the existing row. Invited members who never signed up keep only their invite badge.</p></div>
+        </a>
+        <a class="card shot" href="account-settings.html">
+          <div class="cover" style="background: linear-gradient(135deg, oklch(0.666 0.179 58.318), oklch(0.769 0.188 70.08))"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div>
+          <div class="b"><div class="n">Self-serve</div><div class="t">My account settings</div><p class="d">A new read-only Sign-in methods section under Personal information. Your own IdP is always named. Includes the managed-by-your-organization empty state.</p></div>
+        </a>
+      </div>
+
+      <div class="foot">
+        <b>Three traps the PRD is built around.</b><br />
+        Token-auth signup mints a real <code>credential</code> account row with a random password, so those users would be badged
+        <b>Password</b> unless the row is retagged at the write site.<br />
+        The <code>login-link</code> and <code>token-exchange</code> plugins raw-insert sessions, so Better Auth's
+        <code>databaseHooks</code> never fire for them — and "view as student" must never overwrite the learner's record.<br />
+        <code>analytics_login_events</code> is unique per user per day with <code>onConflictDoNothing</code>, so it can only ever hold the
+        day's <i>first</i> login — which is why last-used lives on <code>profile</code> instead.
+      </div>
+    </div>
+
+    <script>
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>

--- a/prototypes/sign-in-methods/settings-team.html
+++ b/prototypes/sign-in-methods/settings-team.html
@@ -63,7 +63,7 @@
 
             <div class="note-banner">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/></svg>
-              Two admins still sign in with a password. Enforce SSO in Settings → Authentication to close that gap.
+              Two team members still sign in with a password. Enforce SSO in Settings → Authentication to close that gap.
             </div>
 
             <div class="fset">

--- a/prototypes/sign-in-methods/settings-team.html
+++ b/prototypes/sign-in-methods/settings-team.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Team · Sign-in Methods · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .fset { border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 20px; background: var(--card); margin-bottom: 18px; }
+      .legend { font-size: 15px; font-weight: 600; letter-spacing: -0.01em; margin: 0 0 4px; }
+      .fdesc { font-size: 13px; color: var(--muted-foreground); margin: 0 0 16px; line-height: 1.6; }
+      .mrow { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 11px 0; border-bottom: 1px solid var(--border); }
+      .mrow:last-child { border-bottom: none; padding-bottom: 0; }
+      .mleft { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; min-width: 0; }
+      .mleft .em { font-size: 13.5px; }
+      .badge svg.brand { stroke: none; }
+      .you { font-size: 11px; font-weight: 500; color: var(--muted-foreground); background: var(--muted); padding: 2px 8px; border-radius: 999px; }
+      .rm { font-size: 13px; color: var(--destructive); background: none; border: none; cursor: pointer; font-weight: 500; padding: 4px 8px; border-radius: var(--radius-md); }
+      .rm:hover { background: color-mix(in oklab, var(--destructive) 10%, transparent); }
+      .note-banner { display: flex; align-items: center; gap: 10px; padding: 11px 14px; border-radius: var(--radius-md); background: color-mix(in oklab, var(--primary) 7%, transparent); border: 1px solid color-mix(in oklab, var(--primary) 20%, transparent); font-size: 13px; margin-bottom: 18px; }
+      .note-banner svg { width: 15px; height: 15px; stroke-width: 2; color: var(--primary); flex-shrink: 0; }
+      .tabs { display: flex; gap: 2px; border-bottom: 1px solid var(--border); margin-bottom: 20px; }
+      .tabs a { padding: 9px 14px; font-size: 13.5px; font-weight: 500; color: var(--muted-foreground); border-bottom: 2px solid transparent; margin-bottom: -1px; }
+      .tabs a.on { color: var(--foreground); border-bottom-color: var(--primary); }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="brand"><div class="brand-mark">A</div><div class="brand-name">Acme Training</div></div>
+        <div class="nav-label">Organization</div>
+        <a class="nav-item" href="index.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Dashboard</a>
+        <a class="nav-item" href="index.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Courses<span class="nav-tail tnum">12</span></a>
+        <a class="nav-item" href="audience-list.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/></svg>Audience<span class="nav-tail tnum">248</span></a>
+        <a class="nav-item" href="index.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>Analytics</a>
+        <div class="nav-label">Settings</div>
+        <a class="nav-item" href="account-settings.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>My account</a>
+        <a class="nav-item active" href="settings-team.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/></svg>Team</a>
+        <div class="sidebar-foot"><div class="avatar">JD</div><div class="who"><div class="nm">Jordan Diallo</div><div class="rl">Admin</div></div></div>
+      </aside>
+
+      <div class="main">
+        <header class="topbar">
+          <nav class="crumbs"><a href="index.html">Settings</a><span class="sep">/</span><span class="here">Team</span></nav>
+          <div class="top-actions">
+            <a class="btn btn-sm btn-outline" href="index.html">Prototype map</a>
+            <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+          </div>
+        </header>
+
+        <main class="content">
+          <div class="wrap-narrow">
+            <div class="page-head"><div><h1 class="page-title">Team</h1><p class="page-sub">People who can administer this organization.</p></div></div>
+
+            <div class="tabs">
+              <a href="index.html">Organization</a><a href="index.html">Customize LMS</a><a href="index.html">Domains</a><a class="on" href="settings-team.html">Team</a>
+            </div>
+
+            <div class="note-banner">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/></svg>
+              Two admins still sign in with a password. Enforce SSO in Settings → Authentication to close that gap.
+            </div>
+
+            <div class="fset">
+              <p class="legend">Members</p>
+              <p class="fdesc">The sign-in method shows how each admin gets in. Managed identities — SSO and token auth — are filled; self-managed ones are outlined.</p>
+
+              <div class="mrow">
+                <div class="mleft">
+                  <span class="em">jordan.diallo@acme.com</span>
+                  <span class="badge badge-secondary">Admin</span>
+                  <span class="badge badge-secondary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>Acme Okta</span>
+                  <span class="you">you</span>
+                </div>
+              </div>
+
+              <div class="mrow">
+                <div class="mleft">
+                  <span class="em">ngozi.udo@acme.com</span>
+                  <span class="badge badge-secondary">Admin</span>
+                  <span class="badge badge-secondary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>Acme Okta</span>
+                </div>
+                <button class="rm">Remove</button>
+              </div>
+
+              <div class="mrow">
+                <div class="mleft">
+                  <span class="em">kwame.mensah@acme.com</span>
+                  <span class="badge badge-secondary">Tutor</span>
+                  <span class="badge badge-outline"><svg class="brand" viewBox="0 0 24 24"><path fill="#4285F4" d="M23.5 12.3c0-.8-.1-1.6-.2-2.3H12v4.5h6.5a5.6 5.6 0 0 1-2.4 3.6v3h3.9c2.3-2.1 3.5-5.2 3.5-8.8z"/><path fill="#34A853" d="M12 24c3.2 0 5.9-1.1 7.9-2.9l-3.9-3a7.2 7.2 0 0 1-10.7-3.8h-4v3.1A12 12 0 0 0 12 24z"/><path fill="#FBBC05" d="M5.3 14.3a7.1 7.1 0 0 1 0-4.6v-3h-4a12 12 0 0 0 0 10.7l4-3.1z"/><path fill="#EA4335" d="M12 4.8c1.8 0 3.4.6 4.6 1.8l3.5-3.5A12 12 0 0 0 1.3 6.7l4 3.1A7.2 7.2 0 0 1 12 4.8z"/></svg>Google</span>
+                </div>
+                <button class="rm">Remove</button>
+              </div>
+
+              <div class="mrow">
+                <div class="mleft">
+                  <span class="em">bola.hassan@acme.com</span>
+                  <span class="badge badge-secondary">Tutor</span>
+                  <span class="badge badge-outline"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>Password</span>
+                </div>
+                <button class="rm">Remove</button>
+              </div>
+
+              <div class="mrow">
+                <div class="mleft">
+                  <span class="em">yemi.cole@acme.com</span>
+                  <span class="badge badge-secondary">Admin</span>
+                  <span class="badge badge-outline"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>Password</span>
+                </div>
+                <button class="rm">Remove</button>
+              </div>
+
+              <div class="mrow">
+                <div class="mleft">
+                  <span class="em">newtutor@acme.com</span>
+                  <span class="badge badge-secondary">Tutor</span>
+                  <span class="badge badge-warning">Invite sent</span>
+                </div>
+                <button class="rm">Remove</button>
+              </div>
+            </div>
+
+            <p class="hint">An invited member has no identity until they finish signing up, so they show only the invite badge — never an empty or guessed method.</p>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <script>
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What

PRD + clickable prototypes for surfacing **how each member signs in** — password, Google, enterprise SSO, or token auth — plus the method they last used.

- PRD: `prd/sign-in-methods/README.md`
- Prototypes: `prototypes/sign-in-methods/index.html` (start here)

Docs only. No app code changes.

## Why

`account.provider_id` has held this data since the Better Auth migration, and the only thing that reads it is `hasVerifiedEmailProvider()`. An admin who has rolled out SSO cannot tell who is actually using it and who is still on a password — the most common question after an SSO rollout, and unanswerable in the product today.

## Scope (v1)

Four surfaces: audience member profile, audience list column, Settings → Team list, and the user's own account settings (read-only). Last-used tracking is in scope. Linking/unlinking is not.

## The three traps the audit turned up

These shape most of the technical design:

1. **Token-exchange signup mints a real `credential` row.** `token-exchange.ts:76` calls `signUpEmail` with a random password, so every token-auth user would be badged `Password` — the opposite of the truth. Fixed by retagging the row at the write site.
2. **`login-link` and `token-exchange` raw-insert sessions**, so `databaseHooks.session.create.after` never fires for them. `token-exchange` must record explicitly; `login-link` must *not* — its only caller is "view as student", and impersonation must not overwrite a learner's record.
3. **`analytics_login_events` is `unique(user_id, logged_in_date)` + `onConflictDoNothing`**, so it can only ever hold the day's *first* login. It cannot back a last-used field. Last-used lives on `profile` instead.

Also: `session.update.after` fires on session refresh, not a sign-in, so the recorder is wired to `create` only.

## Tenant safety

`account` rows are global to the user, so a learner in several orgs carries all their SSO identities. A connection's `display_name` is only rendered to admins of the org that owns it; foreign SSO shows a generic `SSO` badge. Enforced in the query layer so no route can opt out.

## Also folded in

Two bugs on the page being edited: `user-analytics.svelte` passes `type=` to `Badge` where the prop is `variant=` (the course filter badges never change state), and the course status badge uses raw color classes instead of the `success`/`warning` variants.

## Open product call

Own-account identities are **read-only** in v1. Unlink needs a last-method guard, a set-a-password step, and re-authentication — worth its own PRD. Easy to reverse if you want it in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prototype screens for sign-in methods across account settings, audience profiles, audience lists, and team settings.
  * Added indicators for SSO, token authentication, Google, and password sign-in methods, including invitation and account status states.
  * Added last-used sign-in information with privacy-aware empty states.
  * Added responsive layouts, light/dark themes, navigation, filtering, and interactive controls.

* **Documentation**
  * Added guidance covering supported methods, display rules, precedence, privacy considerations, and implementation phases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR defines the product and technical design for exposing members’ available and last-used sign-in methods, with clickable prototypes for four dashboard surfaces. The implementation plan still needs to place its required database migration and legacy token-auth backfill into the executable phase checklist.

- Defines method derivation, precedence, tenant-safe SSO labeling, and last-used tracking.
- Specifies handling for token exchange, impersonation sessions, and session refreshes.
- Adds responsive prototypes for audience, team, profile, and account-settings surfaces.
- Requires a database migration and targeted legacy identity backfill, but does not schedule either in the numbered phases.

<h3>Confidence Score: 4/5</h3>

The PR should not be used as the implementation checklist until the required migration and legacy token-auth backfill are explicitly scheduled in its numbered phases.

The document requires new persisted profile columns before application deployment, but its executable phase checklist only edits the schema and runs builds; following that checklist can leave deployed reads and writes targeting absent columns and can leave legacy token-auth users mislabeled.

**Files Needing Attention:** prd/sign-in-methods/README.md

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| prd/sign-in-methods/README.md | Defines the feature’s data, auth, API, and UI implementation, but leaves its required migration and backfill outside the numbered execution plan. |
| prototypes/sign-in-methods/account-settings.html | Prototypes the read-only connected-identities and organization-managed empty states. |
| prototypes/sign-in-methods/audience-list.html | Prototypes the single highest-precedence sign-in method on audience rows. |
| prototypes/sign-in-methods/audience-profile.html | Prototypes full method badges, connected identities, and last-used information on a member profile. |
| prototypes/sign-in-methods/settings-team.html | Prototypes sign-in method badges alongside team role and invitation state. |
| prototypes/sign-in-methods/app-theme.css | Provides shared responsive and light/dark styling for the static prototypes. |
| prototypes/sign-in-methods/index.html | Provides navigation and an overview of the prototype states. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Real sign-in] --> B[Determine sign-in method]
  B --> C[Record last-used fields on profile]
  D[Account identities] --> E[Resolve methods and tenant-safe SSO labels]
  C --> F[API responses]
  E --> F
  F --> G[Audience profile]
  F --> H[Audience list]
  F --> I[Team settings]
  F --> J[Own account settings]
  K[Schema migration] --> C
  L[Legacy token-auth backfill] --> D
```

<sub>Reviews (3): Last reviewed commit: ["docs(prd): correct team prototype banner..."](https://github.com/classroomio/classroomio/commit/a383fc37f9caf1a520617721d5c3e8b470109e77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52894901)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->