### PR TITLE
chore(website): enable Cloudflare Workers observability and logs

### DIFF
--- a/apps/website/wrangler.jsonc
+++ b/apps/website/wrangler.jsonc
@@ -7,5 +7,12 @@
   "assets": {
     "binding": "ASSETS",
     "directory": ".svelte-kit/cloudflare"
+  },
+  "observability": {
+    "enabled": true,
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Enables Cloudflare Workers Logs for `apps/website` so the marketing site Worker persists observability data (including invocation logs) to the Cloudflare dashboard.

Newly created Workers enable observability by default, but this Worker had no explicit setting. This adds the same logs config used by `apps/dashboard` and `apps/docs`, plus top-level `observability.enabled`.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Confirm `apps/website/wrangler.jsonc` includes:

```jsonc
"observability": {
  "enabled": true,
  "logs": {
    "enabled": true,
    "invocation_logs": true
  }
}
```

- After deploy, Workers Logs for `cio-web` should show invocation logs in the Cloudflare dashboard.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d013b362-bdce-4fe5-b83e-bd3d736aca30?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d013b362-bdce-4fe5-b83e-bd3d736aca30&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled website worker observability, including operational logs and invocation logs for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enables Cloudflare Workers observability and invocation logging for the public website Worker.
- Adds the top-level `observability` configuration to `apps/website/wrangler.jsonc`.
- Enables persisted Worker logs and invocation logs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no identified blocking or non-blocking issues.

The change is limited to enabling observability and invocation logging, and the review found no concrete reachable failure caused by the new configuration.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/wrangler.jsonc | Adds Worker observability and invocation-log settings; no actionable defect was established. |

<sub>Reviews (1): Last reviewed commit: ["chore(website): enable Cloudflare Worker..."](https://github.com/classroomio/classroomio/commit/572ffd805d86d85628a538fee75e883b529320a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52958107)</sub>

<!-- /greptile_comment -->