### PR TITLE
fix(course): stop mobile sidebar crashes and restore mark complete

### DIFF
--- a/apps/dashboard/src/lib/features/course/components/mobile/course-mobile-bottom-nav.svelte
+++ b/apps/dashboard/src/lib/features/course/components/mobile/course-mobile-bottom-nav.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
+  import { page } from '$app/state';
   import { PublicCourseBottomNav } from '@cio/ui/custom/public-course';
   import { courseApi } from '$features/course/api';
   import { getContentRoute, getCourseProgress } from '$features/course/utils/content';
@@ -28,11 +29,12 @@
 
   let sheetOpen = $state(false);
 
+  const currentPath = $derived(path || page.url.pathname);
   const courseProgress = $derived(getCourseProgress(courseApi.course));
-  const activeIndex = $derived(resolveActiveNavigableContentIndex(courseApi.course, path));
-  const activeItem = $derived(getActiveNavigableContent(courseApi.course, path));
-  const previousItem = $derived(getPreviousNavigableContent(courseApi.course, path));
-  const nextItem = $derived(getNextIncompleteNavigableContent(courseApi.course, path));
+  const activeIndex = $derived(resolveActiveNavigableContentIndex(courseApi.course, currentPath));
+  const activeItem = $derived(getActiveNavigableContent(courseApi.course, currentPath));
+  const previousItem = $derived(getPreviousNavigableContent(courseApi.course, currentPath));
+  const nextItem = $derived(getNextIncompleteNavigableContent(courseApi.course, currentPath));
 
   const positionLabel = $derived(
     activeIndex >= 0 && courseProgress.total > 0 ? `${activeIndex + 1} / ${courseProgress.total}` : ''
@@ -87,4 +89,4 @@
   progressPercent={courseProgress.percent}
 />
 
-<CourseMobileOutlineSheet bind:open={sheetOpen} {path} {courseId} />
+<CourseMobileOutlineSheet bind:open={sheetOpen} path={currentPath} {courseId} />

--- a/apps/dashboard/src/lib/features/course/utils/content-navigation.test.ts
+++ b/apps/dashboard/src/lib/features/course/utils/content-navigation.test.ts
@@ -1,0 +1,28 @@
+import { isContentItemInPath } from './content-navigation';
+
+describe('isContentItemInPath', () => {
+  it('returns false when the current path is missing', () => {
+    expect(isContentItemInPath('lesson-1', undefined)).toBe(false);
+    expect(isContentItemInPath('lesson-1', null)).toBe(false);
+    expect(isContentItemInPath('lesson-1', '')).toBe(false);
+  });
+
+  it('matches content ids as exact pathname segments', () => {
+    expect(isContentItemInPath('lesson-1', '/courses/abc/lessons/lesson-1')).toBe(true);
+    expect(isContentItemInPath('lesson-1', '/courses/abc/lessons/lesson-10')).toBe(false);
+  });
+});
+
+
+describe('isContentItemInPath', () => {
+  it('returns false when the current path is missing', () => {
+    expect(isContentItemInPath('lesson-1', undefined)).toBe(false);
+    expect(isContentItemInPath('lesson-1', null)).toBe(false);
+    expect(isContentItemInPath('lesson-1', '')).toBe(false);
+  });
+
+  it('matches content ids as exact pathname segments', () => {
+    expect(isContentItemInPath('lesson-1', '/courses/abc/lessons/lesson-1')).toBe(true);
+    expect(isContentItemInPath('lesson-1', '/courses/abc/lessons/lesson-10')).toBe(false);
+  });
+});

--- a/apps/dashboard/src/lib/features/course/utils/content-navigation.ts
+++ b/apps/dashboard/src/lib/features/course/utils/content-navigation.ts
@@ -9,16 +9,23 @@ export function getFirstIncompleteNavigableContent(course: Course | null): Conte
   return getOrderedNavigableContent(course).find((item) => !item.isComplete && isNavigableContentUnlocked(item));
 }
 
