### PR TITLE
fix(course): restore mobile mark complete and outline progress card

### DIFF
--- a/apps/dashboard/src/lib/features/course/components/course-progress-card.svelte
+++ b/apps/dashboard/src/lib/features/course/components/course-progress-card.svelte
@@ -4,27 +4,33 @@
   import type { ContentProgress } from '$features/course/utils/content';
 
   interface Props {
-    progress: ContentProgress;
+    progress?: ContentProgress;
     class?: string;
   }
 
   let { progress, class: className = '' }: Props = $props();
+
+  const percent = $derived(progress?.percent ?? 0);
+  const lessonsComplete = $derived(progress?.lessonsComplete ?? 0);
+  const lessonsTotal = $derived(progress?.lessonsTotal ?? 0);
+  const exercisesComplete = $derived(progress?.exercisesComplete ?? 0);
+  const exercisesTotal = $derived(progress?.exercisesTotal ?? 0);
 </script>
 
 <div class={className}>
   <div class="flex items-baseline justify-between gap-2">
     <span class="text-xs font-medium">{$t('course.sidebar.progress.title')}</span>
-    <span class="ui:text-primary text-xs font-semibold tabular-nums">{progress.percent}%</span>
+    <span class="ui:text-primary text-xs font-semibold tabular-nums">{percent}%</span>
   </div>
-  <Progress value={progress.percent} max={100} class="ui:h-1.5 mt-2" />
+  <Progress value={percent} max={100} class="ui:h-1.5 mt-2" />
   <p class="ui:text-muted-foreground mt-2 truncate text-[11px]">
     {$t('course.sidebar.progress.lessons', {
-      completed: progress.lessonsComplete,
-      total: progress.lessonsTotal
-    })}{#if progress.exercisesTotal > 0}
+      completed: lessonsComplete,
+      total: lessonsTotal
+    })}{#if exercisesTotal > 0}
       · {$t('course.sidebar.progress.exercises', {
-        completed: progress.exercisesComplete,
-        total: progress.exercisesTotal
+        completed: exercisesComplete,
+        total: exercisesTotal
       })}{/if}
   </p>
 </div>

--- a/apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte
+++ b/apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte
@@ -29,9 +29,11 @@
     courseId: string;
     /** When on an exercise page, pass this to show prev/next content in content order (no mark-complete). */
     exerciseId?: string;
+    /** When false, hide prev/next chevrons (mobile bottom nav already has them). */
+    showPrevNext?: boolean;
   }
 
-  let { lessonId, courseId, exerciseId }: Props = $props();
+  let { lessonId, courseId, exerciseId, showPrevNext = true }: Props = $props();
 
   let isMarkingComplete = $state(false);
 
@@ -242,40 +244,42 @@
       </Button>
     {/if}
 
