### PR TITLE
feat(ai-assistant): add OrcaRouter as a named AI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,9 +119,11 @@ UNSPLASH_API_KEY=
 # AI Assistant — set at least one provider key to enable the in-course chat.
 # The dashboard model picker exposes Gemini 3 Flash (Google) and GPT-4o (OpenAI).
 # Anthropic is supported in code but not surfaced in the picker UI.
+# OrcaRouter (https://api.orcarouter.ai/v1) is an OpenAI-compatible gateway.
 OPENAI_API_KEY=
 GOOGLE_API_KEY=
 ANTHROPIC_API_KEY=
+ORCAROUTER_API_KEY=
 
 # Enterprise license (SSO, token-auth, no-tracking)
 LICENSE_KEY=

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ The in-course AI chat (course authoring, plan generation, lesson edits) is **dis
 OPENAI_API_KEY=sk-...        # enables GPT-4o
 GOOGLE_API_KEY=AIza...       # enables Gemini 2.5 Flash (default model in the picker)
 ANTHROPIC_API_KEY=sk-ant-... # supported in code; not currently in the picker UI
+ORCAROUTER_API_KEY=sk-orca-... # enables OrcaRouter (OpenAI-compatible gateway, https://api.orcarouter.ai/v1)
 ```
 
 Notes:

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -83,6 +83,7 @@ OPENAI_API_KEY=""
 GOOGLE_API_KEY=""
 ANTHROPIC_API_KEY=""
 MOONSHOT_API_KEY=""
+ORCAROUTER_API_KEY=""
 
 # Jina Reader — optional Bearer for higher rate limits when using fetch_documentation_url
 # JINA_API_KEY=""

--- a/apps/api/src/services/agent/text-generation.ts
+++ b/apps/api/src/services/agent/text-generation.ts
@@ -5,7 +5,8 @@ const TEXT_GEN_MODELS: Record<AIProvider, string> = {
   [AIProvider.OPENAI]: 'gpt-4o-mini',
   [AIProvider.ANTHROPIC]: 'claude-haiku-4-5-20251001',
   [AIProvider.GOOGLE]: 'gemini-3.1-flash-lite',
-  [AIProvider.MOONSHOT]: 'kimi-k2.6'
+  [AIProvider.MOONSHOT]: 'kimi-k2.6',
+  [AIProvider.ORCAROUTER]: 'orcarouter/auto'
 };
 
 export interface GenerateFieldTextResult {

--- a/apps/api/src/services/agent/title-generation.ts
+++ b/apps/api/src/services/agent/title-generation.ts
@@ -9,7 +9,8 @@ const TITLE_MODELS: Record<AIProvider, string> = {
   [AIProvider.OPENAI]: 'gpt-4o-mini',
   [AIProvider.ANTHROPIC]: 'claude-haiku-4-5-20251001',
   [AIProvider.GOOGLE]: 'gemini-3.1-flash-lite',
-  [AIProvider.MOONSHOT]: 'kimi-k2.6'
+  [AIProvider.MOONSHOT]: 'kimi-k2.6',
+  [AIProvider.ORCAROUTER]: 'orcarouter/auto'
 };
 
 function createTitleModel(config: AIProviderConfig) {

--- a/packages/ai-assistant/src/providers/index.ts
+++ b/packages/ai-assistant/src/providers/index.ts
@@ -9,14 +9,16 @@ const DEFAULT_MODELS: Record<AIProvider, string> = {
   [AIProvider.OPENAI]: 'gpt-5.4-mini',
   [AIProvider.ANTHROPIC]: 'claude-sonnet-4-20250514',
   [AIProvider.GOOGLE]: 'gemini-3.1-flash-lite',
-  [AIProvider.MOONSHOT]: 'kimi-k2.6'
+  [AIProvider.MOONSHOT]: 'kimi-k2.6',
+  [AIProvider.ORCAROUTER]: 'orcarouter/auto'
 };
 
 const PROVIDER_API_KEY_ENV: Record<AIProvider, string> = {
   [AIProvider.OPENAI]: 'OPENAI_API_KEY',
   [AIProvider.ANTHROPIC]: 'ANTHROPIC_API_KEY',
   [AIProvider.GOOGLE]: 'GOOGLE_API_KEY',
-  [AIProvider.MOONSHOT]: 'MOONSHOT_API_KEY'
+  [AIProvider.MOONSHOT]: 'MOONSHOT_API_KEY',
+  [AIProvider.ORCAROUTER]: 'ORCAROUTER_API_KEY'
 };
 
 /**
@@ -43,6 +45,15 @@ export function createModel(config: AIProviderConfig): LanguageModel {
       const moonshot = createMoonshotAI({ apiKey: config.apiKey });
       return moonshot(modelName);
     }
+    case AIProvider.ORCAROUTER: {
+      const orcarouter = createOpenAI({
+        apiKey: config.apiKey,
+        baseURL: 'https://api.orcarouter.ai/v1'
+      });
+      // OrcaRouter is an OpenAI-compatible chat gateway, so use the Chat
+      // Completions model rather than the default Responses API.
+      return orcarouter.chat(modelName);
+    }
     default:
       throw new Error(`Unsupported AI provider: ${config.provider}`);
   }
@@ -64,7 +75,7 @@ export function getProviderConfigForProvider(provider: AIProvider): AIProviderCo
  * Used by routes that don't take an explicit model (status check, title generation).
  */
 export function pickAnyConfiguredProvider(): AIProviderConfig | null {
-  const order: AIProvider[] = [AIProvider.GOOGLE, AIProvider.OPENAI, AIProvider.ANTHROPIC];
+  const order: AIProvider[] = [AIProvider.GOOGLE, AIProvider.OPENAI, AIProvider.ANTHROPIC, AIProvider.ORCAROUTER];
 
   for (const provider of order) {
     const config = getProviderConfigForProvider(provider);

--- a/packages/ai-assistant/src/types.ts
+++ b/packages/ai-assistant/src/types.ts
@@ -15,7 +15,8 @@ export const AIProvider = {
   OPENAI: 'openai',
   ANTHROPIC: 'anthropic',
   GOOGLE: 'google',
-  MOONSHOT: 'moonshot'
+  MOONSHOT: 'moonshot',
+  ORCAROUTER: 'orcarouter'
 } as const;
 
 export type AIProvider = (typeof AIProvider)[keyof typeof AIProvider];

--- a/packages/utils/src/agent-models/index.ts
+++ b/packages/utils/src/agent-models/index.ts
@@ -7,10 +7,16 @@
  *   even though it isn't currently exposed to users.
  */
 
-export const AGENT_MODEL_IDS = ['gemini-3.1-flash-lite', 'gpt-5.4-mini', 'claude-sonnet-3-5', 'kimi-k2.6'] as const;
+export const AGENT_MODEL_IDS = [
+  'gemini-3.1-flash-lite',
+  'gpt-5.4-mini',
+  'claude-sonnet-3-5',
+  'kimi-k2.6',
+  'orcarouter/auto'
+] as const;
 
 export type AgentModelId = (typeof AGENT_MODEL_IDS)[number];
-export type AgentModelProvider = 'google' | 'openai' | 'anthropic' | 'moonshot';
+export type AgentModelProvider = 'google' | 'openai' | 'anthropic' | 'moonshot' | 'orcarouter';
 export type AgentModelCostTier = 'low' | 'high';
 
 export interface AgentModelDescriptor {
@@ -58,6 +64,14 @@ export const AGENT_MODELS: Record<AgentModelId, AgentModelDescriptor> = {
     isFree: true,
     costTier: 'low',
     contextWindow: 262_144
+  },
+  'orcarouter/auto': {
+    provider: 'orcarouter',
+    label: 'OrcaRouter Auto',
+    backendModelId: 'orcarouter/auto',
+    isFree: true,
+    costTier: 'low',
+    contextWindow: 131_072
   }
 };
 
@@ -65,7 +79,8 @@ export const UI_PICKER_MODEL_IDS = [
   'kimi-k2.6',
   'gemini-3.1-flash-lite',
   'gpt-5.4-mini',
-  'claude-sonnet-3-5'
+  'claude-sonnet-3-5',
+  'orcarouter/auto'
 ] as const satisfies readonly AgentModelId[];
 
 export const DEFAULT_PICKER_MODEL_ID: AgentModelId = 'gemini-3.1-flash-lite';

--- a/prd/ai-course-assistant [DONE]/README.md
+++ b/prd/ai-course-assistant [DONE]/README.md
@@ -298,7 +298,7 @@ A thin, backend-focused package consumed by `apps/api`. No UI code. The heavy li
 
 ### Responsibilities
 
-- **Provider factory** — creates the right AI SDK `LanguageModel` for a given provider (`createModel`); `getProviderConfigForProvider(provider)` reads the per-provider key (`OPENAI_API_KEY` / `GOOGLE_API_KEY` / `ANTHROPIC_API_KEY`); `pickAnyConfiguredProvider()` returns the first provider with a key set, used by the status route and title generation
+- **Provider factory** — creates the right AI SDK `LanguageModel` for a given provider (`createModel`); `getProviderConfigForProvider(provider)` reads the per-provider key (`OPENAI_API_KEY` / `GOOGLE_API_KEY` / `ANTHROPIC_API_KEY` / `ORCAROUTER_API_KEY`); `pickAnyConfiguredProvider()` returns the first provider with a key set, used by the status route and title generation
 - **Role-aware tool registry** — `getToolSchemas(role)` returns Zod schemas per role
 - **Role-aware system prompt** — `buildSystemPrompt(context)` generates different LLM instructions for teachers vs students, including Plan Mode vs Agent Mode behavior
 - **Course plan types** — `CoursePlan`, `CoursePlanSection`, `CoursePlanLesson` types used by both API and dashboard
@@ -606,7 +606,7 @@ When not configured (self-hosted, or dev environments), events are silently skip
 ## Self-Hosted vs Cloud
 
 - **Cloud**: AI assistant enabled by default. ClassroomIO provides the LLM API key server-side. Usage metered per plan tier.
-- **Self-hosted**: AI assistant **disabled by default**. To enable, admin sets at least one of `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `ANTHROPIC_API_KEY`. The dashboard model picker exposes Gemini 2.5 Flash (Google) and GPT-4o (OpenAI); each option requires its own provider key. Anthropic is supported in code but not exposed in the picker. The assistant button is hidden when no provider key is set. No token metering for self-hosted (user's own API key, their cost).
+- **Self-hosted**: AI assistant **disabled by default**. To enable, admin sets at least one of `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY`, or `ORCAROUTER_API_KEY`. The dashboard model picker exposes Gemini 2.5 Flash (Google), GPT-4o (OpenAI), and OrcaRouter Auto (OrcaRouter, OpenAI-compatible gateway); each option requires its own provider key. Anthropic is supported in code but not exposed in the picker. The assistant button is hidden when no provider key is set. No token metering for self-hosted (user's own API key, their cost).
 
 ---
 
@@ -801,6 +801,7 @@ Per-provider API keys configure which models are available:
 - `OPENAI_API_KEY` — enables GPT-4o (and `gpt-4o-mini` for title generation)
 - `GOOGLE_API_KEY` — enables Gemini 2.5 Flash
 - `ANTHROPIC_API_KEY` — enables Claude (Sonnet 4.5 / Haiku for titles); supported in code, not in the picker UI
+- `ORCAROUTER_API_KEY` — enables [OrcaRouter](https://www.orcarouter.ai) (`orcarouter/auto`), an OpenAI-compatible gateway at `https://api.orcarouter.ai/v1`
 - `TINYBIRD_TOKEN` — Tinybird API token for event ingestion (optional; events silently skipped when not set)
 - `TINYBIRD_BASE_URL` — Tinybird API base URL (default: `https://api.tinybird.co`)
 


### PR DESCRIPTION
## What does this PR do?

Adds [OrcaRouter](https://www.orcarouter.ai) as a named AI provider for the in-course AI assistant, mirroring the existing OpenAI/Anthropic/Google/Moonshot provider wiring. It is an OpenAI-compatible gateway at `https://api.orcarouter.ai/v1`; when `ORCAROUTER_API_KEY` is set, `orcarouter/auto` appears in the dashboard model picker and the assistant resolves it through the same `createModel()` factory.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Demo

No visual change beyond the model picker gaining an "OrcaRouter Auto" entry.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

1. Set `ORCAROUTER_API_KEY` in `apps/api/.env`, restart the API.
2. In a course's AI chat, open the model picker → select **OrcaRouter Auto**.
3. Send a message; the assistant streams a response routed through OrcaRouter.

### Local verification

- `pnpm --filter @cio/api^... build` and `pnpm --filter @cio/api build` — clean (includes `packages/ai-assistant` + `packages/utils`).
- `pnpm --filter @cio/dashboard^... build` and `pnpm --filter @cio/dashboard build` — clean.
- `pnpm --filter @cio/utils test` — 17/17 pass.
- `pnpm format:check` (pre-commit gate) — passes.
- L3 live test through the real provider path (`createOpenAI({ baseURL: 'https://api.orcarouter.ai/v1' }).chat('orcarouter/auto')` via `generateText`) — returned `ORCA-LIVE-OK` with a real key.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the ClassroomIO Docs if changes were necessary

---

Disclosure: I'm an engineer on the OrcaRouter team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as an AI provider through an OpenAI-compatible gateway.
  * Added OrcaRouter Auto to the available model selection options.
  * Added Moonshot support for text generation.
  * Added configuration documentation for the optional OrcaRouter API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds OrcaRouter as an OpenAI-compatible AI-assistant provider and exposes its automatic-routing model in the dashboard picker.

- Adds provider typing, API-key resolution, model construction, and defaults for text and title generation.
- Adds OrcaRouter model metadata and picker registration.
- Documents `ORCAROUTER_API_KEY` in environment templates and self-host guidance.
- The picker does not conditionally hide the model when its key is absent, and Docker self-host deployments do not forward the documented key to the API.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until OrcaRouter availability is aligned with configured keys and the self-host Docker stack forwards ORCAROUTER_API_KEY to the API.

Users can select an unconfigured OrcaRouter model and receive a 503, while self-host operators cannot make the provider configured through the documented root environment because both Compose API environments omit the key.

**Files Needing Attention:** packages/utils/src/agent-models/index.ts, .env.example, docker-compose.yaml, docker-compose.images.yaml

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ai-assistant/src/providers/index.ts | Adds complete OrcaRouter factory and key mapping, but its configuration depends on deployment wiring omitted elsewhere. |
| packages/utils/src/agent-models/index.ts | Registers OrcaRouter metadata and exposes it unconditionally, allowing selection when the provider is unavailable. |
| .env.example | Advertises a self-host key that neither supported Compose API service forwards. |
| apps/api/src/services/agent/text-generation.ts | Adds the OrcaRouter default model to the exhaustive provider map. |
| apps/api/src/services/agent/title-generation.ts | Adds the OrcaRouter default title-generation model to the exhaustive provider map. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Env[ORCAROUTER_API_KEY in root .env] -. omitted by Compose .-> API[API container]
  Picker[Dashboard model picker] -->|orcarouter/auto| Route[Agent chat route]
  Route --> Config[getProviderConfigForProvider]
  API --> Config
  Config -->|key present| Orca[OrcaRouter API]
  Config -->|key absent| Error[503 AI_NOT_CONFIGURED]
```

<sub>Reviews (1): Last reviewed commit: ["feat(ai-assistant): add OrcaRouter as a ..."](https://github.com/classroomio/classroomio/commit/743500035407aac5e4634fba350fb7c2dee446c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54993875)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [AI Assistant Package (`@cio/ai-assistant`)](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/ai-assistant-package.md)
- Knowledge Base — [Self-host lifecycle manager (`classroomio.sh`)](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/self-host-lifecycle.md)

<!-- /greptile_comment -->