-export function isContentItemInPath(itemId: string, currentPath: string): boolean {
+export function isContentItemInPath(itemId: string, currentPath: string | null | undefined): boolean {
+  if (!itemId || !currentPath) {
+    return false;
+  }
+
   const pathSegments = currentPath.split('/').filter(Boolean);
   return pathSegments.includes(itemId);
 }
 
-export function findActiveNavigableContentIndex(items: ContentItem[], currentPath: string): number {
+export function findActiveNavigableContentIndex(items: ContentItem[], currentPath: string | null | undefined): number {
   return items.findIndex((item) => isContentItemInPath(item.id, currentPath));
 }
 
-export function resolveActiveNavigableContentIndex(course: Course | null, currentPath: string): number {
+export function resolveActiveNavigableContentIndex(
+  course: Course | null,
+  currentPath: string | null | undefined
+): number {
   const items = getOrderedNavigableContent(course);
   if (items.length === 0) {
     return -1;
@@ -37,7 +44,10 @@ export function resolveActiveNavigableContentIndex(course: Course | null, curren
   return 0;
 }
 
-export function getPreviousNavigableContent(course: Course | null, currentPath: string): ContentItem | null {
+export function getPreviousNavigableContent(
+  course: Course | null,
+  currentPath: string | null | undefined
+): ContentItem | null {
   const items = getOrderedNavigableContent(course);
   const activeIndex = resolveActiveNavigableContentIndex(course, currentPath);
   if (activeIndex <= 0) {
@@ -47,7 +57,10 @@ export function getPreviousNavigableContent(course: Course | null, currentPath: 
   return items[activeIndex - 1] ?? null;
 }
 
-export function getNextIncompleteNavigableContent(course: Course | null, currentPath: string): ContentItem | null {
+export function getNextIncompleteNavigableContent(
+  course: Course | null,
+  currentPath: string | null | undefined
+): ContentItem | null {
   const items = getOrderedNavigableContent(course);
   const activeIndex = resolveActiveNavigableContentIndex(course, currentPath);
   if (activeIndex < 0) {
@@ -64,7 +77,10 @@ export function getNextIncompleteNavigableContent(course: Course | null, current
   return null;
 }
 
-export function getActiveNavigableContent(course: Course | null, currentPath: string): ContentItem | null {
+export function getActiveNavigableContent(
+  course: Course | null,
+  currentPath: string | null | undefined
+): ContentItem | null {
   const items = getOrderedNavigableContent(course);
   const activeIndex = resolveActiveNavigableContentIndex(course, currentPath);
   if (activeIndex < 0) {
@@ -93,7 +109,7 @@ export function getSectionIdForContentItem(course: Course | null, itemId: string
   return null;
 }
 
-export function getActiveSectionId(course: Course | null, currentPath: string): string | null {
+export function getActiveSectionId(course: Course | null, currentPath: string | null | undefined): string | null {
   const activeItem = getActiveNavigableContent(course, currentPath);
   if (!activeItem) {
     return null;

--- a/apps/dashboard/src/routes/(app)/courses/[id]/+layout.svelte
+++ b/apps/dashboard/src/routes/(app)/courses/[id]/+layout.svelte
@@ -45,7 +45,6 @@
 
   interface Props {
     children?: import('svelte').Snippet;
-    path: string;
     data: {
       course?: Course;
       courseId: string;
@@ -53,7 +52,8 @@
     };
   }
 
-  let { children, path, data }: Props = $props();
+  let { children, data }: Props = $props();
+  const currentPath = $derived(page.url.pathname);
   let sidebarWidth = $state(COURSE_SIDEBAR_DEFAULT_WIDTH);
   let hasLoadedSidebarWidth = $state(false);
   let sidebarProviderElement = $state<HTMLDivElement | null>(null);
@@ -208,7 +208,7 @@
   style={`--sidebar-width: ${sidebarWidth}px; --side-panel-width: ${sidePanel.width}px;`}
 >
   <CourseSidebar
-    {path}
+    path={currentPath}
     id={data.courseId}
     {isCourseReady}
     {sidebarWidth}
@@ -243,7 +243,7 @@
       {/if}
 
       {#if showMobileBottomNav}
-        <CourseMobileBottomNav courseId={data.courseId} {path} />
+        <CourseMobileBottomNav courseId={data.courseId} path={currentPath} />
       {/if}
     {/if}
   </Sidebar.Inset>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes two mobile course-nav crashes after #814, and restores **Mark as Complete** on mobile student lessons.

1. **Hamburger / bottom nav crash** — `isContentItemInPath` called `.split()` on an undefined `path` because the course layout never receives a `path` prop from SvelteKit. The layout now uses `page.url.pathname`, and the helper guards missing paths.

2. **Outline sheet crash** — opening the mobile outline sheet crashed with `Cannot read properties of undefined (reading 'percent')`. The sheet passed `{courseProgress}` (a `courseProgress` prop) instead of `progress={courseProgress}` to `CourseProgressCard`. The card now also treats missing progress as zeros.

3. **No way to mark complete on mobile** — the bottom nav hid the whole lesson action row, including Mark as Complete. Prev/next stay in the bottom bar; Mark as Complete (and video-watch progress) stay in the lesson header.

The `/ingest/e/` 404 on `my.fastlearner.io` is PostHog analytics (`setupCloudAnalytics`) and is unrelated to these crashes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- On a phone (or a viewport under 768px), open the **org site** (`?org=<siteName>` locally) and log in as a student
- Open a course lesson
- Open the hamburger course sidebar — it should open without a `split` error
- Tap the bottom-bar center to open the outline sheet — it should show **Your progress** without a `percent` error
- Bottom nav should show the current lesson title and prev/next
- **Mark as Complete** should be visible under the lesson title on mobile
- Tapping it should complete the lesson, snackbar, and update the outline/progress
- Desktop course sidebar prev/next should still work

## Demo (local, org-site student, phone-width)

Logged in as `student@test.com` on `?org=udemy-test`.

**Mark as Complete on mobile**

[mobile_mark_as_complete.mp4](https://cursor.com/agents/bc-5b70dc13-3036-488a-abf8-837bd76757fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_mark_as_complete.mp4)

[Mark as Complete under the lesson title on mobile](https://cursor.com/agents/bc-5b70dc13-3036-488a-abf8-837bd76757fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_mark_as_complete_button.webp)
[Your progress at 17 percent after marking complete](https://cursor.com/agents/bc-5b70dc13-3036-488a-abf8-837bd76757fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_progress_after_complete.webp)

Verified: tap Mark as Complete → snackbar "Marked as complete" → button disables → Content sheet shows 17% and 1 of 3 lessons.

**Earlier nav/crash walkthrough**

[mobile_student_course_nav_full_flow.mp4](https://cursor.com/agents/bc-5b70dc13-3036-488a-abf8-837bd76757fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_student_course_nav_full_flow.mp4)

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Ran `pnpm build` (`pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`)
- [x] Recorded the mobile student flow including mark complete


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b70dc13-3036-488a-abf8-837bd76757fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b70dc13-3036-488a-abf8-837bd76757fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the mobile course-sidebar crash by sourcing the current pathname from SvelteKit state and making course-navigation helpers tolerate missing paths.
- Replaces the unprovided course-layout `path` prop with a reactive `page.url.pathname`.
- Adds a pathname fallback in the mobile bottom navigation and propagates it to the outline sheet.
- Adds null guards and nullable path types throughout the content-navigation helpers.
- Adds tests for missing paths and exact pathname-segment matching, though the new suite is duplicated.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking duplicated test suite to clean up.

The pathname fix follows established reactive routing patterns and closes the undefined split path; the only accepted issue is redundant execution and maintenance of identical tests.

**Files Needing Attention:** apps/dashboard/src/lib/features/course/utils/content-navigation.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/routes/(app)/courses/[id]/+layout.svelte | Replaces the undefined layout prop with a reactive SvelteKit pathname and consistently passes it to course navigation components. |
| apps/dashboard/src/lib/features/course/components/mobile/course-mobile-bottom-nav.svelte | Adds a reactive pathname fallback and uses the resolved path for all mobile navigation state. |
| apps/dashboard/src/lib/features/course/utils/content-navigation.ts | Safely accepts missing paths throughout navigation helpers and prevents splitting nullish values. |
| apps/dashboard/src/lib/features/course/utils/content-navigation.test.ts | Covers the intended null guard and exact-segment behavior, but duplicates the entire test suite. |

<sub>Reviews (1): Last reviewed commit: ["fix(course): stop mobile sidebar crash w..."](https://github.com/classroomio/classroomio/commit/277d3a8420949a305384433a5d15e88260fe6d1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54741235)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved course navigation by deriving the active path from the current page when no path is provided.
  * Fixed content matching to recognize exact pathname segments and safely handle missing paths.
  * Improved active, previous, and next content navigation behavior when the current path is unavailable.

* **Tests**
  * Added coverage for missing paths and exact content ID matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->