### PR TITLE
fix(dashboard): repair certificates tab handler so main can build

### DIFF
--- a/apps/dashboard/src/routes/(app)/courses/[id]/certificates/+page.svelte
+++ b/apps/dashboard/src/routes/(app)/courses/[id]/certificates/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
-  import { goto } from '$app/navigation';
+  import { replaceState } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { CertificatesPage } from '$features/course/pages';
   import * as Page from '@cio/ui/base/page';
@@ -18,10 +18,12 @@
 
   let errors = $state<Record<string, string>>({});
 
-  const certificateActiveTab = $derived.by(() => {
-    const tabInParam = page.url.searchParams.get('tab');
-    return tabInParam === 'settings' ? 'settings' : 'design';
-  });
+  function normalizeCertificateTab(tab: string | null) {
+    return tab === 'settings' ? 'settings' : 'design';
+  }
+
+  // replaceState does not update page.url; keep the tab in local state and sync the query string.
+  let certificateActiveTab = $state(normalizeCertificateTab(page.url.searchParams.get('tab')));
 
   let hasUnsavedChanges = $state(false);
   let savedCertificateState = $state<string | null>(null);
@@ -144,12 +146,17 @@
   }
 
   function handleActiveTabChange(tab: string) {
+    const nextTab = normalizeCertificateTab(tab);
+
+    if (nextTab === certificateActiveTab) {
+      return;
+    }
+
+    certificateActiveTab = nextTab;
+
     const url = new URL(page.url);
-    url.searchParams.set('tab', tab);
-  function handleActiveTabChange(tab: string) {
-    const url = new URL(page.url);
-    url.searchParams.set('tab', tab);
-    replaceState(url, {});
+    url.searchParams.set('tab', nextTab);
+    replaceState(resolve(`${url.pathname}${url.search}`, {}), page.state);
   }
 </script>
 

--- a/apps/dashboard/src/routes/(app)/courses/[id]/certificates/+page.svelte
+++ b/apps/dashboard/src/routes/(app)/courses/[id]/certificates/+page.svelte
@@ -22,8 +22,12 @@
     return tab === 'settings' ? 'settings' : 'design';
   }
 
-  // replaceState does not update page.url; keep the tab in local state and sync the query string.
+  // replaceState does not update page.url; local state handles tab clicks, this resyncs on navigation.
   let certificateActiveTab = $state(normalizeCertificateTab(page.url.searchParams.get('tab')));
+
+  $effect.pre(() => {
+    certificateActiveTab = normalizeCertificateTab(page.url.searchParams.get('tab'));
+  });
 
   let hasUnsavedChanges = $state(false);
   let savedCertificateState = $state<string | null>(null);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes the dashboard production build that is currently failing on `main`.

`#854` merged a duplicated, unclosed `handleActiveTabChange` in `apps/dashboard/src/routes/(app)/courses/[id]/certificates/+page.svelte`. Vite/Svelte then fails with:

```
Unexpected token
</script>
```

That breaks **Package build check** and the **Publish Docker Images** dashboard smoke test on the latest `main` commits (`#854`, `#919`).

This PR:
- Removes the duplicated/unclosed function
- Keeps the active tab in local state (SvelteKit `replaceState` does not update `page.url`)
- Syncs `?tab=` with `replaceState` so the unsaved-changes prompt is not triggered
- Resyncs the tab from `page.url` in `$effect.pre` when SvelteKit reuses the page across course ids

Fixes the build regression from #854.

## Demo

This restores a production parse/build. Verified:

- Local: `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build` succeeds; certificates page compiles
- CI: **Package build check** is green on the first commit; the tab-resync follow-up uses the same build

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Confirm `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build` succeeds
- Open a course → Certificates
- Switch between Design and Settings; `?tab=` updates and the save bar only shows on Settings
- With unsaved settings, switching tabs should not prompt to discard changes
- Deep-link `?tab=settings` still opens the Settings tab
- From a course on `?tab=settings`, open another course’s certificates URL with `?tab=design` (or no tab) and confirm the tab matches the new URL

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build` (`pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e902b58b-2189-4355-9dd6-98433430a77d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e902b58b-2189-4355-9dd6-98433430a77d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate tab navigation and URL synchronization.
  * Kept the selected tab aligned when navigating through URL changes.
  * Prevented redundant navigation when selecting the active tab.
  * Ensured tab selections consistently use the supported Design and Settings options.
  * Preserved the selected tab when moving between certificate settings and design views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR repairs the certificates page parse failure and changes tab selection to use local state while synchronizing the `tab` query parameter through history replacement.
- Removes the duplicated, unclosed tab-change handler.
- Normalizes tab values to Design or Settings.
- Preserves current page state while updating the URL without triggering navigation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/routes/(app)/courses/[id]/certificates/+page.svelte | Repairs the malformed handler and aligns certificate tab state with non-navigating URL updates; no eligible follow-up defect was identified. |

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): resync certificate tab w..."](https://github.com/classroomio/classroomio/commit/a5284acd5c9b11f267c97c673b22ea19f441efea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54344554)</sub>

**Context used:**

- Knowledge Base — [Dashboard app (`apps/dashboard`)](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/dashboard-app.md)

<!-- /greptile_comment -->