### PR TITLE
fix: correct Discord and docs links in issue auto-comment

### DIFF
--- a/.github/workflows/auto-comment-issues.yml
+++ b/.github/workflows/auto-comment-issues.yml
@@ -19,5 +19,5 @@ jobs:
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
-            Thanks for the issue, our team will look into it as soon as possible. If you would like to work on this issue, please wait for us to decide if it's ready. To claim an issue that does not have the "needs triage" label, please leave a comment that says ".take". If you have any questions, please reach out to us on [Discord](https://discord.gg/KJUb2AwM) or follow up on the issue itself.
-            For full info on how to contribute, please check out our [contributors guide](https://classroomio.com/docs/contributor-guides/devs).
+            Thanks for the issue, our team will look into it as soon as possible. If you would like to work on this issue, please wait for us to decide if it's ready. To claim an issue that does not have the "needs triage" label, please leave a comment that says ".take". If you have any questions, please reach out to us on [Discord](https://dub.sh/ciodiscord) or follow up on the issue itself.
+            For full info on how to contribute, please check out our [contributors guide](https://classroomio.com/docs/guides/contributing/devs).


### PR DESCRIPTION
## What does this PR do?

Fixes the Discord invite and contributors guide URLs in the GitHub Actions auto-comment that posts when a new issue is opened.

The previous Discord invite (`https://discord.gg/KJUb2AwM`) is expired/invalid, and the docs link used the old `/docs/contributor-guides/devs` path. This updates them to the same destinations used elsewhere in the repo:

- Discord: `https://dub.sh/ciodiscord`
- Contributors guide: `https://classroomio.com/docs/guides/contributing/devs`

Fixes #846

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Open `.github/workflows/auto-comment-issues.yml` and confirm the Discord link is `https://dub.sh/ciodiscord` and the contributors guide link is `https://classroomio.com/docs/guides/contributing/devs`.
- Click both URLs and confirm they resolve (Discord invite works; docs page loads).
- Optional: open a new issue in a fork/test repo with this workflow enabled and confirm the auto-comment uses the updated links.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the automatic new-issue comment to replace stale Discord and contributor documentation links with the repository’s current canonical destinations.
- Replaces the expired Discord invite with `https://dub.sh/ciodiscord`.
- Updates the contributor guide to `/docs/guides/contributing/devs`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the updated links match the repository’s canonical Discord and contributor-guide destinations.

The workflow retains valid YAML and Markdown syntax, and both replacement URLs are corroborated by existing repository documentation and configuration.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/auto-comment-issues.yml | The two static links are updated to canonical repository destinations without altering workflow behavior or comment formatting. |

<sub>Reviews (1): Last reviewed commit: ["fix: correct Discord and docs links in i..."](https://github.com/classroomio/classroomio/commit/aed26571933b8df84c179f12c2658520bd2ebbc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53893745)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated links in automatic issue comments to point to the current Discord community and contributors guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->