### PR TITLE
fix(api): restore public API OpenAPI paths dropped by sub-router error handler

### DIFF
--- a/apps/api/scripts/upload-openapi-spec.ts
+++ b/apps/api/scripts/upload-openapi-spec.ts
@@ -152,8 +152,18 @@ class OpenAPISpecGenerator {
       });
 
       const publicApiSpec = filterPublicApiSpec(spec as Record<string, unknown>);
+      const pathCount = Object.keys((publicApiSpec as { paths?: Record<string, unknown> }).paths ?? {}).length;
+
+      if (pathCount === 0) {
+        throw new Error(
+          'Generated OpenAPI spec has zero public API paths. Refusing to publish an empty spec — ' +
+            'this usually means route metadata (describeRoute) is being dropped before reaching ' +
+            'hono-openapi, e.g. by an .onError() on a sub-router that gets merged via .route().'
+        );
+      }
+
       const specString = JSON.stringify(publicApiSpec, null, 2);
-      console.log('✅ OpenAPI specification generated successfully');
+      console.log(`✅ OpenAPI specification generated successfully (${pathCount} path(s))`);
 
       return specString;
     } catch (error) {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -13,7 +13,7 @@ import {
   shouldRewriteOAuthProxyCallbackLocation
 } from '@api/utils/oauth-proxy-redirect';
 import { Hono } from '@api/utils/hono';
-import { ErrorCodes } from '@api/utils/errors';
+import { ErrorCodes, handlePublicApiError } from '@api/utils/errors';
 import { accountRouter } from '@api/routes/account';
 import { agentRouter } from '@api/routes/agent';
 import { auth } from '@cio/db/auth';
@@ -261,6 +261,11 @@ export const app = new Hono()
   .onError((err, c) => {
     Sentry.captureException(err);
     console.error('Error:', err);
+
+    if (c.req.path.startsWith('/public-api/v1/')) {
+      return handlePublicApiError(c, err, 'Internal Server Error', ErrorCodes.INTERNAL_ERROR);
+    }
+
     return c.json({ error: 'Internal Server Error' }, 500);
   });
 

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -1,21 +1,9 @@
-import * as Sentry from '@sentry/node';
-
 import { Hono } from '@api/utils/hono';
 import { publicApiCors } from '@api/middlewares/cors';
-import { ErrorCodes, handlePublicApiError } from '@api/utils/errors';
 import { v1AudienceRouter } from './audience';
 import { v1CoursesRouter } from './courses';
 
 export const v1Router = new Hono()
   .use('*', publicApiCors)
-  .use('*', async (c, next) => {
-    try {
-      await next();
-    } catch (err) {
-      console.error('Public API error:', err);
-      Sentry.captureException(err);
-      return handlePublicApiError(c, err, 'Internal Server Error', ErrorCodes.INTERNAL_ERROR);
-    }
-  })
   .route('/audience', v1AudienceRouter)
   .route('/courses', v1CoursesRouter);

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -8,10 +8,14 @@ import { v1CoursesRouter } from './courses';
 
 export const v1Router = new Hono()
   .use('*', publicApiCors)
+  .use('*', async (c, next) => {
+    try {
+      await next();
+    } catch (err) {
+      console.error('Public API error:', err);
+      Sentry.captureException(err);
+      return handlePublicApiError(c, err, 'Internal Server Error', ErrorCodes.INTERNAL_ERROR);
+    }
+  })
   .route('/audience', v1AudienceRouter)
-  .route('/courses', v1CoursesRouter)
-  .onError((err, c) => {
-    console.error('Public API error:', err);
-    Sentry.captureException(err);
-    return handlePublicApiError(c, err, 'Internal Server Error', ErrorCodes.INTERNAL_ERROR);
-  });
+  .route('/courses', v1CoursesRouter);


### PR DESCRIPTION
## What does this PR do?

Fixes the public API reference on the docs site (`/api`) silently showing zero endpoints and no "Try it" panel since Aug 11.

Root cause: PR #809 added a custom `.onError()` handler directly on `v1Router` (the public API's sub-router) to standardize error responses. Hono has an undocumented quirk: when a sub-router with its own `.onError()` is merged into a parent via `.route()`, Hono rewraps every one of that sub-router's handlers into new closures before re-registering them. That rewrap drops the metadata `hono-openapi`'s `describeRoute()` attaches to each handler, so `generateSpecs()` silently skips every `/public-api/v1/*` route when building the OpenAPI spec — no error, no warning, just an empty `paths: {}`. The spec-upload GitHub Action kept reporting green the whole time because nothing in the pipeline actually throws.

An initial attempt replaced `.onError()` with a try/catch middleware on `v1Router` itself, but that doesn't actually work: Hono only ever consults a *single* error handler per request — the outermost app's, set once when the whole middleware chain is composed (`hono-base.js`, `#dispatch`/`compose()`). When something throws deep in the chain, Hono resolves it immediately at that point via the top-level handler; the exception never bubbles back up through an earlier sub-router's own try/catch. Confirmed via source reading and an isolated repro against the real `hono` package — a try/catch on `v1Router` never fired.

This PR:
- Reverts `v1Router` (`apps/api/src/routes/v1/index.ts`) to its original minimal form — no `.onError()`, no middleware-based error handling — so Hono never rewraps its handlers and `describeRoute()` metadata survives.
- Moves the public-API-specific error formatting into the top-level `app.onError` (`apps/api/src/app.ts`), gated on `c.req.path.startsWith('/public-api/v1/')`, since that's the only error handler Hono ever actually calls. Same `handlePublicApiError` shape and Sentry capture as before, just relocated to where it actually takes effect.
- Adds a guard to `apps/api/scripts/upload-openapi-spec.ts` that throws (failing the build) if the generated public API spec ever has zero paths again, instead of silently publishing an empty spec.

Fixes # (add issue number if one exists)

## Demo

N/A — backend/docs-pipeline fix, no UI change. Verifiable via `https://api.cdn.clsrio.com/openapi/public-api/openapi-latest.json` (paths populated) and the docs site `/api` page (endpoints + "Try it" visible) after this merges to `main` and the `upload-openapi-spec.yml` workflow runs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Isolated repro against the real installed `hono`/`hono-openapi` packages, mirroring the fixed router structure: confirms `generateSpecs()` now returns `/public-api/v1/courses` (and `/audience`), and that an uncaught error thrown deep in a public API route still resolves to the `{"success":false,"error":...,"code":...}` shape via `app.onError`, not the generic `{"error":"Internal Server Error"}`.
- Manually verify public API error responses: hit a public API endpoint with an invalid request (e.g. malformed query params, or force an unhandled throw) and confirm the response is still the `handlePublicApiError` JSON shape.
- After merge: confirm `.github/workflows/upload-openapi-spec.yml` succeeds and re-fetch `https://api.cdn.clsrio.com/openapi/public-api/openapi-latest.json` to confirm non-empty `paths`.
- Run `pnpm --filter @cio/docs dev`, visit `/api`, confirm the endpoint list populates and "Try it" works end to end.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description — N/A, none of those are touched by this PR

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR — N/A, no UI change
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores public API OpenAPI route metadata while preserving the stable public error-response contract at the application boundary.
- Removes the sub-router error handler that caused Hono to rewrap handlers and discard OpenAPI metadata.
- Routes errors from matched public API v1 endpoints through `handlePublicApiError` in the top-level handler.
- Prevents publication when the generated public API specification contains no paths.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/app.ts | Moves public API error formatting to the effective top-level Hono error handler and correctly scopes currently reachable v1 routes. |
| apps/api/src/routes/v1/index.ts | Removes the sub-router error handler so mounted route handlers retain their OpenAPI metadata. |
| apps/api/scripts/upload-openapi-spec.ts | Adds a fail-fast guard against publishing a public API specification with no paths. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Request[Public API request] --> App[Top-level Hono app]
  App --> V1[Public API v1 router]
  V1 --> Route[Audience or courses handler]
  Route -->|Success| Response[Public API response]
  Route -->|Unhandled error| ErrorHandler[Top-level app.onError]
  ErrorHandler --> PublicError[handlePublicApiError]
  V1 --> Metadata[describeRoute metadata remains intact]
  Metadata --> Generator[OpenAPI generation]
  Generator --> Check{Public paths present?}
  Check -->|Yes| Publish[Publish specification]
  Check -->|No| Fail[Abort publication]
```

<sub>Reviews (2): Last reviewed commit: ["fix(api): enhance error handling for pub..."](https://github.com/classroomio/classroomio/commit/aa29effcc18496bfecde27f027f81eecb55c32cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55185736)</sub>

**Context used:**

- Knowledge Base — [API app (`apps/api`)](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/api-app.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Public API v1 requests with consistent internal-server-error responses.
  * Preserved existing error behavior for non-Public API requests.

* **Documentation**
  * OpenAPI specification generation now verifies that public API paths are available before completing.
  * Successful specification generation reports the number of generated API paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->