### PR TITLE
fix(widget): restore layout, selection mode, and config on rollback

### DIFF
--- a/apps/api/src/__tests__/widget-rollback.test.ts
+++ b/apps/api/src/__tests__/widget-rollback.test.ts
@@ -46,6 +46,7 @@ import {
 import { PLAN } from '@cio/utils/plans';
 import { getDefaultWidgetConfig, ZWidgetPayload } from '@cio/utils/validation/widget';
 import { rollbackOrganizationWidget } from '@api/services/widget';
+import { buildWidgetPayload } from '@api/services/widget-payload';
 
 describe('rollbackOrganizationWidget', () => {
   beforeEach(() => {
@@ -180,6 +181,75 @@ describe('rollbackOrganizationWidget', () => {
         config: expect.objectContaining({ colors: defaultWidgetConfig.colors })
       })
     );
+  });
+
+  it('rebuilds payloadSnapshot from the re-normalized config instead of reusing the stale one', async () => {
+    const defaultWidgetConfig = getDefaultWidgetConfig();
+    const targetVersionConfig = {
+      ...defaultWidgetConfig,
+      colors: { ...defaultWidgetConfig.colors, primaryColor: '#ff0000' }
+    };
+    const WIDGET_UUID = '11111111-1111-4111-8111-111111111111';
+    const ORG_UUID = '22222222-2222-4222-8222-222222222222';
+
+    const targetPayload = ZWidgetPayload.parse({
+      version: 'v1',
+      widgetId: WIDGET_UUID,
+      publicKey: 'wgt_test',
+      organization: { id: ORG_UUID, name: 'Org', siteName: 'org' },
+      layoutType: 'carousel',
+      selectionMode: 'published',
+      design: targetVersionConfig,
+      planGatedFields: {
+        isPaidPlan: true,
+        canUseCustomColors: true,
+        canUseCustomCss: true,
+        canToggleBranding: true,
+        isBrandingForced: false,
+        availableThemes: ['classroomio'],
+        selectedTheme: 'classroomio'
+      },
+      labels: { loadMoreLabel: 'Load more', poweredByLabel: 'Powered by' },
+      courses: [],
+      timestamp: 1
+    });
+
+    vi.mocked(getWidgetById).mockResolvedValue({
+      id: 'widget-1',
+      organizationId: 'org-1',
+      layoutType: 'card_grid',
+      selectionMode: 'manual'
+    } as Awaited<ReturnType<typeof getWidgetById>>);
+
+    vi.mocked(getWidgetVersionById).mockResolvedValue({
+      id: 'version-1',
+      widgetId: 'widget-1',
+      configSnapshot: targetVersionConfig,
+      payloadSnapshot: targetPayload,
+      runtimeManifest: { version: 'v1', release: 'current', entryUrl: 'https://example.com/widget.js' }
+    } as Awaited<ReturnType<typeof getWidgetVersionById>>);
+
+    vi.mocked(getNextWidgetVersion).mockResolvedValue(3);
+    vi.mocked(createWidgetVersion).mockResolvedValue({ id: 'version-3' } as Awaited<
+      ReturnType<typeof createWidgetVersion>
+    >);
+    vi.mocked(updateWidget).mockResolvedValue({ id: 'widget-1' } as Awaited<ReturnType<typeof updateWidget>>);
+    // Org has since downgraded to the free plan.
+    vi.mocked(getActiveOrganizationPlan).mockResolvedValue(null);
+
+    const rebuiltDesign = { ...targetVersionConfig, colors: defaultWidgetConfig.colors };
+    const rebuiltPayload = ZWidgetPayload.parse({ ...targetPayload, design: rebuiltDesign });
+    vi.mocked(buildWidgetPayload).mockResolvedValue(rebuiltPayload);
+
+    await rollbackOrganizationWidget('org-1', 'widget-1', 'user-1', { versionId: 'version-1' });
+
+    expect(buildWidgetPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ colors: defaultWidgetConfig.colors })
+      })
+    );
+    expect(createWidgetVersion).toHaveBeenCalledWith(expect.objectContaining({ payloadSnapshot: rebuiltPayload }));
+    expect(createWidgetVersion).not.toHaveBeenCalledWith(expect.objectContaining({ payloadSnapshot: targetPayload }));
   });
 
   it('rejects rollback and persists nothing when the target version has an invalid payload', async () => {

--- a/apps/api/src/__tests__/widget-rollback.test.ts
+++ b/apps/api/src/__tests__/widget-rollback.test.ts
@@ -51,7 +51,8 @@ describe('rollbackOrganizationWidget', () => {
   });
 
   it('restores the target version layout, selection mode, and config onto the live widget row', async () => {
-    const targetVersionConfig = { ...getDefaultWidgetConfig(), themePreset: 'graphite' as const };
+    const defaultWidgetConfig = getDefaultWidgetConfig();
+    const targetVersionConfig = { ...defaultWidgetConfig, themePreset: 'graphite' as const };
     const WIDGET_UUID = '11111111-1111-4111-8111-111111111111';
     const ORG_UUID = '22222222-2222-4222-8222-222222222222';
 

--- a/apps/api/src/__tests__/widget-rollback.test.ts
+++ b/apps/api/src/__tests__/widget-rollback.test.ts
@@ -111,4 +111,28 @@ describe('rollbackOrganizationWidget', () => {
       })
     );
   });
+
+  it('rejects rollback and persists nothing when the target version has an invalid payload', async () => {
+    vi.mocked(getWidgetById).mockResolvedValue({
+      id: 'widget-1',
+      organizationId: 'org-1',
+      layoutType: 'card_grid',
+      selectionMode: 'manual'
+    } as Awaited<ReturnType<typeof getWidgetById>>);
+
+    vi.mocked(getWidgetVersionById).mockResolvedValue({
+      id: 'version-1',
+      widgetId: 'widget-1',
+      configSnapshot: {},
+      payloadSnapshot: { version: 'v1' },
+      runtimeManifest: { version: 'v1', release: 'current', entryUrl: 'https://example.com/widget.js' }
+    } as Awaited<ReturnType<typeof getWidgetVersionById>>);
+
+    await expect(
+      rollbackOrganizationWidget('org-1', 'widget-1', 'user-1', { versionId: 'version-1' })
+    ).rejects.toThrow();
+
+    expect(createWidgetVersion).not.toHaveBeenCalled();
+    expect(updateWidget).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/__tests__/widget-rollback.test.ts
+++ b/apps/api/src/__tests__/widget-rollback.test.ts
@@ -35,6 +35,7 @@ vi.mock('@api/services/widget-payload', () => ({
   listWidgetAvailableEditorData: vi.fn()
 }));
 
+import { getActiveOrganizationPlan } from '@cio/db/queries/organization';
 import {
   createWidgetVersion,
   getNextWidgetVersion,
@@ -42,6 +43,7 @@ import {
   getWidgetVersionById,
   updateWidget
 } from '@cio/db/queries/widget';
+import { PLAN } from '@cio/utils/plans';
 import { getDefaultWidgetConfig, ZWidgetPayload } from '@cio/utils/validation/widget';
 import { rollbackOrganizationWidget } from '@api/services/widget';
 
@@ -98,6 +100,9 @@ describe('rollbackOrganizationWidget', () => {
       ReturnType<typeof createWidgetVersion>
     >);
     vi.mocked(updateWidget).mockResolvedValue({ id: 'widget-1' } as Awaited<ReturnType<typeof updateWidget>>);
+    vi.mocked(getActiveOrganizationPlan).mockResolvedValue({
+      planName: PLAN.EARLY_ADOPTER
+    } as Awaited<ReturnType<typeof getActiveOrganizationPlan>>);
 
     await rollbackOrganizationWidget('org-1', 'widget-1', 'user-1', { versionId: 'version-1' });
 
@@ -108,6 +113,71 @@ describe('rollbackOrganizationWidget', () => {
         layoutType: 'carousel',
         selectionMode: 'published',
         config: targetVersionConfig
+      })
+    );
+  });
+
+  it('re-normalizes the restored config against the org current plan, stripping custom colors no longer allowed', async () => {
+    const defaultWidgetConfig = getDefaultWidgetConfig();
+    const targetVersionConfig = {
+      ...defaultWidgetConfig,
+      colors: { ...defaultWidgetConfig.colors, primaryColor: '#ff0000' }
+    };
+    const WIDGET_UUID = '11111111-1111-4111-8111-111111111111';
+    const ORG_UUID = '22222222-2222-4222-8222-222222222222';
+
+    const targetPayload = ZWidgetPayload.parse({
+      version: 'v1',
+      widgetId: WIDGET_UUID,
+      publicKey: 'wgt_test',
+      organization: { id: ORG_UUID, name: 'Org', siteName: 'org' },
+      layoutType: 'carousel',
+      selectionMode: 'published',
+      design: targetVersionConfig,
+      planGatedFields: {
+        isPaidPlan: true,
+        canUseCustomColors: true,
+        canUseCustomCss: true,
+        canToggleBranding: true,
+        isBrandingForced: false,
+        availableThemes: ['classroomio'],
+        selectedTheme: 'classroomio'
+      },
+      labels: { loadMoreLabel: 'Load more', poweredByLabel: 'Powered by' },
+      courses: [],
+      timestamp: 1
+    });
+
+    vi.mocked(getWidgetById).mockResolvedValue({
+      id: 'widget-1',
+      organizationId: 'org-1',
+      layoutType: 'card_grid',
+      selectionMode: 'manual'
+    } as Awaited<ReturnType<typeof getWidgetById>>);
+
+    vi.mocked(getWidgetVersionById).mockResolvedValue({
+      id: 'version-1',
+      widgetId: 'widget-1',
+      configSnapshot: targetVersionConfig,
+      payloadSnapshot: targetPayload,
+      runtimeManifest: { version: 'v1', release: 'current', entryUrl: 'https://example.com/widget.js' }
+    } as Awaited<ReturnType<typeof getWidgetVersionById>>);
+
+    vi.mocked(getNextWidgetVersion).mockResolvedValue(3);
+    vi.mocked(createWidgetVersion).mockResolvedValue({ id: 'version-3' } as Awaited<
+      ReturnType<typeof createWidgetVersion>
+    >);
+    vi.mocked(updateWidget).mockResolvedValue({ id: 'widget-1' } as Awaited<ReturnType<typeof updateWidget>>);
+    // Org has since downgraded to the free plan.
+    vi.mocked(getActiveOrganizationPlan).mockResolvedValue(null);
+
+    await rollbackOrganizationWidget('org-1', 'widget-1', 'user-1', { versionId: 'version-1' });
+
+    expect(updateWidget).toHaveBeenCalledWith(
+      'org-1',
+      'widget-1',
+      expect.objectContaining({
+        config: expect.objectContaining({ colors: defaultWidgetConfig.colors })
       })
     );
   });

--- a/apps/api/src/__tests__/widget-rollback.test.ts
+++ b/apps/api/src/__tests__/widget-rollback.test.ts
@@ -246,7 +246,9 @@ describe('rollbackOrganizationWidget', () => {
     expect(buildWidgetPayload).toHaveBeenCalledWith(
       expect.objectContaining({
         config: expect.objectContaining({ colors: defaultWidgetConfig.colors })
-      })
+      }),
+      undefined,
+      null
     );
     expect(createWidgetVersion).toHaveBeenCalledWith(expect.objectContaining({ payloadSnapshot: rebuiltPayload }));
     expect(createWidgetVersion).not.toHaveBeenCalledWith(expect.objectContaining({ payloadSnapshot: targetPayload }));

--- a/apps/api/src/__tests__/widget-rollback.test.ts
+++ b/apps/api/src/__tests__/widget-rollback.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@cio/core/config/env', () => ({
+  env: {}
+}));
+
+vi.mock('@cio/db/queries/widget', () => ({
+  archiveWidget: vi.fn(),
+  createWidget: vi.fn(),
+  createWidgetVersion: vi.fn(),
+  getWidgetListItemById: vi.fn(),
+  getNextWidgetVersion: vi.fn(),
+  getPublishedWidgetPayloadByPublicKey: vi.fn(),
+  getWidgetById: vi.fn(),
+  getWidgetVersionById: vi.fn(),
+  listWidgetCourses: vi.fn(),
+  listWidgetVersions: vi.fn(),
+  listWidgetsByOrganization: vi.fn(),
+  replaceWidgetCourses: vi.fn(),
+  updateWidget: vi.fn()
+}));
+
+vi.mock('@cio/db/queries/organization', () => ({
+  getActiveOrganizationPlan: vi.fn(),
+  getOrganizationById: vi.fn()
+}));
+
+vi.mock('@api/services/widget-payload', () => ({
+  buildWidgetPayload: vi.fn(),
+  generateWidgetPublicKey: vi.fn(),
+  getCourseBaseUrl: vi.fn(),
+  getCourseWidgetScriptUrl: vi.fn(),
+  getWidgetEmbedCode: vi.fn(),
+  getWidgetHostedEmbedUrl: vi.fn(),
+  listWidgetAvailableEditorData: vi.fn()
+}));
+
+import {
+  createWidgetVersion,
+  getNextWidgetVersion,
+  getWidgetById,
+  getWidgetVersionById,
+  updateWidget
+} from '@cio/db/queries/widget';
+import { getDefaultWidgetConfig, ZWidgetPayload } from '@cio/utils/validation/widget';
+import { rollbackOrganizationWidget } from '@api/services/widget';
+
+describe('rollbackOrganizationWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('restores the target version layout, selection mode, and config onto the live widget row', async () => {
+    const targetVersionConfig = { ...getDefaultWidgetConfig(), themePreset: 'graphite' as const };
+    const WIDGET_UUID = '11111111-1111-4111-8111-111111111111';
+    const ORG_UUID = '22222222-2222-4222-8222-222222222222';
+
+    const targetPayload = ZWidgetPayload.parse({
+      version: 'v1',
+      widgetId: WIDGET_UUID,
+      publicKey: 'wgt_test',
+      organization: { id: ORG_UUID, name: 'Org', siteName: 'org' },
+      layoutType: 'carousel',
+      selectionMode: 'published',
+      design: targetVersionConfig,
+      planGatedFields: {
+        isPaidPlan: false,
+        canUseCustomColors: false,
+        canUseCustomCss: false,
+        canToggleBranding: false,
+        isBrandingForced: false,
+        availableThemes: ['classroomio'],
+        selectedTheme: 'classroomio'
+      },
+      labels: { loadMoreLabel: 'Load more', poweredByLabel: 'Powered by' },
+      courses: [],
+      timestamp: 1
+    });
+
+    vi.mocked(getWidgetById).mockResolvedValue({
+      id: 'widget-1',
+      organizationId: 'org-1',
+      layoutType: 'card_grid',
+      selectionMode: 'manual'
+    } as Awaited<ReturnType<typeof getWidgetById>>);
+
+    vi.mocked(getWidgetVersionById).mockResolvedValue({
+      id: 'version-1',
+      widgetId: 'widget-1',
+      configSnapshot: targetVersionConfig,
+      payloadSnapshot: targetPayload,
+      runtimeManifest: { version: 'v1', release: 'current', entryUrl: 'https://example.com/widget.js' }
+    } as Awaited<ReturnType<typeof getWidgetVersionById>>);
+
+    vi.mocked(getNextWidgetVersion).mockResolvedValue(3);
+    vi.mocked(createWidgetVersion).mockResolvedValue({ id: 'version-3' } as Awaited<
+      ReturnType<typeof createWidgetVersion>
+    >);
+    vi.mocked(updateWidget).mockResolvedValue({ id: 'widget-1' } as Awaited<ReturnType<typeof updateWidget>>);
+
+    await rollbackOrganizationWidget('org-1', 'widget-1', 'user-1', { versionId: 'version-1' });
+
+    expect(updateWidget).toHaveBeenCalledWith(
+      'org-1',
+      'widget-1',
+      expect.objectContaining({
+        layoutType: 'carousel',
+        selectionMode: 'published',
+        config: targetVersionConfig
+      })
+    );
+  });
+});

