### PR TITLE
fix(dashboard): hide compliance banner when course sidebar is collapsed

### DIFF
--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-navigation.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-navigation.svelte
@@ -68,6 +68,9 @@
   });
   const showContentCount = $derived(sidebar.open && !sidebar.isMobile && contentCount.total > 0);
   const studentComplianceRecord = $derived(complianceApi.learnerHistory?.currentRecord ?? null);
+  const showComplianceBanner = $derived(
+    isStudent && courseApi.course?.type === 'COMPLIANCE' && (sidebar.open || sidebar.isMobile)
+  );
 
   const navItems = $derived(
     [
@@ -306,7 +309,7 @@
 <Sidebar.Group class="pt-0!">
   <BackButton href={resolve(coursesListPath, {})} label={$t('org_navigation.courses')} class="px-2! py-2!" />
 
-  {#if isStudent && courseApi.course?.type === 'COMPLIANCE'}
+  {#if showComplianceBanner}
     <div
       class="mx-2 mb-3 rounded-lg border border-emerald-200 bg-emerald-50 p-3 dark:border-emerald-900/50 dark:bg-emerald-950/20"
     >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Hides the student compliance due-date banner when the course sidebar is minimized to icon mode. Previously the green banner stayed in the narrow rail, wrapping and clipping so copy like “Due” and the date was unreadable.

The banner still shows when the sidebar is expanded, and on mobile when the course sidebar sheet is open.

## Demo

[Expanded course sidebar with green compliance banner](https://cursor.com/agents/bc-19e8bce1-e75c-4063-8824-025dd2665b11/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompliance_banner_sidebar_expanded.webp)

[Collapsed course sidebar with compliance banner hidden](https://cursor.com/agents/bc-19e8bce1-e75c-4063-8824-025dd2665b11/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompliance_banner_sidebar_collapsed.webp)

[compliance_banner_hides_when_sidebar_collapsed.mp4](https://cursor.com/agents/bc-19e8bce1-e75c-4063-8824-025dd2665b11/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompliance_banner_hides_when_sidebar_collapsed.mp4)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

1. Log in as a student on a `COMPLIANCE` course (seeded Coursera Test: `enterprise-student@test.com` / `123456`, e.g. HIPAA Awareness 2026). Use `?org=coursera-test` in cloud/local multi-tenant mode.
2. Confirm the green compliance banner is visible in the expanded course sidebar.
3. Minimize/collapse the course sidebar to icon mode.
4. Confirm the compliance banner is gone and only nav icons remain.
5. Expand the sidebar again and confirm the banner returns.
6. Optionally check mobile: opening the course sidebar sheet should still show the banner.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build` (dashboard and its workspace dependencies)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19e8bce1-e75c-4063-8824-025dd2665b11?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19e8bce1-e75c-4063-8824-025dd2665b11&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the compliance-course navigation banner to follow sidebar presentation state.
- Keeps the banner visible for students when the desktop course sidebar is expanded.
- Hides it when the desktop sidebar is collapsed to its icon rail.
- Preserves it within the mobile sidebar sheet.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and implements the intended sidebar behavior without an identified regression.

The new condition correctly distinguishes the collapsed desktop icon rail from the expanded sidebar and retains the compliance banner in the mobile sidebar.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-navigation.svelte | Adds a derived visibility condition so the student compliance banner is hidden in the collapsed desktop sidebar while remaining available on mobile. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): hide compliance banner w..."](https://github.com/classroomio/classroomio/commit/bd57460766ac8d683145542e1de94ed2b0ac713c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60476401)</sub>

**Context used:**

- Knowledge Base — [Administration dashboard](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/administration-dashboard.md)

<!-- /greptile_comment -->