### PR TITLE
docs: updated docs for AI disabling

### DIFF
--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -197,6 +197,7 @@ export default defineConfig({
               '/self-hosted/configuration/storage',
               '/self-hosted/configuration/csp',
               '/self-hosted/configuration/integrations',
+              '/self-hosted/configuration/ai',
               '/self-hosted/enterprise'
             ]
           },

--- a/apps/docs/content/docs/self-hosted/configuration/ai.mdx
+++ b/apps/docs/content/docs/self-hosted/configuration/ai.mdx
@@ -1,0 +1,45 @@
+---
+title: AI features
+description: Enable or disable AI features across the ClassroomIO dashboard for self-hosted deployments.
+---
+
+ClassroomIO includes several AI-powered features — course generation, lesson summarisation, an AI tutor, and an in-app assistant. If you run a self-hosted instance and prefer not to use these, you can hide every AI surface in the dashboard with a single environment variable.
+
+## Environment variable
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PUBLIC_IS_AI_ENABLED` | `true` | Set to `false` to hide all AI features in the dashboard |
+
+The variable is read at runtime via `$env/dynamic/public`, so you can change it without rebuilding the app. Restart the dashboard container (or the dev server) after updating your `.env` file.
+
+```bash title=".env"
+PUBLIC_IS_AI_ENABLED=false
+```
+
+:::note[Value matching]
+Only the exact string `false` disables AI. Any other value — including `true`, an empty string, or a typo like `FALSE` — keeps AI enabled.
+:::
+
+## What gets disabled
+
+When `PUBLIC_IS_AI_ENABLED` is set to `false`:
+
+| Area | Change |
+|------|--------|
+| **Home page** | The AI course-creator page is hidden; admins are redirected to the dashboard (`/dash`) instead |
+| **Sidebar navigation** | The "Home" nav item is removed |
+| **Course header** | The "AI Assistant" button (sparkles icon) is removed |
+| **Course sidebar** | The "AI Tutor" nav item is hidden for tutors and admins |
+| **Lesson actions** | The "Summarize lesson" button and the "Quote in chat" text selection overlay are removed |
+| **Floating AI bar** | The "Ask AI" bar at the bottom of lesson and exercise pages is not rendered |
+| **Settings** | The "AI Credits" and "AI Tutor" tabs are removed from Settings |
+
+:::info[Backend note]
+This flag controls the **UI only**. Backend API routes that power AI features still exist but are unreachable from the dashboard when AI is hidden.
+:::
+
+## Related
+
+- To connect an OpenAI API key for transcription and course generation, see [Integrations](/self-hosted/configuration/integrations).
+- To configure enterprise features like SSO, see [Enterprise & licensing](/self-hosted/enterprise).

--- a/apps/docs/content/docs/self-hosted/configuration/index.mdx
+++ b/apps/docs/content/docs/self-hosted/configuration/index.mdx
@@ -39,6 +39,9 @@ use that feature. Leaving an optional variable blank never causes a build or boo
   <Card title="Integrations" href="/self-hosted/configuration/integrations" icon="plug">
     Google OAuth, Unsplash, OpenAI transcription and AI course generation.
   </Card>
+  <Card title="AI features" href="/self-hosted/configuration/ai" icon="sparkles">
+    Enable or disable AI features across the dashboard for self-hosted deployments.
+  </Card>
   <Card title="Enterprise & licensing" href="/self-hosted/enterprise" icon="id-card">
     Set `LICENSE_KEY` to unlock Enterprise features such as SSO.
   </Card>

--- a/apps/docs/content/docs/self-hosted/configuration/integrations.mdx
+++ b/apps/docs/content/docs/self-hosted/configuration/integrations.mdx
@@ -24,6 +24,10 @@ key wherever the worker reads its environment.
 |----------|-------------|
 | `OPENAI_API_KEY` | OpenAI API key — transcription + AI course generation |
 
+:::tip[Disable AI features]
+To hide all AI-related UI across the dashboard, see [AI features](/self-hosted/configuration/ai).
+:::
+
 ## Unsplash
 
 Enables the in-app Unsplash image search.


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR updates the docs to make self hosters understand how turning of AI 

Fixes # (place issue number here without bracket)

## Demo

<!-- Please upload a video here or attach a link to a video player like Awesome Screenshot or Loom to show the change in action. This speeds up reviews, especially for visual changes. -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [x] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring AI features in self-hosted deployments.
  * Documented how to enable or disable AI-related dashboard interfaces and clarified runtime behavior.
  * Added an AI features topic to the self-hosted configuration section.
  * Added cross-references from integration guidance to the new AI configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds self-hosting documentation for configuring AI visibility and links the new page from the configuration navigation.

- Documents `PUBLIC_IS_AI_ENABLED` and the dashboard surfaces it is intended to control.
- Adds the AI configuration page to the sidebar and configuration overview.
- Cross-references the new guidance from the integrations page.

<h3>Confidence Score: 4/5</h3>

The PR is not safe to merge until the documented AI disable setting is implemented by the dashboard or the unsupported guidance is removed.

The prior finding remains outstanding: the documentation instructs self-hosters to set `PUBLIC_IS_AI_ENABLED=false`, while current dashboard AI surfaces and calls do not read or enforce that variable.

**Files Needing Attention:** apps/docs/content/docs/self-hosted/configuration/ai.mdx and the corresponding apps/dashboard AI surfaces

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/docs/blume.config.ts | Adds the new AI configuration page to the self-hosted configuration sidebar. |
| apps/docs/content/docs/self-hosted/configuration/ai.mdx | Adds documentation for the AI visibility configuration, its value semantics, and affected dashboard surfaces. |
| apps/docs/content/docs/self-hosted/configuration/index.mdx | Adds a discoverable configuration card linking to the AI features page. |
| apps/docs/content/docs/self-hosted/configuration/integrations.mdx | Adds a cross-reference from OpenAI integration guidance to AI feature configuration. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into docs-for-AI-dis..."](https://github.com/classroomio/classroomio/commit/33cb98a11e52b4ad7c52b353e15fa57e7c253ad8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54782584)</sub>

**Context used:**

- Knowledge Base — [Docs App (`apps/docs`)](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/docs-app.md)

<!-- /greptile_comment -->