### PR TITLE
fix(dashboard): compact course list rows

### DIFF
--- a/apps/dashboard/src/lib/features/course/components/course-list-row.svelte
+++ b/apps/dashboard/src/lib/features/course/components/course-list-row.svelte
@@ -165,19 +165,19 @@
 
 {#snippet rowContent()}
   <div
-    class="grid w-full grid-cols-1 items-start gap-x-3 gap-y-2 @3xl:grid-cols-[var(--row-cols)]"
+    class="grid w-full grid-cols-[5rem_minmax(0,1fr)] items-center gap-x-3 gap-y-1.5 @3xl:grid-cols-[var(--row-cols)]"
     style="--row-cols: {gridTemplateColumns}"
   >
     <!-- Banner -->
     <div
-      class="ui:border-border bg-muted relative size-28 shrink-0 overflow-hidden rounded-md border"
+      class="ui:border-border bg-muted relative size-20 shrink-0 overflow-hidden rounded-md border @3xl:size-24"
       aria-hidden="true"
     >
       <Image src={bannerImage} alt="" className="h-full w-full object-cover" />
     </div>
 
     <!-- Title / type / updated -->
-    <div class="flex min-w-0 flex-col gap-0.5">
+    <div class="col-start-2 flex min-w-0 flex-col gap-0.5 @3xl:col-start-auto">
       <div class="flex min-w-0 flex-wrap items-center gap-2">
         <p class="line-clamp-2 min-w-0 flex-1 text-base">{title}</p>
         {#if type === 'PUBLIC'}
@@ -194,7 +194,7 @@
 
     <!-- Published badge -->
     {#if !hidden.has('published')}
-      <div>
+      <div class="col-start-2 @3xl:col-start-auto">
         {#if isPublished}
           <Badge variant="success" class="whitespace-nowrap">
             {$t('courses.course_card.published')}
@@ -209,7 +209,7 @@
 
     <!-- Tags -->
     {#if !hidden.has('tags')}
-      <div class="flex min-w-0 flex-wrap items-center gap-1">
+      <div class="col-start-2 flex min-w-0 flex-wrap items-center gap-1 @3xl:col-start-auto">
         {#if tags.length === 0}
           <span class="ui:text-muted-foreground text-xs">—</span>
         {:else}
@@ -231,7 +231,7 @@
     {/if}
 
     <!-- Lessons / exercises -->
-    <div class="flex flex-col gap-1 tabular-nums">
+    <div class="col-start-2 flex flex-col gap-1 tabular-nums @3xl:col-start-auto">
       <p class="flex items-center gap-1.5 text-sm" aria-label="{lessonCount} lessons">
         <CourseContentIcon type={ContentType.Lesson} size={14} />
         <span class="font-medium">{lessonCount}</span>
@@ -244,7 +244,7 @@
 
     <!-- Students -->
     {#if !hidden.has('students')}
-      <div class="flex items-center gap-1">
+      <div class="col-start-2 flex items-center gap-1 @3xl:col-start-auto">
         {#if totalStudents > 0}
           {#if totalStudents < 3}
             <div class="flex items-center gap-1">
@@ -285,7 +285,7 @@
 
     <!-- Actions -->
     {#if showActionsColumn}
-      <div class="flex justify-end">
+      <div class="col-start-2 flex justify-start @3xl:col-start-auto @3xl:justify-end">
         {#if isLMS && isExplore}
           <Button
             variant="outline"
@@ -344,7 +344,7 @@
   </div>
 {/snippet}
 
-<ResourceListRow.Root variant="default" size="sm" align="start" class="cursor-pointer py-4!">
+<ResourceListRow.Root variant="default" size="sm" align="start" class="cursor-pointer py-3!">
   {#snippet child({ props })}
     {#if courseUrl}
       <a href={courseUrl} {...props} class={cn('block', props.class as string)}>


### PR DESCRIPTION
## What does this PR do?

Fixes #843

Makes course list rows more compact and readable across responsive layouts:

- uses a two-column mobile grid so the thumbnail stays beside the course details
- keeps secondary fields aligned in the content column on narrow containers
- reduces vertical padding and row gaps
- uses smaller responsive thumbnail sizes
- preserves the existing multi-column desktop layout at the `@3xl` breakpoint

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

1. Open the dashboard course list in row view on a narrow/mobile viewport.
2. Confirm the thumbnail and course details render side by side without excessive whitespace.
3. Resize to a wide container and confirm the existing desktop columns and right-aligned actions are preserved.
4. Check rows with hidden optional columns and with/without actions.

Verification completed:
- Prettier formatting check passed.
- Svelte compiler check passed.
- The branch was created from the latest upstream `main`.

Earlier mobile and desktop screenshots are available in the discussion on #843.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [x] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: not applicable

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the ClassroomIO Docs if changes were necessary: not required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the course list’s responsive layout on mobile devices.
  * Reduced banner size and row spacing for a more compact view.
  * Adjusted content and action control alignment across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR compacts dashboard course-list rows while preserving their responsive desktop structure.

- Uses a two-column mobile grid to keep the thumbnail beside course details.
- Reduces thumbnail size, row padding, and grid gaps.
- Aligns optional fields and actions in the content column on narrow containers, then restores automatic placement at the `@3xl` breakpoint.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable functional or security issues identified.

The responsive placement resets consistently at the desktop breakpoint, and rendered optional columns remain aligned with the dynamically computed grid tracks.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/course/components/course-list-row.svelte | Updates responsive grid placement, thumbnail sizing, spacing, and action alignment without identifying a concrete functional regression. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): compact course list rows"](https://github.com/classroomio/classroomio/commit/2180af30e2a9352f93d2e10063e97bcf4868faf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53264762)</sub>

<!-- /greptile_comment -->