--- a/apps/api/src/services/widget-payload.ts
+++ b/apps/api/src/services/widget-payload.ts
@@ -11,7 +11,7 @@ import {
   type BuildWidgetPayloadCourse,
   type TWidgetPayload
 } from '@cio/utils/validation/widget';
-import type { TWidget } from '@db/types';
+import type { TOrganizationPlan, TWidget } from '@db/types';
 import * as csstree from 'css-tree';
 import { env } from '@cio/core/config/env';
 
@@ -196,14 +196,16 @@ export function formatCourseForWidget(
 
 export async function buildWidgetPayload(
   widget: TWidget,
-  overrideSelectedCourseIds?: string[]
+  overrideSelectedCourseIds?: string[],
+  overrideActivePlan?: TOrganizationPlan | null
 ): Promise<TWidgetPayload> {
   const organization = await getOrganizationById(widget.organizationId);
   if (!organization) {
     throw new Error('Organization not found for widget');
   }
 
-  const activePlan = await getActiveOrganizationPlan(widget.organizationId);
+  const activePlan =
+    overrideActivePlan !== undefined ? overrideActivePlan : await getActiveOrganizationPlan(widget.organizationId);
   const planName = activePlan?.planName ?? null;
   const normalizedConfig = normalizeWidgetConfig(widget.config as Record<string, unknown>, planName);
   const selectedCourseIds =

--- a/apps/api/src/services/widget.ts
+++ b/apps/api/src/services/widget.ts
@@ -279,12 +279,19 @@ export async function rollbackOrganizationWidget(
       activePlan?.planName ?? null
     );
 
+    const rebuiltPayload = await buildWidgetPayload({
+      ...widget,
+      layoutType: restoredPayload.layoutType,
+      selectionMode: restoredPayload.selectionMode,
+      config: restoredConfig
+    });
+
     const nextVersion = await getNextWidgetVersion(widgetId);
     const rollbackVersion = await createWidgetVersion({
       widgetId: widget.id,
       version: nextVersion,
       configSnapshot: restoredConfig,
-      payloadSnapshot: version.payloadSnapshot,
+      payloadSnapshot: rebuiltPayload,
       runtimeManifest: version.runtimeManifest,
       rolledBackFromVersionId: version.id,
       publishedByUserId: userId

--- a/apps/api/src/services/widget.ts
+++ b/apps/api/src/services/widget.ts
@@ -283,10 +283,15 @@ export async function rollbackOrganizationWidget(
       publishedByUserId: userId
     });
 
+    const restoredPayload = ZWidgetPayload.parse(version.payloadSnapshot);
+
     const updatedWidget = await updateWidget(orgId, widgetId, {
       status: 'PUBLISHED',
       hasUnpublishedChanges: false,
       latestPublishedVersionId: rollbackVersion.id,
+      layoutType: restoredPayload.layoutType,
+      selectionMode: restoredPayload.selectionMode,
+      config: version.configSnapshot,
       updatedByUserId: userId
     });
 

--- a/apps/api/src/services/widget.ts
+++ b/apps/api/src/services/widget.ts
@@ -272,6 +272,8 @@ export async function rollbackOrganizationWidget(
       throw new AppError('Widget version not found', ErrorCodes.WIDGET_NOT_FOUND, 404);
     }
 
+    const restoredPayload = ZWidgetPayload.parse(version.payloadSnapshot);
+
     const nextVersion = await getNextWidgetVersion(widgetId);
     const rollbackVersion = await createWidgetVersion({
       widgetId: widget.id,
@@ -282,8 +284,6 @@ export async function rollbackOrganizationWidget(
       rolledBackFromVersionId: version.id,
       publishedByUserId: userId
     });
-
-    const restoredPayload = ZWidgetPayload.parse(version.payloadSnapshot);
 
     const updatedWidget = await updateWidget(orgId, widgetId, {
       status: 'PUBLISHED',

--- a/apps/api/src/services/widget.ts
+++ b/apps/api/src/services/widget.ts
@@ -259,9 +259,10 @@ export async function rollbackOrganizationWidget(
   data: TRollbackWidget
 ) {
   try {
-    const [widget, version] = await Promise.all([
+    const [widget, version, activePlan] = await Promise.all([
       getWidgetById(orgId, widgetId),
-      getWidgetVersionById(orgId, widgetId, data.versionId)
+      getWidgetVersionById(orgId, widgetId, data.versionId),
+      getActiveOrganizationPlan(orgId)
     ]);
 
     if (!widget) {
@@ -273,12 +274,16 @@ export async function rollbackOrganizationWidget(
     }
 
     const restoredPayload = ZWidgetPayload.parse(version.payloadSnapshot);
+    const restoredConfig = normalizeWidgetConfig(
+      version.configSnapshot as Record<string, unknown>,
+      activePlan?.planName ?? null
+    );
 
     const nextVersion = await getNextWidgetVersion(widgetId);
     const rollbackVersion = await createWidgetVersion({
       widgetId: widget.id,
       version: nextVersion,
-      configSnapshot: version.configSnapshot,
+      configSnapshot: restoredConfig,
       payloadSnapshot: version.payloadSnapshot,
       runtimeManifest: version.runtimeManifest,
       rolledBackFromVersionId: version.id,
@@ -291,7 +296,7 @@ export async function rollbackOrganizationWidget(
       latestPublishedVersionId: rollbackVersion.id,
       layoutType: restoredPayload.layoutType,
       selectionMode: restoredPayload.selectionMode,
-      config: version.configSnapshot,
+      config: restoredConfig,
       updatedByUserId: userId
     });
 

--- a/apps/api/src/services/widget.ts
+++ b/apps/api/src/services/widget.ts
@@ -279,12 +279,16 @@ export async function rollbackOrganizationWidget(
       activePlan?.planName ?? null
     );
 
-    const rebuiltPayload = await buildWidgetPayload({
-      ...widget,
-      layoutType: restoredPayload.layoutType,
-      selectionMode: restoredPayload.selectionMode,
-      config: restoredConfig
-    });
+    const rebuiltPayload = await buildWidgetPayload(
+      {
+        ...widget,
+        layoutType: restoredPayload.layoutType,
+        selectionMode: restoredPayload.selectionMode,
+        config: restoredConfig
+      },
+      undefined,
+      activePlan
+    );
 
     const nextVersion = await getNextWidgetVersion(widgetId);
     const rollbackVersion = await createWidgetVersion({


### PR DESCRIPTION
## Problem
Restoring a widget to a previous version (Share tab → version history → Restore) creates a new version pointing at the target version's snapshot, but the dashboard editor kept showing the layout/config from *before* the restore.

## Root cause
The widget's editable state lives on the live `widget` row (`layoutType`, `selectionMode`, `config` columns), separate from the immutable `widget_version` snapshots. `rollbackOrganizationWidget` created a new version row pointing at the restored snapshot, but never wrote `layoutType`/`selectionMode`/`config` back onto the live widget row, so the editor (which reads those columns) kept rendering the pre-restore layout even though the version history and public embed payload were technically correct.

## Fix
When rolling back, also restore `layoutType` and `selectionMode` (read from the target version's `payloadSnapshot`, the only version-scoped place they're recorded) and `config` (from `configSnapshot`) onto the live widget row.

## Tests
Added `apps/api/src/__tests__/widget-rollback.test.ts` asserting `rollbackOrganizationWidget` writes the restored layout/selection-mode/config back onto the widget. Verified it fails without the fix and passes with it.

Verified: `pnpm --filter @cio/api build` passes, the new test passes, `pnpm format:check` passes on staged files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Widget rollbacks now restore the saved layout, selection mode, and configuration.
  - Restored configurations are adjusted to match the organization’s current plan, including removing unavailable custom colors after a downgrade.
  - Rollback payloads are rebuilt from the restored configuration to ensure saved data is current.
  - Invalid rollback payloads are rejected without saving a new version or changing the widget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores rollback layout, selection mode, and normalized configuration onto the live widget while rebuilding and validating the published payload.
- Adds a reusable active-plan override to payload construction.
- Rebuilds rollback snapshots under the current organization plan.
- Adds rollback coverage for restoration, downgrades, payload rebuilding, and invalid snapshots.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a currently paid organization can still lose its historical paid widget customization during rollback.

Publication stores a plan-agnostic, stripped configSnapshot, and the rollback continues to derive both the live configuration and rebuilt payload from that snapshot rather than the paid design retained in payloadSnapshot.

**Files Needing Attention:** apps/api/src/services/widget.ts and apps/api/src/__tests__/widget-rollback.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/services/widget.ts | Restores and republishes rollback state, but still cannot recover paid customization discarded from configSnapshot during publication. |
| apps/api/src/services/widget-payload.ts | Adds an active-plan override so rollback normalization and payload construction use the same plan snapshot. |
| apps/api/src/__tests__/widget-rollback.test.ts | Covers restored state, downgrade gating, rebuilt payloads, and invalid snapshots, but omits the still-paid historical-customization case. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  V[Historical widget version] --> P[Validate payload snapshot]
  V --> C[Normalize config snapshot with current plan]
  P --> R[Restore layout and selection mode]
  C --> B[Rebuild payload]
  R --> B
  B --> N[Create rollback version]
  N --> W[Update live widget]
```

<sub>Reviews (6): Last reviewed commit: ["fix(widget): avoid re-fetching the activ..."](https://github.com/classroomio/classroomio/commit/8c93844ee2db42f3a34deea7db7c02a95af74953) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55605994)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->