### PR TITLE
fix(public-course): render exercise description as rich-text HTML

### DIFF
--- a/packages/ui/src/custom/public-course/exercise-view.svelte
+++ b/packages/ui/src/custom/public-course/exercise-view.svelte
@@ -13,6 +13,7 @@
   import { QuestionList } from '../exercise-question';
   import { cn } from '../../tools';
   import Callout from './callout.svelte';
+  import { SafeHtmlContent } from '../safe-html-content';
   import type { PublicCourseCalloutAnimation, PublicCourseCalloutData, PublicExerciseViewData } from './types';
   import type { PublicExerciseStoredAttempt } from './public-exercise-attempts-storage';
   import {
@@ -401,7 +402,9 @@
     </h1>
 
     {#if exercise.description}
-      <p class="ui:mt-3 ui:text-muted-foreground">{exercise.description}</p>
+      <div class="prose ui:sm:prose-sm ui:mt-8 ui:max-w-none ui:dark:text-white">
+        <SafeHtmlContent content={exercise.description} />
+      </div>
     {/if}
 
     <div class="ui:mt-8 ui:space-y-6">

--- a/packages/ui/src/custom/public-course/types.ts
+++ b/packages/ui/src/custom/public-course/types.ts
@@ -81,6 +81,7 @@ export interface PublicLessonViewData {
 export interface PublicExerciseViewData {
   kind: 'exercise';
   title: string;
+  /** Rich-text HTML (as produced by the exercise description editor). */
   description: string | null;
   sectionTitle: string | null;
   isUnlocked: boolean;


### PR DESCRIPTION
## Summary

`PublicExerciseView` was rendering `exercise.description` inside a plain `<p>` tag as escaped text. Since the exercise description is rich-text HTML (produced by the `TextEditor` in the authenticated exercise editor), the literal markup — e.g. `<p>...</p>` — was showing up in the public course page instead of the formatted content.

## Changes

- `packages/ui/src/custom/public-course/exercise-view.svelte`: render the description with `SafeHtmlContent` wrapped in a `prose` container, matching how `PublicLessonView` renders `lesson.body`.
- `packages/ui/src/custom/public-course/types.ts`: document that `PublicExerciseViewData.description` holds rich-text HTML.

## Verification

- `pnpm format:check` ✅
- `pnpm --filter @cio/ui prefix:check` ✅
- `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exercise descriptions now support rich-text formatting when displayed.
  * Improved styling preserves the intended formatting and presentation of exercise content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renders public exercise descriptions as sanitized rich-text HTML instead of escaped text and documents the description field’s HTML contract.
- Reuses `SafeHtmlContent`, matching the established public lesson and authenticated exercise rendering paths.
- Applies the existing public-course prose wrapper to exercise descriptions.
- Adds type-level documentation for the rich-text description.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The new public exercise rendering path reuses the repository’s existing sanitized HTML component and mirrors the established lesson and authenticated exercise behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/custom/public-course/exercise-view.svelte | Replaces escaped description text with the established sanitized rich-text renderer and matching prose wrapper; no actionable defect was identified. |
| packages/ui/src/custom/public-course/types.ts | Documents the existing description field as rich-text HTML without changing its runtime or type contract. |

<sub>Reviews (1): Last reviewed commit: ["fix(public-course): render exercise desc..."](https://github.com/classroomio/classroomio/commit/326af3c1b9738609ce46ad81fd30a62a4c07f57e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53821187)</sub>

<!-- /greptile_comment -->