### PR TITLE
fix(ci): migrate postgres before jobs docker smoke test so images publish

### DIFF
--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -49,6 +49,15 @@ case "${SERVICE}" in
     ;;
 
   jobs)
+    # Workers query Postgres on boot (analytics rollups, media jobs, etc.).
+    # Apply schema first — this job has its own empty postgres, unlike api which
+    # runs db:setup in its entrypoint.
+    docker run --rm --network host \
+      -e DATABASE_URL="${DB_URL}" -e PRIVATE_DATABASE_URL="${DB_URL}" \
+      --entrypoint pnpm \
+      "${IMAGE}" \
+      --filter @cio/db db:migrate
+
     docker run -d --name "${NAME}" --network host \
       -e NODE_ENV=production -e DATABASE_URL="${DB_URL}" -e REDIS_URL="${REDIS_URL}" \
       "${IMAGE}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

`my.fastlearner.io` is still crashing on `progress.percent` because **#942 never reached the published images**.

Publish Docker Images has failed on every `main` push since the student sidebar (#814), including #934 and #942. The jobs smoke test boots workers against an empty Postgres. Analytics rollups query `analytics_page_event` on startup, the worker never logs `all-workers-running`, and `fail-fast` cancels the dashboard/api smokes. `build-and-push` is skipped, so Render/self-host still serve the 19 Aug bundle (the old `progress.percent` card).

This runs `pnpm --filter @cio/db db:migrate` against that empty DB before starting jobs, the same schema step the API entrypoint already does.

Merging this should publish `classroomio/{dashboard,api,jobs}:latest` with the #942 progress-card fix.

This PR changes `.github/workflows/**` / publish config: it changes `docker/smoke-test.sh`, which the `Publish Docker Images` workflow runs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Merge to `main` and confirm **Publish Docker Images** gets past `Smoke test (jobs)` and runs `build-and-push`
- Confirm Docker Hub `classroomio/dashboard:latest` is newer than 19 Aug
- On `my.fastlearner.io`, hard-refresh a student lesson, open the mobile outline sheet — it must not throw `Cannot read properties of undefined (reading 'percent')`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b70dc13-3036-488a-abf8-837bd76757fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b70dc13-3036-488a-abf8-837bd76757fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved job service startup validation by applying required database migrations before the worker launches.
  - Smoke tests now verify that jobs can start successfully against an up-to-date database.

- **Reliability**
  - Enhanced coverage for database configuration and migration handling during job-related deployment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the fresh Postgres smoke-test database before starting the jobs image, allowing workers that query database tables during startup to become healthy.
- Runs the existing `@cio/db` migration command from the jobs image.
- Supplies both public and private database URLs to the migration container.
- Preserves the existing worker startup and health validation after migration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the jobs image contains the migration tooling and assets, and the smoke-test database is healthy and reachable before migration begins.

The new command uses the jobs image's installed pnpm workspace, database package, Drizzle configuration, and migration files against the same reachable Postgres service used by the existing smoke tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docker/smoke-test.sh | Adds a viable schema-migration step before the jobs container starts; no actionable defect was identified. |

<sub>Reviews (1): Last reviewed commit: ["fix(ci): migrate postgres before jobs do..."](https://github.com/classroomio/classroomio/commit/6f02ffd36b8fb2bc0b283c943654a305b3102415) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55318949)</sub>

<!-- /greptile_comment -->