-    <div class="flex items-center gap-1">
-      <Tooltip.Root>
-        <Tooltip.Trigger>
-          <Button
-            size="icon-sm"
-            variant="outline"
-            onclick={() => goToContent(prevNextContent.prev)}
-            disabled={isPrevDisabled || isPrevNavBlocked}
-            aria-label={$t('course.navItem.lessons.prev')}
-          >
-            <ChevronLeftIcon size={14} />
-          </Button>
-        </Tooltip.Trigger>
-        <Tooltip.Content side="bottom" sideOffset={4}>
-          {prevNavTooltip}
-        </Tooltip.Content>
-      </Tooltip.Root>
+    {#if showPrevNext}
+      <div class="flex items-center gap-1">
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <Button
+              size="icon-sm"
+              variant="outline"
+              onclick={() => goToContent(prevNextContent.prev)}
+              disabled={isPrevDisabled || isPrevNavBlocked}
+              aria-label={$t('course.navItem.lessons.prev')}
+            >
+              <ChevronLeftIcon size={14} />
+            </Button>
+          </Tooltip.Trigger>
+          <Tooltip.Content side="bottom" sideOffset={4}>
+            {prevNavTooltip}
+          </Tooltip.Content>
+        </Tooltip.Root>
 
-      <Tooltip.Root>
-        <Tooltip.Trigger>
-          <Button
-            size="icon-sm"
-            variant="outline"
-            onclick={() => goToContent(prevNextContent.next)}
-            disabled={isNextDisabled || isNextNavBlocked}
-            aria-label={$t('course.navItem.lessons.next')}
-          >
-            <ChevronRightIcon size={14} />
-          </Button>
-        </Tooltip.Trigger>
-        <Tooltip.Content side="bottom" sideOffset={4}>
-          {nextNavTooltip}
-        </Tooltip.Content>
-      </Tooltip.Root>
-    </div>
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <Button
+              size="icon-sm"
+              variant="outline"
+              onclick={() => goToContent(prevNextContent.next)}
+              disabled={isNextDisabled || isNextNavBlocked}
+              aria-label={$t('course.navItem.lessons.next')}
+            >
+              <ChevronRightIcon size={14} />
+            </Button>
+          </Tooltip.Trigger>
+          <Tooltip.Content side="bottom" sideOffset={4}>
+            {nextNavTooltip}
+          </Tooltip.Content>
+        </Tooltip.Root>
+      </div>
+    {/if}
   </Tooltip.Provider>
 </div>

--- a/apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte
+++ b/apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte
@@ -231,7 +231,7 @@
           {watchProgressTooltip}
         </Tooltip.Content>
       </Tooltip.Root>
-    {:else if showMarkComplete && lessonId && !isLessonLocked && (showVideoWatchCompleteState || !isVideoWatchLesson)}
+    {:else if showMarkComplete && lessonId && !isLessonLocked && !isLessonComplete && !isVideoWatchLesson}
       <Button
         size="sm"
         variant="secondary"

--- a/apps/dashboard/src/lib/features/course/components/lesson/lesson-page-edit-header.svelte
+++ b/apps/dashboard/src/lib/features/course/components/lesson/lesson-page-edit-header.svelte
@@ -10,14 +10,12 @@
   import { isOrgStudent } from '$lib/utils/store/app';
   import { t } from '$lib/utils/functions/translations';
   import { RoleBasedSecurity } from '$features/ui';
-  import { CircleCheckIcon } from '$features/ui/icons';
   import DeleteLessonConfirmation from '$features/course/components/lesson/delete-lesson-confirmation.svelte';
   import { slugifyTitle } from '@cio/utils/validation';
 
   interface Props {
     mode: (typeof MODES)[keyof typeof MODES];
     title: string;
-    isComplete?: boolean;
     isUnlocked?: boolean | null;
     isDeletingLesson?: boolean;
     onTitleChange: (value: string) => void;
@@ -32,7 +30,6 @@
   let {
     mode,
     title,
-    isComplete = false,
     isUnlocked = false,
     isDeletingLesson = false,
     onTitleChange,
@@ -76,14 +73,7 @@
         {/if}
       </RoleBasedSecurity>
     {:else}
-      <Page.Title class="flex min-w-0 items-center gap-2">
-        <span class="min-w-0 truncate">{title}</span>
-        {#if isComplete}
-          <span class="ui:text-primary shrink-0" aria-label={$t('course.navItem.lessons.complete')}>
-            <CircleCheckIcon size={20} filled />
-          </span>
-        {/if}
-      </Page.Title>
+      <Page.Title>{title}</Page.Title>
     {/if}
   </div>
 

--- a/apps/dashboard/src/lib/features/course/components/lesson/lesson-page-edit-header.svelte
+++ b/apps/dashboard/src/lib/features/course/components/lesson/lesson-page-edit-header.svelte
@@ -10,12 +10,14 @@
   import { isOrgStudent } from '$lib/utils/store/app';
   import { t } from '$lib/utils/functions/translations';
   import { RoleBasedSecurity } from '$features/ui';
+  import { CircleCheckIcon } from '$features/ui/icons';
   import DeleteLessonConfirmation from '$features/course/components/lesson/delete-lesson-confirmation.svelte';
   import { slugifyTitle } from '@cio/utils/validation';
 
   interface Props {
     mode: (typeof MODES)[keyof typeof MODES];
     title: string;
+    isComplete?: boolean;
     isUnlocked?: boolean | null;
     isDeletingLesson?: boolean;
     onTitleChange: (value: string) => void;
@@ -30,6 +32,7 @@
   let {
     mode,
     title,
+    isComplete = false,
     isUnlocked = false,
     isDeletingLesson = false,
     onTitleChange,
@@ -73,7 +76,14 @@
         {/if}
       </RoleBasedSecurity>
     {:else}
-      <Page.Title>{title}</Page.Title>
+      <Page.Title class="flex min-w-0 items-center gap-2">
+        <span class="min-w-0 truncate">{title}</span>
+        {#if isComplete}
+          <span class="ui:text-primary shrink-0" aria-label={$t('course.navItem.lessons.complete')}>
+            <CircleCheckIcon size={20} filled />
+          </span>
+        {/if}
+      </Page.Title>
     {/if}
   </div>
 

--- a/apps/dashboard/src/lib/features/course/components/mobile/course-mobile-bottom-nav.svelte
+++ b/apps/dashboard/src/lib/features/course/components/mobile/course-mobile-bottom-nav.svelte
@@ -77,6 +77,7 @@
 <PublicCourseBottomNav
   {positionLabel}
   sublineLabel={activeItem?.title}
+  sublineComplete={activeItem?.isComplete ?? false}
   hasPrev={!isPreviousDisabled}
   hasNext={!isNextDisabled}
   onPrev={() => goToContent(previousItem)}

--- a/apps/dashboard/src/lib/features/course/components/mobile/course-mobile-outline-sheet.svelte
+++ b/apps/dashboard/src/lib/features/course/components/mobile/course-mobile-outline-sheet.svelte
@@ -52,7 +52,7 @@
       </Drawer.Header>
 
       <div class="shrink-0 px-3 pb-2">
-        <CourseProgressCard {courseProgress} class="rounded-lg border p-3" />
+        <CourseProgressCard progress={courseProgress} class="rounded-lg border p-3" />
       </div>
 
       <div bind:this={scrollContainer} class="flex-1 overflow-y-auto px-2 pb-[max(env(safe-area-inset-bottom),1rem)]">

--- a/apps/dashboard/src/lib/features/course/pages/lesson.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/lesson.svelte
@@ -95,7 +95,6 @@
       (item) => item.type === ContentType.Lesson && item.id === lessonId
     )
   );
-  const isLessonComplete = $derived(currentLessonContentItem?.isComplete ?? lessonApi.lesson?.isComplete ?? false);
   const lessonTitle = $derived(currentLessonContentItem?.title || lessonApi.lesson?.title || 'Lesson');
   const contentLockReason = $derived(getStudentContentLockReason(courseApi.course, lessonId, ContentType.Lesson));
   const isStudentLessonStateReady = $derived.by(() => {
@@ -421,7 +420,6 @@
     <LessonPageEditHeader
       {mode}
       title={lessonTitle}
-      isComplete={mode === MODES.view && isLessonComplete}
       isUnlocked={lessonApi.lesson?.isUnlocked ?? false}
       {isDeletingLesson}
       onTitleChange={handleLessonTitleChange}

--- a/apps/dashboard/src/lib/features/course/pages/lesson.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/lesson.svelte
@@ -95,6 +95,7 @@
       (item) => item.type === ContentType.Lesson && item.id === lessonId
     )
   );
+  const isLessonComplete = $derived(currentLessonContentItem?.isComplete ?? lessonApi.lesson?.isComplete ?? false);
   const lessonTitle = $derived(currentLessonContentItem?.title || lessonApi.lesson?.title || 'Lesson');
   const contentLockReason = $derived(getStudentContentLockReason(courseApi.course, lessonId, ContentType.Lesson));
   const isStudentLessonStateReady = $derived.by(() => {
@@ -420,6 +421,7 @@
     <LessonPageEditHeader
       {mode}
       title={lessonTitle}
+      isComplete={mode === MODES.view && isLessonComplete}
       isUnlocked={lessonApi.lesson?.isUnlocked ?? false}
       {isDeletingLesson}
       onTitleChange={handleLessonTitleChange}

--- a/apps/dashboard/src/lib/features/course/pages/lesson.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/lesson.svelte
@@ -433,8 +433,8 @@
   </Page.HeaderContent>
   <Page.Action>
     <div class="flex items-center gap-2">
-      {#if mode === MODES.view && $isCourseLearnerView && !showMobileBottomNav}
-        <ContentNavigationActions {lessonId} {courseId} />
+      {#if mode === MODES.view && $isCourseLearnerView}
+        <ContentNavigationActions {lessonId} {courseId} showPrevNext={!showMobileBottomNav} />
       {/if}
 
       <RoleBasedSecurity allowedRoles={[1, 2]}>

--- a/packages/storybook/src/molecules/public-course/public-course.stories.svelte
+++ b/packages/storybook/src/molecules/public-course/public-course.stories.svelte
@@ -124,6 +124,25 @@
   {/snippet}
 </Story>
 
+<Story name="Bottom nav · completed lesson">
+  {#snippet template()}
+    <div class="ui:relative ui:min-h-[200px] ui:bg-background">
+      <PublicCourse.PublicCourseBottomNav
+        positionLabel="2 / 6"
+        sublineLabel="Delving into Data Analysis with Pandas"
+        sublineComplete
+        hasPrev
+        hasNext
+        centerVariant="ring"
+        progressPercent={33}
+        onPrev={() => console.log('prev')}
+        onNext={() => console.log('next')}
+        onOpenSheet={() => console.log('open sheet')}
+      />
+    </div>
+  {/snippet}
+</Story>
+
 <Story name="Mobile sheet · collapse + long course">
   {#snippet template()}
     {@const activeSlug = 'module-10-lesson-4'}

--- a/packages/ui/src/custom/public-course/bottom-nav.svelte
+++ b/packages/ui/src/custom/public-course/bottom-nav.svelte
@@ -8,6 +8,8 @@
     /** Current position — e.g. "3 of 12" — plus a subline — e.g. "Hallucination & limitations". */
     positionLabel: string;
     sublineLabel?: string;
+    /** When true, a filled check is shown to the right of `sublineLabel`. */
+    sublineComplete?: boolean;
     hasPrev: boolean;
     hasNext: boolean;
     onPrev: () => void;
@@ -27,6 +29,7 @@
   let {
     positionLabel,
     sublineLabel,
+    sublineComplete = false,
     hasPrev,
     hasNext,
     onPrev,
@@ -98,7 +101,21 @@
         {positionLabel}
       </span>
       {#if sublineLabel}
-        <span class="ui:max-w-[55vw] ui:truncate ui:text-sm ui:font-medium ui:text-foreground">{sublineLabel}</span>
+        <span class="ui:flex ui:max-w-[55vw] ui:min-w-0 ui:items-center ui:gap-1">
+          <span class="ui:min-w-0 ui:truncate ui:text-sm ui:font-medium ui:text-foreground">{sublineLabel}</span>
+          {#if sublineComplete}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              class="ui:size-3.5 ui:shrink-0 ui:text-primary"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="10" fill="currentColor"></circle>
+              <path d="m9 12 2 2 4-4" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          {/if}
+        </span>
       {/if}
     </span>
   </button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

#934 was squash-merged with only the `path.split()` crash fix. Follow-up work was pushed onto that branch after merge and never reached `main`. This PR is those fixes on current `main`:

1. **Outline sheet crash** — opening the mobile outline sheet crashed with `Cannot read properties of undefined (reading 'percent')`. The sheet now passes `progress={courseProgress}` and the card treats missing progress as zeros.

2. **No way to mark complete on mobile** — the bottom nav hid the whole lesson action row, including Mark as Complete. Prev/next stay in the bottom bar; Mark as Complete stays in the lesson header.

3. **Check on the mobile bottom-nav title** — after a lesson is marked complete, a filled check appears on the **right of the lesson title in the mobile bottom bar** (not next to the page heading).

## Demo

**Mark as Complete on mobile**

[mobile_mark_as_complete.mp4](https://cursor.com/agents/bc-5b70dc13-3036-488a-abf8-837bd76757fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_mark_as_complete.mp4)

[Mark as Complete under the lesson title on mobile](https://cursor.com/agents/bc-5b70dc13-3036-488a-abf8-837bd76757fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_mark_as_complete_button.webp)
[Your progress at 17 percent after marking complete](https://cursor.com/agents/bc-5b70dc13-3036-488a-abf8-837bd76757fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_progress_after_complete.webp)

**Check on the right of the bottom-nav lesson title**

[Completed lesson: no check on the page heading, filled check to the right of the bottom-bar title](https://cursor.com/agents/bc-5b70dc13-3036-488a-abf8-837bd76757fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_bottom_nav_title_check.webp)
[Close-up of the mobile bottom bar with a filled check to the right of the lesson title](https://cursor.com/agents/bc-5b70dc13-3036-488a-abf8-837bd76757fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_bottom_nav_title_check_closeup.webp)

**Outline sheet (no percent crash)**

[mobile_student_course_nav_full_flow.mp4](https://cursor.com/agents/bc-5b70dc13-3036-488a-abf8-837bd76757fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_student_course_nav_full_flow.mp4)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (small improvements)

## How should this be tested?

- On a phone (viewport under 768px), open the org site (`?org=<siteName>` locally) and log in as a student
- Open a course lesson
- Tap the bottom-bar center — the outline sheet should show **Your progress** without a `percent` error
- **Mark as Complete** should be visible under the lesson title
- After tapping it, a check should appear on the **right of the lesson title in the bottom bar** (the page heading should not get a check)
- Bottom nav prev/next should still work

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Ran `pnpm build` (`pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`)

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b70dc13-3036-488a-abf8-837bd76757fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b70dc13-3036-488a-abf8-837bd76757fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added completion indicators to course bottom navigation.
  - Added optional previous/next lesson navigation controls.
  - Course progress cards now gracefully display when progress data is unavailable.

- **Bug Fixes**
  - Prevented completion actions from appearing for completed lessons.
  - Improved lesson navigation behavior on mobile.
  - Preserved accurate completion status across mobile navigation.

- **Documentation**
  - Added an example showing completed-lesson navigation states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores mobile lesson completion controls and completion feedback while making the mobile outline progress card resilient to absent progress data.
- Keeps the completion action in the lesson header while delegating previous/next navigation to the mobile bottom bar.
- Adds a completed-lesson indicator beside the bottom-navigation lesson title.
- Correctly supplies course progress to the outline sheet and defaults missing progress metrics to zero.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/course/components/course-progress-card.svelte | Makes progress optional and consistently renders zero-valued metrics when it is unavailable. |
| apps/dashboard/src/lib/features/course/components/lesson/content-navigation-actions.svelte | Separates previous/next visibility from lesson completion controls and hides manual completion after completion. |
| apps/dashboard/src/lib/features/course/components/mobile/course-mobile-bottom-nav.svelte | Passes the active content completion state into the shared mobile navigation. |
| apps/dashboard/src/lib/features/course/components/mobile/course-mobile-outline-sheet.svelte | Fixes the progress-card prop binding in the mobile outline sheet. |
| apps/dashboard/src/lib/features/course/pages/lesson.svelte | Keeps lesson completion controls available on mobile while suppressing duplicate navigation chevrons. |
| packages/ui/src/custom/public-course/bottom-nav.svelte | Displays completion state beside the current lesson title. |
| packages/storybook/src/molecules/public-course/public-course.stories.svelte | Adds a story demonstrating the completed-lesson bottom-navigation state. |

<sub>Reviews (3): Last reviewed commit: ["fix(course): show completion check on mo..."](https://github.com/classroomio/classroomio/commit/aee532397d817fd04d10f2f53f0f8d3d7ce60e4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55189735)</sub>

<!-- /greptile_comment -->