### PR TITLE
fix(course): use distinct shield-check icon for Compliance nav

### DIFF
--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-navigation.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-navigation.svelte
@@ -8,10 +8,10 @@
   import { BackButton } from '@cio/ui';
 
   import TableOfContentsIcon from '@lucide/svelte/icons/table-of-contents';
-  import BotIcon from '@lucide/svelte/icons/bot';
   import {
     AnalyticsIcon,
     AttendanceIcon,
+    BotIcon,
     CertificateIcon,
     ContentIcon,
     HoverableItem,

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-navigation.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-navigation.svelte
@@ -9,6 +9,7 @@
 
   import TableOfContentsIcon from '@lucide/svelte/icons/table-of-contents';
   import BotIcon from '@lucide/svelte/icons/bot';
+  import ShieldCheckIcon from '@lucide/svelte/icons/shield-check';
   import {
     AnalyticsIcon,
     AttendanceIcon,
@@ -248,7 +249,7 @@
     } else if (id === NAV_IDS.MARKS) {
       return MarksIcon;
     } else if (id === NAV_IDS.COMPLIANCE) {
-      return CertificateIcon;
+      return ShieldCheckIcon;
     } else if (id === NAV_IDS.PEOPLE) {
       return PeopleIcon;
     } else if (id === NAV_IDS.ANALYTICS) {
@@ -402,7 +403,7 @@
                 {#snippet children(isHovered)}
                   {@const Icon = item.icon}
                   <a href={resolve(item.url, {})} {...props}>
-                    {#if Icon === TableOfContentsIcon}
+                    {#if Icon === TableOfContentsIcon || Icon === BotIcon || Icon === ShieldCheckIcon}
                       <Icon size={16} />
                     {:else}
                       <Icon {isHovered} size={16} />

--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-navigation.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-navigation.svelte
@@ -9,7 +9,6 @@
 
   import TableOfContentsIcon from '@lucide/svelte/icons/table-of-contents';
   import BotIcon from '@lucide/svelte/icons/bot';
-  import ShieldCheckIcon from '@lucide/svelte/icons/shield-check';
   import {
     AnalyticsIcon,
     AttendanceIcon,
@@ -22,6 +21,7 @@
     PeopleIcon,
     PremiumIcon,
     SettingsIcon,
+    ShieldCheckIcon,
     SubmissionIcon
   } from '@cio/ui/custom/moving-icons';
   import { ContentType } from '@cio/utils/constants/content';
@@ -403,7 +403,7 @@
                 {#snippet children(isHovered)}
                   {@const Icon = item.icon}
                   <a href={resolve(item.url, {})} {...props}>
-                    {#if Icon === TableOfContentsIcon || Icon === BotIcon || Icon === ShieldCheckIcon}
+                    {#if Icon === TableOfContentsIcon}
                       <Icon size={16} />
                     {:else}
                       <Icon {isHovered} size={16} />

--- a/packages/ui/src/custom/moving-icons/index.ts
+++ b/packages/ui/src/custom/moving-icons/index.ts
@@ -31,6 +31,7 @@ export { default as RadioIcon } from './radio.svelte';
 export { default as ReviewIcon } from './review.svelte';
 export { default as SettingsIcon } from './settings.svelte';
 export { default as SetupIcon } from './setup.svelte';
+export { default as ShieldCheckIcon } from './shield-check.svelte';
 export { default as SubmissionIcon } from './submission.svelte';
 export { default as TagIcon } from './tag.svelte';
 export { default as UploadIcon } from './upload.svelte';

--- a/packages/ui/src/custom/moving-icons/shield-check.svelte
+++ b/packages/ui/src/custom/moving-icons/shield-check.svelte
@@ -1,0 +1,77 @@
+<script>
+  /**
+   * @typedef {Object} Props
+   * @property {string} [color]
+   * @property {number} [size]
+   * @property {number} [strokeWidth]
+   * @property {boolean} [isHovered]
+   * @property {string} [class]
+   */
+
+  /** @type {Props} */
+  let { color = 'currentColor', size = 24, strokeWidth = 2, isHovered = false, class: className = '' } = $props();
+
+  function handleMouseEnter() {
+    isHovered = true;
+    setTimeout(() => {
+      isHovered = false;
+    }, 500);
+  }
+</script>
+
+<div class={className} aria-label="shield-check" role="img" onmouseenter={handleMouseEnter}>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    stroke-width={strokeWidth}
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="shield-check-icon"
+    class:animate={isHovered}
+  >
+    <path
+      d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+    />
+    <path d="m9 12 2 2 4-4" class="check-path" />
+  </svg>
+</div>
+
+<style>
+  div {
+    display: inline-block;
+  }
+  .shield-check-icon {
+    overflow: visible;
+  }
+
+  .check-path {
+    stroke-dasharray: 9;
+    stroke-dashoffset: 0;
+    transition:
+      stroke-dashoffset 0.125s ease-out,
+      opacity 0.125s ease-out;
+  }
+
+  .shield-check-icon.animate .check-path {
+    animation: checkAnimation 0.5s ease-out backwards;
+  }
+
+  @keyframes checkAnimation {
+    0% {
+      stroke-dashoffset: 9;
+      opacity: 0;
+    }
+    33% {
+      stroke-dashoffset: 9;
+      opacity: 0;
+    }
+    100% {
+      stroke-dashoffset: 0;
+      opacity: 1;
+    }
+  }
+</style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Certificates and Compliance in the course left sidebar both used `CertificateIcon`. Compliance now uses a new `ShieldCheckIcon` moving icon. Also switches AI Tutor from Lucide `bot` to the existing moving-icons `BotIcon` so hover animation matches the rest of the sidebar.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (small improvements)

## How should this be tested?

- Open a compliance course as admin (Coursera Test — e.g. SOC 2 or HIPAA Awareness).
- Confirm Compliance in the left sidebar shows a shield-with-check icon (not the award medal).
- Hover Compliance and confirm the checkmark animates like other moving icons.
- Confirm Certificates still shows the award/medal icon.
- Confirm AI Tutor uses the moving bot icon (hover animation).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a004c0-0631-78fe-bad2-951827ba2c24?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a004c0-0631-78fe-bad2-951827ba2c24&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the compliance navigation item with a shield-check icon.
  * Added an animated checkmark reveal when hovering over the icon.
  * Improved visual clarity and consistency for compliance navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR gives Compliance a distinct animated shield-check icon and switches AI Tutor to the shared animated bot icon.
- Adds and exports a reusable `ShieldCheckIcon`.
- Updates course sidebar icon selection for Compliance and AI Tutor.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-navigation.svelte | Updates the Compliance and AI Tutor sidebar icon mappings without changing navigation behavior. |
| packages/ui/src/custom/moving-icons/index.ts | Exports the new shield-check moving icon. |
| packages/ui/src/custom/moving-icons/shield-check.svelte | Adds the animated shield-check presentation component. |

<sub>Reviews (3): Last reviewed commit: ["fix(course): use moving BotIcon for AI t..."](https://github.com/classroomio/classroomio/commit/8f810d1f08837c8a49c73bb288b755a85e8e366e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53595462)</sub>

<!-- /greptile_comment -->