### PR TITLE
docs: student profile redesign PRD and prototypes

### DIFF
--- a/packages/storybook/src/templates/student-profile/course-student.stories.svelte
+++ b/packages/storybook/src/templates/student-profile/course-student.stories.svelte
@@ -2,7 +2,6 @@
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
   import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
-  import AwardIcon from '@lucide/svelte/icons/award';
   import CircleCheckIcon from '@lucide/svelte/icons/circle-check-big';
   import ClockIcon from '@lucide/svelte/icons/clock';
   import DownloadIcon from '@lucide/svelte/icons/download';
@@ -42,11 +41,27 @@
 
   const PEOPLE_HREF = '#people';
 
-  function gradeVariant(grade: number) {
+  function gradeVariant(grade: number | null) {
+    if (grade === null) return 'outline';
     if (grade >= 70) return 'success';
     if (grade >= 50) return 'warning';
 
     return 'secondary';
+  }
+
+  /** No grade is not a grade of 0 — it renders as an em dash. */
+  function gradeLabel(grade: number | null) {
+    return grade === null ? '—' : `${grade}%`;
+  }
+
+  /**
+   * Percentage for one exercise, or `null` when it cannot have one. An exercise
+   * whose questions sum to zero points would otherwise produce NaN.
+   */
+  function exercisePercent(exercise: { score: number; totalPoints: number }) {
+    if (exercise.totalPoints <= 0) return null;
+
+    return Math.round((exercise.score / exercise.totalPoints) * 100);
   }
 
   function scoreLabel(exercise: { score: number; totalPoints: number; status: number | undefined }) {
@@ -159,7 +174,7 @@
               {@render factRow('Lessons', `${data.lessonsCompleted}/${data.lessonsCount}`)}
               {@render factRow('Exercises', `${completedExercises}/${totalExercises}`)}
               {@render factRow('Assignment completion', `${exerciseCompletion}%`)}
-              {@render factRow('Average grade', `${data.averageGrade}%`)}
+              {@render factRow('Average grade', gradeLabel(data.averageGrade))}
             </Card.Content>
           </Card.Root>
 
@@ -220,10 +235,7 @@
                     <ResourceListRow.End class="ui:gap-6 ui:self-start">
                       <div class="flex w-20 justify-end">
                         {#if isGraded(exercise)}
-                          <Badge
-                            variant={gradeVariant(Math.round((exercise.score / exercise.totalPoints) * 100))}
-                            class="ui:tabular-nums"
-                          >
+                          <Badge variant={gradeVariant(exercisePercent(exercise))} class="ui:tabular-nums">
                             {scoreLabel(exercise)}
                           </Badge>
                         {:else}

--- a/packages/storybook/src/templates/student-profile/course-student.stories.svelte
+++ b/packages/storybook/src/templates/student-profile/course-student.stories.svelte
@@ -1,0 +1,264 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
+  import AwardIcon from '@lucide/svelte/icons/award';
+  import CircleCheckIcon from '@lucide/svelte/icons/circle-check-big';
+  import ClockIcon from '@lucide/svelte/icons/clock';
+  import DownloadIcon from '@lucide/svelte/icons/download';
+  import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
+  import FileTextIcon from '@lucide/svelte/icons/file-text';
+  import ListChecksIcon from '@lucide/svelte/icons/list-checks';
+  import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
+
+  import * as Card from '@cio/ui/base/card';
+  import * as DropdownMenu from '@cio/ui/base/dropdown-menu';
+  import * as Empty from '@cio/ui/base/empty';
+  import * as Page from '@cio/ui/base/page';
+  import * as ResourceListRow from '@cio/ui/custom/resource-list-row';
+  import { Badge } from '@cio/ui/base/badge';
+  import { Button } from '@cio/ui/base/button';
+  import { PercentRingProgress } from '@cio/ui/custom/percent-ring-progress';
+  import { Progress } from '@cio/ui/base/progress';
+  import { Separator } from '@cio/ui/base/separator';
+  import { UserAvatar } from '@cio/ui/custom/user-avatar';
+
+  import {
+    countCompletedExercises,
+    courseStudent,
+    courseStudentNoExercises,
+    courseStudentNotStarted,
+    isGraded,
+    SUBMISSION_STATUS
+  } from './fixtures';
+
+  const { Story } = defineMeta({
+    title: 'Templates/Course Student Detail',
+    parameters: {
+      layout: 'padded'
+    },
+    tags: ['autodocs']
+  });
+
+  const PEOPLE_HREF = '#people';
+
+  function gradeVariant(grade: number) {
+    if (grade >= 70) return 'success';
+    if (grade >= 50) return 'warning';
+
+    return 'secondary';
+  }
+
+  function scoreLabel(exercise: { score: number; totalPoints: number; status: number | undefined }) {
+    // An ungraded submission has no meaningful score yet — showing "0/20" reads
+    // as a zero the student earned, which is a different thing entirely.
+    if (exercise.status !== SUBMISSION_STATUS.GRADED) return `—/${exercise.totalPoints}`;
+
+    return `${exercise.score}/${exercise.totalPoints}`;
+  }
+</script>
+
+<!-- ------------------------------------------------------------------ -->
+<!-- Shared snippets                                                    -->
+<!-- ------------------------------------------------------------------ -->
+
+<!-- Actions collapse into one 3-dot menu. Reset is destructive and course
+     scoped, so it lives here rather than as a standing header button. -->
+{#snippet studentActions()}
+  <DropdownMenu.Root>
+    <DropdownMenu.Trigger>
+      {#snippet child({ props })}
+        <Button {...props} variant="secondary" size="icon" aria-label="Student actions">
+          <EllipsisIcon />
+        </Button>
+      {/snippet}
+    </DropdownMenu.Trigger>
+    <DropdownMenu.Content align="end">
+      <DropdownMenu.Item>
+        <DownloadIcon />
+        Export progress
+      </DropdownMenu.Item>
+      <DropdownMenu.Separator />
+      <DropdownMenu.Item variant="destructive">
+        <RotateCcwIcon />
+        Reset progress
+      </DropdownMenu.Item>
+    </DropdownMenu.Content>
+  </DropdownMenu.Root>
+{/snippet}
+
+{#snippet factRow(label, value)}
+  <div class="flex items-center justify-between gap-3 py-1.5 text-sm">
+    <span class="ui:text-muted-foreground">{label}</span>
+    <span class="ui:tabular-nums font-medium">{value}</span>
+  </div>
+{/snippet}
+
+{#snippet exerciseStatusBadge(exercise)}
+  {#if isGraded(exercise)}
+    <Badge variant="success">
+      <CircleCheckIcon />
+      Graded
+    </Badge>
+  {:else if exercise.isCompleted}
+    <Badge variant="secondary">Awaiting grade</Badge>
+  {:else}
+    <Badge variant="outline">Not submitted</Badge>
+  {/if}
+{/snippet}
+
+<!-- ------------------------------------------------------------------ -->
+<!-- Course student detail — rail + exercise list, no tabs               -->
+<!-- ------------------------------------------------------------------ -->
+
+{#snippet courseStudentDetail(data)}
+  {@const completedExercises = countCompletedExercises(data.userExercisesStats)}
+  {@const totalExercises = data.userExercisesStats.length}
+  {@const exerciseCompletion = totalExercises === 0 ? 0 : Math.round((completedExercises / totalExercises) * 100)}
+  <Page.Root>
+    <Page.Header>
+      <Page.HeaderContent>
+        <Button variant="link" href={PEOPLE_HREF} class="ui:h-fit! ui:justify-start! ui:p-0 mb-1">
+          <ArrowLeftIcon />
+          <span class="text-xs">People</span>
+        </Button>
+      </Page.HeaderContent>
+      <Page.Action>
+        {@render studentActions()}
+      </Page.Action>
+    </Page.Header>
+
+    <Page.Body>
+      {#snippet child()}
+        <div class="grid grid-cols-1 items-start gap-4 lg:grid-cols-[19rem_1fr]">
+          <!-- Identity rail — same construction as the audience student profile,
+               with course-scoped facts instead of cross-course ones. -->
+          <Card.Root class="ui:gap-4 ui:py-4 lg:sticky lg:top-4">
+            <Card.Content class="flex flex-col items-center gap-3 text-center">
+              <UserAvatar src={data.user.avatarUrl} alt={data.user.fullName} class="ui:size-20" />
+              <div class="flex flex-col gap-1">
+                <p class="text-base font-semibold">{data.user.fullName}</p>
+                <p class="ui:text-muted-foreground text-sm break-all">{data.user.email}</p>
+              </div>
+              <Badge variant="secondary">
+                <ClockIcon />
+                Last seen {data.user.lastSeen ?? 'a while ago'}
+              </Badge>
+            </Card.Content>
+
+            <Separator />
+
+            <Card.Content class="flex flex-col items-center gap-1">
+              <PercentRingProgress value={data.progressPercentage} size="default" />
+              <p class="ui:text-muted-foreground text-xs">Course progress</p>
+            </Card.Content>
+
+            <Separator />
+
+            <Card.Content>
+              {@render factRow('Lessons', `${data.lessonsCompleted}/${data.lessonsCount}`)}
+              {@render factRow('Exercises', `${completedExercises}/${totalExercises}`)}
+              {@render factRow('Assignment completion', `${exerciseCompletion}%`)}
+              {@render factRow('Average grade', `${data.averageGrade}%`)}
+            </Card.Content>
+          </Card.Root>
+
+          <!-- Exercises. No tab bar: this is the only dataset the course-scoped
+               page has, so a single-tab tab bar would be chrome for nothing. -->
+          <Card.Root class="ui:gap-0 ui:overflow-hidden ui:py-0">
+            <div class="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+              <div class="flex items-center gap-2">
+                <h2 class="text-sm font-semibold">Exercises</h2>
+                <Badge variant="outline" class="ui:tabular-nums">{totalExercises}</Badge>
+              </div>
+              {#if totalExercises > 0}
+                <div class="flex w-full items-center gap-2 sm:w-48">
+                  <Progress value={exerciseCompletion} class="ui:h-1.5" />
+                  <span class="ui:tabular-nums ui:text-muted-foreground w-12 shrink-0 text-right text-xs">
+                    {completedExercises}/{totalExercises}
+                  </span>
+                </div>
+              {/if}
+            </div>
+            <Separator />
+
+            {#if totalExercises === 0}
+              <Empty.Root class="ui:py-10">
+                <Empty.Header>
+                  <Empty.Media variant="icon">
+                    <ListChecksIcon />
+                  </Empty.Media>
+                  <Empty.Title>No exercises in this course</Empty.Title>
+                  <Empty.Description>
+                    Add an exercise to a lesson and each student's attempts show up here.
+                  </Empty.Description>
+                </Empty.Header>
+              </Empty.Root>
+            {:else}
+              <ResourceListRow.Group class="ui:rounded-none ui:border-0">
+                {#each data.userExercisesStats as exercise (exercise.id)}
+                  <ResourceListRow.Root variant="default" align="start" class="ui:py-3">
+                    <ResourceListRow.Lead class="ui:self-start">
+                      <div
+                        class="ui:bg-muted ui:text-muted-foreground flex size-9 items-center justify-center rounded-sm"
+                      >
+                        <FileTextIcon class="size-4" />
+                      </div>
+                    </ResourceListRow.Lead>
+                    <ResourceListRow.Main class="ui:gap-1">
+                      <a href="#exercise" class="line-clamp-1 text-sm font-semibold hover:underline">
+                        {exercise.title}
+                      </a>
+                      {#if exercise.lessonId}
+                        <a href="#lesson" class="ui:text-muted-foreground line-clamp-1 text-xs hover:underline">
+                          {exercise.lessonTitle}
+                        </a>
+                      {:else}
+                        <span class="ui:text-muted-foreground text-xs">Course-level exercise</span>
+                      {/if}
+                    </ResourceListRow.Main>
+                    <ResourceListRow.End class="ui:gap-6 ui:self-start">
+                      <div class="flex w-20 justify-end">
+                        {#if isGraded(exercise)}
+                          <Badge
+                            variant={gradeVariant(Math.round((exercise.score / exercise.totalPoints) * 100))}
+                            class="ui:tabular-nums"
+                          >
+                            {scoreLabel(exercise)}
+                          </Badge>
+                        {:else}
+                          <span class="ui:tabular-nums ui:text-muted-foreground text-sm">{scoreLabel(exercise)}</span>
+                        {/if}
+                      </div>
+                      <div class="flex w-32 justify-end">
+                        {@render exerciseStatusBadge(exercise)}
+                      </div>
+                    </ResourceListRow.End>
+                  </ResourceListRow.Root>
+                {/each}
+              </ResourceListRow.Group>
+            {/if}
+          </Card.Root>
+        </div>
+      {/snippet}
+    </Page.Body>
+  </Page.Root>
+{/snippet}
+
+<Story name="Course Student Detail">
+  {#snippet template()}
+    {@render courseStudentDetail(courseStudent)}
+  {/snippet}
+</Story>
+
+<Story name="Course Student Detail Not Started">
+  {#snippet template()}
+    {@render courseStudentDetail(courseStudentNotStarted)}
+  {/snippet}
+</Story>
+
+<Story name="Course Student Detail No Exercises">
+  {#snippet template()}
+    {@render courseStudentDetail(courseStudentNoExercises)}
+  {/snippet}
+</Story>

--- a/packages/storybook/src/templates/student-profile/fixtures.ts
+++ b/packages/storybook/src/templates/student-profile/fixtures.ts
@@ -1,0 +1,357 @@
+/**
+ * Mock data for the student-profile redesign prototypes.
+ *
+ * Field names mirror the real payloads so a chosen prototype can be wired up
+ * without reshaping data:
+ *   - `StudentProfileAnalytics` → `GET /organization/audience/:userId/analytics`
+ *   - `CourseStudentAnalytics`  → the `userCourseAnalytics` server load on
+ *                                 `/courses/[id]/people/[personId]`
+ *
+ * Only fields that exist on the real runtime payload are modelled. The one
+ * exception is `StudentProfileCourse.exercises`, which the API fetches per course
+ * today and discards after averaging — see the PRD.
+ */
+
+/* ------------------------------------------------------------------ */
+/* Exercise rows (shared by both surfaces)                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Submission status codes, from
+ * `apps/dashboard/src/lib/features/course/components/exercise/constants.ts`.
+ * `PENDING` has no DB row — "not submitted" arrives as `status: undefined` plus
+ * `isCompleted: false`, never as `0`.
+ */
+export const SUBMISSION_STATUS = { PENDING: 0, SUBMITTED: 1, IN_PROGRESS: 2, GRADED: 3 } as const;
+
+/** Mirrors a `getUserExercisesStats` row exactly. */
+export interface StudentExerciseStat {
+  id: string;
+  lessonId: string | null;
+  lessonTitle: string;
+  title: string;
+  status: number | undefined;
+  score: number;
+  totalPoints: number;
+  isCompleted: boolean;
+}
+
+export const supabaseExercises: StudentExerciseStat[] = [
+  {
+    id: 'e-1',
+    lessonId: 'l-1',
+    lessonTitle: 'Setting up Supabase',
+    title: 'Provision your first project',
+    status: SUBMISSION_STATUS.GRADED,
+    score: 18,
+    totalPoints: 20,
+    isCompleted: true
+  },
+  {
+    id: 'e-2',
+    lessonId: 'l-2',
+    lessonTitle: 'Row Level Security',
+    title: 'Write an RLS policy for the posts table',
+    status: SUBMISSION_STATUS.GRADED,
+    score: 12,
+    totalPoints: 20,
+    isCompleted: true
+  },
+  {
+    id: 'e-3',
+    lessonId: 'l-3',
+    lessonTitle: 'Realtime subscriptions',
+    title: 'Build a live comment feed',
+    status: SUBMISSION_STATUS.SUBMITTED,
+    score: 0,
+    totalPoints: 25,
+    isCompleted: true
+  },
+  {
+    id: 'e-4',
+    lessonId: 'l-4',
+    lessonTitle: 'Edge Functions',
+    title: 'Deploy a webhook handler',
+    status: SUBMISSION_STATUS.IN_PROGRESS,
+    score: 0,
+    totalPoints: 15,
+    isCompleted: true
+  },
+  {
+    id: 'e-5',
+    lessonId: 'l-5',
+    lessonTitle: 'Auth deep dive',
+    title: 'Add magic-link sign in',
+    status: undefined,
+    score: 0,
+    totalPoints: 20,
+    isCompleted: false
+  },
+  {
+    // `exercise.lessonId` is nullable in the schema, so a row must render
+    // without a lesson link.
+    id: 'e-6',
+    lessonId: null,
+    lessonTitle: '',
+    title: 'Final capstone submission',
+    status: undefined,
+    score: 0,
+    totalPoints: 50,
+    isCompleted: false
+  }
+];
+
+const reactExercises: StudentExerciseStat[] = [
+  {
+    id: 'e-r1',
+    lessonId: 'l-r1',
+    lessonTitle: 'Component patterns',
+    title: 'Refactor to compound components',
+    status: SUBMISSION_STATUS.GRADED,
+    score: 19,
+    totalPoints: 20,
+    isCompleted: true
+  },
+  {
+    id: 'e-r2',
+    lessonId: 'l-r2',
+    lessonTitle: 'Data fetching',
+    title: 'Add optimistic updates',
+    status: SUBMISSION_STATUS.GRADED,
+    score: 17,
+    totalPoints: 20,
+    isCompleted: true
+  }
+];
+
+const pythonExercises: StudentExerciseStat[] = [
+  {
+    id: 'e-p1',
+    lessonId: 'l-p1',
+    lessonTitle: 'DataFrames',
+    title: 'Clean the housing dataset',
+    status: SUBMISSION_STATUS.GRADED,
+    score: 9,
+    totalPoints: 20,
+    isCompleted: true
+  },
+  {
+    id: 'e-p2',
+    lessonId: 'l-p2',
+    lessonTitle: 'Joins and aggregation',
+    title: 'Group sales by region',
+    status: undefined,
+    score: 0,
+    totalPoints: 20,
+    isCompleted: false
+  }
+];
+
+export function isGraded(exercise: StudentExerciseStat) {
+  return exercise.status === SUBMISSION_STATUS.GRADED;
+}
+
+export function countCompletedExercises(list: StudentExerciseStat[]) {
+  return list.filter((exercise) => exercise.isCompleted).length;
+}
+
+/* ------------------------------------------------------------------ */
+/* Org-wide student profile (/org/[slug]/audience/[profileId])          */
+/* ------------------------------------------------------------------ */
+
+export interface StudentProfileCourse {
+  id: string;
+  title: string;
+  description: string;
+  logo: string | null;
+  type: 'SELF_PACED' | 'LIVE_CLASS';
+  lessons_count: number;
+  lessons_completed: number;
+  exercises_count: number;
+  exercises_completed: number;
+  progress_percentage: number;
+  average_grade: number;
+  /**
+   * Per-exercise rows for this course. The API already fetches these per course
+   * (`getUserExercisesStats`) and currently discards them after averaging into
+   * `average_grade` — surfacing them is the one API change this redesign needs.
+   */
+  exercises: StudentExerciseStat[];
+}
+
+export interface StudentProfileAnalytics {
+  user: {
+    id: string;
+    fullName: string;
+    email: string;
+    avatarUrl: string | null;
+    lastSeen: string | undefined;
+  };
+  courses: StudentProfileCourse[];
+  overallCourseProgress: number;
+  overallAverageGrade: number;
+}
+
+const SUPABASE_LOGO = 'https://placehold.co/240x160/1e3a8a/ffffff?text=Supabase+%26+Svelte';
+const REACT_LOGO = 'https://placehold.co/240x160/0f172a/38bdf8?text=Modern+React';
+const PYTHON_LOGO = 'https://placehold.co/240x160/134e4a/99f6e4?text=Data+Science';
+const DESIGN_LOGO = 'https://placehold.co/240x160/4c1d95/ede9fe?text=Design+Systems';
+
+export const student: StudentProfileAnalytics['user'] = {
+  id: 'e2f0a1c4-8b1e-4a4b-9f77-6c2d4c0a1b23',
+  fullName: 'Abdul-muizz Hamzat',
+  email: 'abdulmuizzayo6@gmail.com',
+  avatarUrl: 'https://github.com/shadcn.png',
+  lastSeen: '5 days ago'
+};
+
+export const courses: StudentProfileCourse[] = [
+  {
+    id: 'c-1',
+    title: 'Building Fullstack Applications with Supabase & Svelte',
+    description:
+      'Dive into real-time web application development with our Supabase Mastery Bootcamp, tailored for Svelte developers. Hands-on projects, weekly reviews and a capstone.',
+    logo: SUPABASE_LOGO,
+    type: 'SELF_PACED',
+    lessons_count: 24,
+    lessons_completed: 9,
+    exercises_count: 6,
+    exercises_completed: 4,
+    progress_percentage: 38,
+    average_grade: 72,
+    exercises: supabaseExercises
+  },
+  {
+    id: 'c-2',
+    title: 'Modern Web Development with React',
+    description:
+      'Component patterns, data fetching, routing and testing — everything needed to ship a production React application.',
+    logo: REACT_LOGO,
+    type: 'LIVE_CLASS',
+    lessons_count: 18,
+    lessons_completed: 18,
+    exercises_count: 2,
+    exercises_completed: 2,
+    progress_percentage: 100,
+    average_grade: 91,
+    exercises: reactExercises
+  },
+  {
+    id: 'c-3',
+    title: 'Data Science with Python and Pandas',
+    description:
+      'Clean, reshape and visualise real datasets. Covers dataframes, aggregation, joins and a final analysis notebook.',
+    logo: PYTHON_LOGO,
+    type: 'SELF_PACED',
+    lessons_count: 30,
+    lessons_completed: 4,
+    exercises_count: 2,
+    exercises_completed: 1,
+    progress_percentage: 13,
+    average_grade: 45,
+    exercises: pythonExercises
+  },
+  {
+    id: 'c-4',
+    title: 'Design Systems Fundamentals',
+    description:
+      'Tokens, primitives and documentation practices for building a component library a whole team can rely on.',
+    logo: DESIGN_LOGO,
+    type: 'SELF_PACED',
+    lessons_count: 12,
+    lessons_completed: 0,
+    exercises_count: 0,
+    exercises_completed: 0,
+    progress_percentage: 0,
+    average_grade: 0,
+    exercises: []
+  }
+];
+
+export const analytics: StudentProfileAnalytics = {
+  user: student,
+  courses,
+  overallCourseProgress: 41,
+  overallAverageGrade: 68
+};
+
+/** The state this page most often renders in: one course, nothing started. */
+export const justEnrolledAnalytics: StudentProfileAnalytics = {
+  user: student,
+  courses: [
+    {
+      ...courses[0]!,
+      lessons_completed: 0,
+      exercises_completed: 0,
+      progress_percentage: 0,
+      average_grade: 0,
+      exercises: courses[0]!.exercises.map((exercise) => ({
+        ...exercise,
+        status: undefined,
+        score: 0,
+        isCompleted: false
+      }))
+    }
+  ],
+  overallCourseProgress: 0,
+  overallAverageGrade: 0
+};
+
+export const noCoursesAnalytics: StudentProfileAnalytics = {
+  user: student,
+  courses: [],
+  overallCourseProgress: 0,
+  overallAverageGrade: 0
+};
+
+export function isComplete(course: StudentProfileCourse) {
+  return course.lessons_count > 0 && course.lessons_completed === course.lessons_count;
+}
+
+export function countComplete(list: StudentProfileCourse[]) {
+  return list.filter(isComplete).length;
+}
+
+/* ------------------------------------------------------------------ */
+/* Course-scoped student detail (/courses/[id]/people/[personId])       */
+/* ------------------------------------------------------------------ */
+
+export interface CourseStudentAnalytics {
+  user: StudentProfileAnalytics['user'];
+  courseTitle: string;
+  progressPercentage: number;
+  averageGrade: number;
+  lessonsCompleted: number;
+  lessonsCount: number;
+  userExercisesStats: StudentExerciseStat[];
+}
+
+export const courseStudent: CourseStudentAnalytics = {
+  user: student,
+  courseTitle: 'Building Fullstack Applications with Supabase & Svelte',
+  progressPercentage: 38,
+  averageGrade: 72,
+  lessonsCompleted: 9,
+  lessonsCount: 24,
+  userExercisesStats: supabaseExercises
+};
+
+/** Enrolled, nothing attempted. */
+export const courseStudentNotStarted: CourseStudentAnalytics = {
+  ...courseStudent,
+  progressPercentage: 0,
+  averageGrade: 0,
+  lessonsCompleted: 0,
+  userExercisesStats: supabaseExercises.map((exercise) => ({
+    ...exercise,
+    status: undefined,
+    score: 0,
+    isCompleted: false
+  }))
+};
+
+/** A course with no exercises authored yet. */
+export const courseStudentNoExercises: CourseStudentAnalytics = {
+  ...courseStudent,
+  userExercisesStats: []
+};

--- a/packages/storybook/src/templates/student-profile/fixtures.ts
+++ b/packages/storybook/src/templates/student-profile/fixtures.ts
@@ -170,7 +170,12 @@ export interface StudentProfileCourse {
   exercises_count: number;
   exercises_completed: number;
   progress_percentage: number;
-  average_grade: number;
+  /**
+   * `null` means "no grade yet", which is NOT the same as a grade of 0. A course
+   * whose exercises sum to zero total points cannot produce a grade either, so
+   * this is keyed on grade availability rather than on `exercises.length`.
+   */
+  average_grade: number | null;
   /**
    * Per-exercise rows for this course. The API already fetches these per course
    * (`getUserExercisesStats`) and currently discards them after averaging into
@@ -189,7 +194,8 @@ export interface StudentProfileAnalytics {
   };
   courses: StudentProfileCourse[];
   overallCourseProgress: number;
-  overallAverageGrade: number;
+  /** `null` when no enrolled course has a gradeable exercise. */
+  overallAverageGrade: number | null;
 }
 
 const SUPABASE_LOGO = 'https://placehold.co/240x160/1e3a8a/ffffff?text=Supabase+%26+Svelte';
@@ -199,8 +205,8 @@ const DESIGN_LOGO = 'https://placehold.co/240x160/4c1d95/ede9fe?text=Design+Syst
 
 export const student: StudentProfileAnalytics['user'] = {
   id: 'e2f0a1c4-8b1e-4a4b-9f77-6c2d4c0a1b23',
-  fullName: 'Abdul-muizz Hamzat',
-  email: 'abdulmuizzayo6@gmail.com',
+  fullName: 'Ada Okafor',
+  email: 'ada.okafor@example.com',
   avatarUrl: 'https://github.com/shadcn.png',
   lastSeen: '5 days ago'
 };
@@ -263,7 +269,7 @@ export const courses: StudentProfileCourse[] = [
     exercises_count: 0,
     exercises_completed: 0,
     progress_percentage: 0,
-    average_grade: 0,
+    average_grade: null,
     exercises: []
   }
 ];
@@ -272,7 +278,9 @@ export const analytics: StudentProfileAnalytics = {
   user: student,
   courses,
   overallCourseProgress: 41,
-  overallAverageGrade: 68
+  // mean(72, 91, 45) rounded. The exercise-free course contributes no grade
+  // rather than a 0 — see the PRD's Decision 8.
+  overallAverageGrade: 69
 };
 
 /** The state this page most often renders in: one course, nothing started. */
@@ -284,7 +292,7 @@ export const justEnrolledAnalytics: StudentProfileAnalytics = {
       lessons_completed: 0,
       exercises_completed: 0,
       progress_percentage: 0,
-      average_grade: 0,
+      average_grade: null,
       exercises: courses[0]!.exercises.map((exercise) => ({
         ...exercise,
         status: undefined,
@@ -294,14 +302,14 @@ export const justEnrolledAnalytics: StudentProfileAnalytics = {
     }
   ],
   overallCourseProgress: 0,
-  overallAverageGrade: 0
+  overallAverageGrade: null
 };
 
 export const noCoursesAnalytics: StudentProfileAnalytics = {
   user: student,
   courses: [],
   overallCourseProgress: 0,
-  overallAverageGrade: 0
+  overallAverageGrade: null
 };
 
 export function isComplete(course: StudentProfileCourse) {
@@ -320,7 +328,8 @@ export interface CourseStudentAnalytics {
   user: StudentProfileAnalytics['user'];
   courseTitle: string;
   progressPercentage: number;
-  averageGrade: number;
+  /** `null` when nothing gradeable has been submitted. */
+  averageGrade: number | null;
   lessonsCompleted: number;
   lessonsCount: number;
   userExercisesStats: StudentExerciseStat[];
@@ -340,7 +349,7 @@ export const courseStudent: CourseStudentAnalytics = {
 export const courseStudentNotStarted: CourseStudentAnalytics = {
   ...courseStudent,
   progressPercentage: 0,
-  averageGrade: 0,
+  averageGrade: null,
   lessonsCompleted: 0,
   userExercisesStats: supabaseExercises.map((exercise) => ({
     ...exercise,
@@ -353,5 +362,8 @@ export const courseStudentNotStarted: CourseStudentAnalytics = {
 /** A course with no exercises authored yet. */
 export const courseStudentNoExercises: CourseStudentAnalytics = {
   ...courseStudent,
+  // No exercises means no grade. Lesson progress is independent of exercises, so
+  // progressPercentage and lessonsCompleted deliberately stay as they are.
+  averageGrade: null,
   userExercisesStats: []
 };

--- a/packages/storybook/src/templates/student-profile/student-profile.stories.svelte
+++ b/packages/storybook/src/templates/student-profile/student-profile.stories.svelte
@@ -33,11 +33,17 @@
 
   const AUDIENCE_HREF = '#audience';
 
-  function gradeVariant(grade: number) {
+  function gradeVariant(grade: number | null) {
+    if (grade === null) return 'outline';
     if (grade >= 70) return 'success';
     if (grade >= 50) return 'warning';
 
     return 'secondary';
+  }
+
+  /** No grade is not a grade of 0 — it renders as an em dash. */
+  function gradeLabel(grade: number | null, suffix = '%') {
+    return grade === null ? '—' : `${grade}${suffix}`;
   }
 </script>
 
@@ -136,7 +142,7 @@
               {@render factRow('Enrolled courses', data.courses.length)}
               {@render factRow('Completed', completed)}
               {@render factRow('In progress', inProgress)}
-              {@render factRow('Average grade', `${data.overallAverageGrade}%`)}
+              {@render factRow('Average grade', gradeLabel(data.overallAverageGrade))}
             </Card.Content>
           </Card.Root>
 
@@ -205,7 +211,7 @@
                           </div>
                           <div class="flex flex-col">
                             <span class="ui:text-muted-foreground">Grade</span>
-                            <span class="ui:tabular-nums font-medium">{course.average_grade}%</span>
+                            <span class="ui:tabular-nums font-medium">{gradeLabel(course.average_grade)}</span>
                           </div>
                         </div>
                       </div>
@@ -249,7 +255,7 @@
                           </Table.Cell>
                           <Table.Cell>
                             <Badge variant={gradeVariant(course.average_grade)} class="ui:tabular-nums">
-                              {course.average_grade}% avg
+                              {gradeLabel(course.average_grade, '% avg')}
                             </Badge>
                           </Table.Cell>
                         </Table.Row>

--- a/packages/storybook/src/templates/student-profile/student-profile.stories.svelte
+++ b/packages/storybook/src/templates/student-profile/student-profile.stories.svelte
@@ -1,0 +1,334 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
+  import AwardIcon from '@lucide/svelte/icons/award';
+  import BookOpenIcon from '@lucide/svelte/icons/book-open';
+  import CircleCheckIcon from '@lucide/svelte/icons/circle-check-big';
+  import ClockIcon from '@lucide/svelte/icons/clock';
+  import DownloadIcon from '@lucide/svelte/icons/download';
+  import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
+
+  import * as Card from '@cio/ui/base/card';
+  import * as DropdownMenu from '@cio/ui/base/dropdown-menu';
+  import * as Empty from '@cio/ui/base/empty';
+  import * as Page from '@cio/ui/base/page';
+  import * as Table from '@cio/ui/base/table';
+  import * as UnderlineTabs from '@cio/ui/custom/underline-tabs';
+  import { Badge } from '@cio/ui/base/badge';
+  import { Button } from '@cio/ui/base/button';
+  import { PercentRingProgress } from '@cio/ui/custom/percent-ring-progress';
+  import { Separator } from '@cio/ui/base/separator';
+  import { UserAvatar } from '@cio/ui/custom/user-avatar';
+
+  import { analytics, countComplete, isComplete, justEnrolledAnalytics, noCoursesAnalytics } from './fixtures';
+
+  const { Story } = defineMeta({
+    title: 'Templates/Student Profile',
+    parameters: {
+      layout: 'padded'
+    },
+    tags: ['autodocs']
+  });
+
+  const AUDIENCE_HREF = '#audience';
+
+  function gradeVariant(grade: number) {
+    if (grade >= 70) return 'success';
+    if (grade >= 50) return 'warning';
+
+    return 'secondary';
+  }
+</script>
+
+<!-- ------------------------------------------------------------------ -->
+<!-- Shared snippets                                                    -->
+<!-- ------------------------------------------------------------------ -->
+
+<!-- One 3-dot menu rather than standing buttons. No "Reset progress" here:
+     reset is course-scoped (POST /course/:courseId/members/:memberId/…), so it
+     belongs on the course-scoped page, not this cross-course one. -->
+{#snippet studentActions()}
+  <DropdownMenu.Root>
+    <DropdownMenu.Trigger>
+      {#snippet child({ props })}
+        <Button {...props} variant="secondary" size="icon" aria-label="Student actions">
+          <EllipsisIcon />
+        </Button>
+      {/snippet}
+    </DropdownMenu.Trigger>
+    <DropdownMenu.Content align="end">
+      <DropdownMenu.Item>
+        <DownloadIcon />
+        Export progress
+      </DropdownMenu.Item>
+    </DropdownMenu.Content>
+  </DropdownMenu.Root>
+{/snippet}
+
+{#snippet factRow(label, value)}
+  <div class="flex items-center justify-between gap-3 py-1.5 text-sm">
+    <span class="ui:text-muted-foreground">{label}</span>
+    <span class="ui:tabular-nums font-medium">{value}</span>
+  </div>
+{/snippet}
+
+{#snippet courseStatusBadge(course)}
+  {#if isComplete(course)}
+    <Badge variant="success">
+      <CircleCheckIcon />
+      Complete
+    </Badge>
+  {:else if course.lessons_completed === 0}
+    <Badge variant="outline">Not started</Badge>
+  {:else}
+    <Badge variant="secondary">In progress</Badge>
+  {/if}
+{/snippet}
+
+<!-- ------------------------------------------------------------------ -->
+<!-- Student profile — identity rail + tabbed detail                     -->
+<!-- ------------------------------------------------------------------ -->
+
+{#snippet studentProfile(data, openTab = 'courses')}
+  {@const completed = countComplete(data.courses)}
+  {@const inProgress = data.courses.filter((course) => !isComplete(course) && course.lessons_completed > 0).length}
+  <Page.Root>
+    <Page.Header>
+      <Page.HeaderContent>
+        <Button variant="link" href={AUDIENCE_HREF} class="ui:h-fit! ui:justify-start! ui:p-0 mb-1">
+          <ArrowLeftIcon />
+          <span class="text-xs">Audience</span>
+        </Button>
+      </Page.HeaderContent>
+      <Page.Action>
+        {@render studentActions()}
+      </Page.Action>
+    </Page.Header>
+
+    <Page.Body>
+      {#snippet child()}
+        <div class="grid grid-cols-1 items-start gap-4 lg:grid-cols-[19rem_1fr]">
+          <!-- Identity rail -->
+          <Card.Root class="ui:gap-4 ui:py-4 lg:sticky lg:top-4">
+            <Card.Content class="flex flex-col items-center gap-3 text-center">
+              <UserAvatar src={data.user.avatarUrl} alt={data.user.fullName} class="ui:size-20" />
+              <div class="flex flex-col gap-1">
+                <p class="text-base font-semibold">{data.user.fullName}</p>
+                <p class="ui:text-muted-foreground text-sm break-all">{data.user.email}</p>
+              </div>
+              <Badge variant="secondary">
+                <ClockIcon />
+                Last seen {data.user.lastSeen ?? 'a while ago'}
+              </Badge>
+            </Card.Content>
+
+            <Separator />
+
+            <Card.Content class="flex flex-col items-center gap-1">
+              <PercentRingProgress value={data.overallCourseProgress} size="default" />
+              <p class="ui:text-muted-foreground text-xs">Overall course progress</p>
+            </Card.Content>
+
+            <Separator />
+
+            <Card.Content>
+              {@render factRow('Enrolled courses', data.courses.length)}
+              {@render factRow('Completed', completed)}
+              {@render factRow('In progress', inProgress)}
+              {@render factRow('Average grade', `${data.overallAverageGrade}%`)}
+            </Card.Content>
+          </Card.Root>
+
+          <!-- Detail column -->
+          <UnderlineTabs.Root value={openTab}>
+            <UnderlineTabs.List>
+              <UnderlineTabs.Trigger value="courses">
+                <BookOpenIcon />
+                Courses
+                <Badge variant="secondary" class="ui:tabular-nums">{data.courses.length}</Badge>
+              </UnderlineTabs.Trigger>
+              <UnderlineTabs.Trigger value="grades">
+                <AwardIcon />
+                Grades
+              </UnderlineTabs.Trigger>
+              <UnderlineTabs.Trigger value="activity">
+                <ClockIcon />
+                Activity
+              </UnderlineTabs.Trigger>
+            </UnderlineTabs.List>
+
+            <UnderlineTabs.Content value="courses" class="pt-3">
+              {#if data.courses.length === 0}
+                <Empty.Root class="ui:py-10">
+                  <Empty.Header>
+                    <Empty.Media variant="icon">
+                      <BookOpenIcon />
+                    </Empty.Media>
+                    <Empty.Title>No courses yet</Empty.Title>
+                    <Empty.Description>Enroll this student to start tracking progress.</Empty.Description>
+                  </Empty.Header>
+                </Empty.Root>
+              {:else}
+                <div class="grid grid-cols-1 gap-3 2xl:grid-cols-2">
+                  {#each data.courses as course (course.id)}
+                    <Card.Root class="ui:gap-0 ui:overflow-hidden ui:py-0">
+                      <div class="flex items-start gap-3 p-4">
+                        <div class="h-12 w-16 shrink-0 overflow-hidden rounded-sm">
+                          <img src={course.logo} alt="" class="h-full w-full object-cover" />
+                        </div>
+                        <div class="flex min-w-0 flex-1 flex-col gap-1">
+                          <div class="flex items-start justify-between gap-2">
+                            <a href="#course" class="line-clamp-1 text-sm font-semibold hover:underline">
+                              {course.title}
+                            </a>
+                            {@render courseStatusBadge(course)}
+                          </div>
+                          <p class="ui:text-muted-foreground line-clamp-2 text-xs">{course.description}</p>
+                        </div>
+                      </div>
+                      <Separator />
+                      <div class="flex items-center gap-4 px-4 py-3">
+                        <PercentRingProgress value={course.progress_percentage} />
+                        <div class="grid flex-1 grid-cols-3 gap-2 text-xs">
+                          <div class="flex flex-col">
+                            <span class="ui:text-muted-foreground">Lessons</span>
+                            <span class="ui:tabular-nums font-medium">
+                              {course.lessons_completed}/{course.lessons_count}
+                            </span>
+                          </div>
+                          <div class="flex flex-col">
+                            <span class="ui:text-muted-foreground">Exercises</span>
+                            <span class="ui:tabular-nums font-medium">
+                              {course.exercises_completed}/{course.exercises_count}
+                            </span>
+                          </div>
+                          <div class="flex flex-col">
+                            <span class="ui:text-muted-foreground">Grade</span>
+                            <span class="ui:tabular-nums font-medium">{course.average_grade}%</span>
+                          </div>
+                        </div>
+                      </div>
+                    </Card.Root>
+                  {/each}
+                </div>
+              {/if}
+            </UnderlineTabs.Content>
+
+            <!-- Grades: per-exercise rows grouped under a course header row. The
+                 rows come from `getUserExercisesStats`, which the service already
+                 fetches per course and currently discards after averaging. -->
+            <UnderlineTabs.Content value="grades" class="pt-3">
+              {#if data.courses.length === 0}
+                <Empty.Root class="ui:py-10">
+                  <Empty.Header>
+                    <Empty.Media variant="icon">
+                      <AwardIcon />
+                    </Empty.Media>
+                    <Empty.Title>Nothing graded yet</Empty.Title>
+                    <Empty.Description>Grades appear once this student submits an exercise.</Empty.Description>
+                  </Empty.Header>
+                </Empty.Root>
+              {:else}
+                <Card.Root class="ui:gap-0 ui:overflow-hidden ui:py-0">
+                  <Table.Root>
+                    <Table.Header>
+                      <Table.Row>
+                        <Table.Head>Exercise</Table.Head>
+                        <Table.Head class="ui:w-28 ui:text-right">Score</Table.Head>
+                        <Table.Head class="ui:w-28">Status</Table.Head>
+                      </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                      {#each data.courses as course (course.id)}
+                        <!-- Group header: the course, then its exercises beneath. -->
+                        <Table.Row class="ui:bg-muted/50">
+                          <Table.Cell class="font-semibold">{course.title}</Table.Cell>
+                          <Table.Cell class="ui:tabular-nums ui:text-right">
+                            {course.exercises_completed}/{course.exercises_count}
+                          </Table.Cell>
+                          <Table.Cell>
+                            <Badge variant={gradeVariant(course.average_grade)} class="ui:tabular-nums">
+                              {course.average_grade}% avg
+                            </Badge>
+                          </Table.Cell>
+                        </Table.Row>
+                        {#each course.exercises ?? [] as exercise (exercise.id)}
+                          <Table.Row>
+                            <Table.Cell class="ui:pl-6">
+                              <a href="#exercise" class="text-sm hover:underline">{exercise.title}</a>
+                              <span class="ui:text-muted-foreground block text-xs">{exercise.lessonTitle}</span>
+                            </Table.Cell>
+                            <Table.Cell class="ui:tabular-nums ui:text-right">
+                              {exercise.status === 3
+                                ? `${exercise.score}/${exercise.totalPoints}`
+                                : `—/${exercise.totalPoints}`}
+                            </Table.Cell>
+                            <Table.Cell>
+                              {#if exercise.status === 3}
+                                <Badge variant="success">Graded</Badge>
+                              {:else if exercise.isCompleted}
+                                <Badge variant="secondary">Awaiting grade</Badge>
+                              {:else}
+                                <Badge variant="outline">Not submitted</Badge>
+                              {/if}
+                            </Table.Cell>
+                          </Table.Row>
+                        {/each}
+                      {/each}
+                    </Table.Body>
+                  </Table.Root>
+                </Card.Root>
+              {/if}
+            </UnderlineTabs.Content>
+
+            <UnderlineTabs.Content value="activity" class="pt-3">
+              <Empty.Root class="ui:py-10">
+                <Empty.Header>
+                  <Empty.Media variant="icon">
+                    <ClockIcon />
+                  </Empty.Media>
+                  <Empty.Title>Activity timeline</Empty.Title>
+                  <Empty.Description>
+                    Lesson completions and submissions over time. Not in this release — timestamps exist
+                    (lesson_completion.created_at, submission.created_at) but no endpoint returns them yet.
+                  </Empty.Description>
+                </Empty.Header>
+              </Empty.Root>
+            </UnderlineTabs.Content>
+          </UnderlineTabs.Root>
+        </div>
+      {/snippet}
+    </Page.Body>
+  </Page.Root>
+{/snippet}
+
+<Story name="Student Profile">
+  {#snippet template()}
+    {@render studentProfile(analytics)}
+  {/snippet}
+</Story>
+
+<Story name="Student Profile Grades Tab">
+  {#snippet template()}
+    {@render studentProfile(analytics, 'grades')}
+  {/snippet}
+</Story>
+
+<Story name="Student Profile Activity Tab">
+  {#snippet template()}
+    {@render studentProfile(analytics, 'activity')}
+  {/snippet}
+</Story>
+
+<Story name="Student Profile Single Course">
+  {#snippet template()}
+    {@render studentProfile(justEnrolledAnalytics)}
+  {/snippet}
+</Story>
+
+<Story name="Student Profile No Courses">
+  {#snippet template()}
+    {@render studentProfile(noCoursesAnalytics)}
+  {/snippet}
+</Story>

--- a/prd/student-profile-redesign/README.md
+++ b/prd/student-profile-redesign/README.md
@@ -1,0 +1,303 @@
+# Student Profile Redesign PRD
+
+## Status
+
+- Draft
+
+## Prototypes — the UX source of truth
+
+UX comes from Storybook, not from this document. Where prose and prototype disagree on a UI detail, **the prototype wins**.
+
+```bash
+pnpm --filter @cio/storybook dev   # http://localhost:6006
+```
+
+Then open **Templates → Student Profile** and **Templates → Course Student Detail**.
+
+| Surface                                     | Story                                        | Files                                                                      |
+| ------------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------- |
+| Org student profile — Courses tab            | `Templates/Student Profile → Student Profile`             | `packages/storybook/src/templates/student-profile/student-profile.stories.svelte` |
+| Org student profile — Grades tab             | `… → Student Profile Grades Tab`             | same                                                                       |
+| Org student profile — Activity tab (empty)   | `… → Student Profile Activity Tab`           | same                                                                       |
+| Org student profile — one course, not started | `… → Student Profile Single Course`          | same                                                                       |
+| Org student profile — no enrollments         | `… → Student Profile No Courses`             | same                                                                       |
+| Course student detail                        | `Templates/Course Student Detail → Course Student Detail` | `packages/storybook/src/templates/student-profile/course-student.stories.svelte` |
+| Course student detail — nothing attempted    | `… → Course Student Detail Not Started`      | same                                                                       |
+| Course student detail — no exercises authored | `… → Course Student Detail No Exercises`     | same                                                                       |
+
+Shared mock data: `packages/storybook/src/templates/student-profile/fixtures.ts`. Field names mirror the real payloads exactly, so a component can be lifted from a story into the app without reshaping data.
+
+> **Deviation from the house process:** these are Storybook stories built from the real `@cio/ui` components, not standalone HTML under `prototypes/`. For a redesign of two existing admin pages that reuse shipped primitives (`UnderlineTabs`, `PercentRingProgress`, `ResourceListRow`, `Table`, `Empty`), Storybook is higher fidelity than a hand-styled HTML mock and cannot drift from the design system. Flagged for veto.
+
+## Purpose
+
+Two dashboard pages answer the same question — "how is this student doing?" — at two scopes: across an org (`/org/[slug]/audience/[profileId]`) and inside one course (`/courses/[id]/people/[personId]`). Both are currently a stack of KPI cards above a colour-coded list. This redesign gives both a persistent identity rail with the metrics that matter, moves the detail into a scannable column, and surfaces per-exercise grades that the API already computes and throws away.
+
+## Problem Statement
+
+- **The page heading says nothing.** Both pages title themselves generically ("Student profile", "People") and bury the person's name in a card below — a heading that costs vertical space on every view while identifying nobody.
+- **Three progress indicators compete** on the org page: an overall bar, a per-course bar, and green/yellow card backgrounds that read as warnings rather than status.
+- **Grades are a single number.** `Total Average Grade` is the only grade signal on the org page, even though the API fetches every exercise's score per course and discards it (`apps/api/src/services/organization.ts:856-861`).
+- **A failed load looks like a loading state.** Both pages end in `{:else} <LoadingPage />`, and their loaders coalesce failures to `null` — so a dead API spins a skeleton forever.
+- **There is nowhere to put activity.** The team wants a lesson/submission timeline; the current single-column layout has no home for it.
+- **A destructive action sits in the header.** `Reset progress` is a standing `variant="destructive"` button on the course people page (`routes/(app)/courses/[id]/people/+layout.svelte:62`).
+- **The org page's overall average grade is numerically broken** — it can render `5200 %`. See Decision 8.
+
+## Confirmed Decisions
+
+1. **Direction: identity rail + tabbed detail** for the org student profile. Chosen from three Storybook prototypes; the other two (single-column "Overview", dense "Compact roster") were deleted.
+2. **v1 scope: page shell + Courses tab + Grades tab.** The Activity tab is visible but renders an empty state explaining it is not in this release.
+3. **Selected tab lives in the URL** as `?tab=courses|grades|activity`, so staff can link a colleague straight to a student's grades.
+4. **The course student detail page gets no tab bar.** It has exactly one dataset (per-exercise attempts); a one-tab tab bar is chrome for nothing. It gets the same rail, with the exercise list beside it.
+5. **No shared rail component.** Each page owns its rail. Accepted trade-off: faster to land page-by-page, at the cost of drift risk (see Risks).
+6. **Header actions collapse into one 3-dot menu.** `Export progress` on both pages; `Reset progress` joins the menu on the course page instead of being a standing destructive button. `Message student` and `Remove from audience` are cut — no backend exists for either.
+7. **Grades show per-exercise rows grouped under a course header row**, matching what the course-scoped page shows for a single course. Requires the API change in Technical Design.
+8. **`overallAverageGrade` is fixed as part of this work.** Two separate defects, both live in `apps/api/src/services/organization.ts:947-948`:
+
+   ```ts
+   const allGrades = sumArrObject(coursesWithStats, 'average_grade'); // a SUM of percentages
+   const overallAverageGrade = calcPercentageWithRounding(allGrades, coursesWithStats.length);
+   // calcPercentageWithRounding(a, b) === Math.round((a / b) * 100)
+   ```
+
+   - **Double-scaling.** The values are already percentages, so multiplying by 100 again is wrong. Course grades of 72/91/45/0 produce `Math.round((208 / 4) * 100)` = **5200**, and the page renders `5200 %`. Nothing clamps it client-side. It reads as `0 %` only when every course grade is 0 — which is exactly the state the current screenshots happen to be in, which is why it has gone unnoticed.
+   - **Dilution.** A course with no exercises has no grade, but contributes a `0` to the mean. Excluding those, the same data averages **69%**, not 52%.
+
+   Both are fixed together; `overallCourseProgress` on the line above is correct (it divides raw lesson counts) and must not be touched.
+
+9. **Neither page renders a `Page.Title` or `Page.Subtitle`.** The header carries only the back link and the 3-dot menu; the rail identifies the student. This removes "Student profile / Progress, grades, and activity across their courses." and "People / _course title_". Two consequences that are easy to get wrong — see Technical Design § Removing the page headings.
+
+## Current-State Audit
+
+| Capability                    | Current state                                                                                      | Notes                                                                             |
+| ----------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Org page identity             | `HeroProfileCard` (`$features/ui/analytics/hero-profile-card.svelte`)                               | Also used by the course page. **Keep the component** — both pages stop using it.  |
+| KPI tiles                     | 3× `ActivityCard`                                                                                   | Used in **5 other places** (lms dashboard, mcp, media, org dash). Do not delete.  |
+| Per-exercise data (org page)  | Fetched per course by `getUserExercisesStats`, then discarded after averaging                        | `apps/api/src/services/organization.ts:850-861`                                   |
+| Per-exercise data (course page) | Already returned as `userCourseAnalytics.userExercisesStats`                                       | Full shape: `id, lessonId, lessonTitle, title, status, score, totalPoints, isCompleted` |
+| Failed server load            | Coalesced to `null` by `safeServerApi`, then rendered as `<LoadingPage />`                           | No error state exists anywhere in the dashboard                                    |
+| Empty state idiom             | `Empty` from `@cio/ui/custom/empty`, `variant="page"`                                               | 40 files use it; the pattern to follow                                            |
+| Tab state in URL              | None on either page                                                                                 | Canonical pattern to copy: `$features/course/pages/exercise.svelte:476-523`        |
+| Reset progress                | Shipped: `POST /course/:courseId/members/:memberId/reset-progress`, `ResetProgressButton` + dialog   | `prd/reset-student-course-progress [DONE]`. Course-scoped only.                    |
+| Export progress               | Does not exist                                                                                      | Reuse the CSV pattern in `$features/course/utils/marks-utils.ts:151` (`Papa.unparse`) |
+| `ScrollToTop`                 | Does not exist in `packages/ui`                                                                     | Specced in `prd/scroll-to-top/README.md`. **Out of scope here** — see Non-Goals.  |
+| Org page container width      | `md:max-w-5xl`                                                                                      | Fits a 19rem rail + detail column                                                 |
+| Course page container width   | `md:max-w-3xl`                                                                                       | Too narrow for a rail; must widen                                                 |
+| Dashboard types               | Hand-written `UserCourseWithStats` (`$lib/utils/types/analytics.ts:70-89`)                            | 7 declared fields do not exist at runtime (`org_id`, `total_lessons`, `total_students`, `member_profile_id`, `banner_image`, `is_published`, `progress_rate`) |
+| `features/audience/`          | No `utils/types.ts`; the route's `+page.server.ts` inlines its inferred types                        | CLAUDE.md wants them in `features/{domain}/utils/types.ts`                         |
+| Translations                  | Most needed keys already exist under `analytics.*`                                                    | `exercises`, `graded`, `not_graded`, `average_grade`, `last_seen`, `a_while_ago`, `lessons_completed` are all present and unused by these pages |
+
+## Product Goals
+
+1. The student being viewed is identifiable at a glance on both pages, at any scroll position.
+2. A teacher can see every exercise a student attempted, its score, and whether it has been graded — without leaving the page.
+3. Both pages tell the truth when data fails to load.
+4. The two pages read as one system.
+5. No regression for the five other consumers of `ActivityCard` or the one other consumer of `HeroProfileCard`.
+
+## Non-Goals (v1)
+
+- **The Activity timeline.** The timestamps exist (`lesson_completion.created_at`, `submission.created_at`), but no query or endpoint returns them. The tab ships as an empty state.
+- **A shared rail component** (Decision 5).
+- **`Message student` and `Remove from audience`** — no endpoints exist.
+- **`ScrollToTop`.** It is unbuilt; building it belongs to `prd/scroll-to-top/README.md`, not here. Note that both redesigned pages qualify for it once it exists.
+- **A per-lesson completion list.** Only counts exist today, not per-lesson rows.
+- **Retiring the hand-written `analytics.ts` types.** The new pages use inferred types; the legacy interfaces stay for their other consumers.
+
+## Functional Requirements
+
+### Org student profile — `/org/[slug]/audience/[profileId]`
+
+Prototype: `Templates/Student Profile`.
+
+**Identity rail** (sticky from `lg` up, 19rem): avatar, full name, email, a `Last seen` badge, a `PercentRingProgress` for overall course progress, then a facts list — Enrolled courses, Completed, In progress, Average grade.
+
+**Tabs** — `Courses` (with a count badge), `Grades`, `Activity`. Selected tab syncs to `?tab=`; an unknown or absent value normalizes to `courses`.
+
+- **Courses tab** — one card per course: logo, title (links to the course), description clamped to two lines, a status badge (`Complete` / `In progress` / `Not started`, derived from `lessons_completed` vs `lessons_count`), then a footer with the progress ring plus Lessons, Exercises and Grade figures. Empty state when the student has no enrollments.
+- **Grades tab** — a single table. Each course contributes a muted group header row (course title, exercises completed/total, average-grade badge) followed by one row per exercise: title (links to the exercise), lesson title beneath, score, and status. **An ungraded submission renders `—/20`, never `0/20`** — a zero the student did not earn is a different claim. Status is `Graded` / `Awaiting grade` / `Not submitted`. A course with no exercises shows its header row only. Empty state when there are no enrollments.
+- **Activity tab** — `Empty` state naming what will land here and why it has not.
+
+**Header** — the back link to Audience on the left, a 3-dot menu containing `Export progress` on the right. No heading or subtitle (Decision 9).
+
+### Course student detail — `/courses/[id]/people/[personId]`
+
+Prototype: `Templates/Course Student Detail`.
+
+**Identity rail** — same construction, course-scoped facts: Lessons, Exercises, Assignment completion, Average grade, and a ring for course progress.
+
+**Header** — the back link to People on the left, the 3-dot menu on the right. No heading or subtitle (Decision 9). Which course this is stays legible from the surrounding course shell and nav, so it is not repeated here.
+
+**Exercise list** — a card with an `Exercises` header (count badge plus a completion bar), then one row per exercise: an icon, the title (links to the exercise), the lesson title beneath (links to the lesson) or `Course-level exercise` when `lessonId` is null, the score, and a status badge. Same `—/N` rule for ungraded work. Empty state when the course has no exercises authored.
+
+**Header** — the 3-dot menu holds `Export progress` and `Reset progress`. Reset keeps its existing confirmation dialog, its `RoleBasedSecurity allowedRoles={[1, 2]}` gate, and its disabled condition (`memberId && progressImpact`); a disabled reset renders as a disabled menu item.
+
+### Both pages
+
+- A failed load renders `Empty variant="page"` with an error icon and a retry action — never `LoadingPage`.
+- All copy comes from translation keys.
+
+## Technical Design
+
+### API — one changed response, no new routes
+
+`getUserAnalytics` already has the rows in hand; it just stops discarding them. There is **no zod response schema, DTO or serializer** on this route, so the new field flows to the dashboard's `InferResponseType` automatically.
+
+```ts
+// apps/api/src/services/organization.ts — inside the per-course map
+const totalEarnedPoints = sumArrObject(userExercisesStats, 'score');
+const totalPoints = sumArrObject(userExercisesStats, 'totalPoints');
+const averageGrade = calcPercentageWithRounding(totalEarnedPoints, totalPoints);
+
+return {
+  ...course,
+  ...courseProgress,
+  progress_percentage: calcPercentageWithRounding(lessonsCompleted, lessonsCount),
+  average_grade: averageGrade,
+  exercises: userExercisesStats // ← was discarded
+};
+```
+
+And Decision 8. Note that `calcPercentageWithRounding` is **not** the right helper here — its `× 100` is what produces `5200 %`. These values are already percentages, so this is a plain mean:
+
+```ts
+// A course with no exercises has no grade, which is not the same as a grade of 0.
+const gradedCourses = coursesWithStats.filter((course) => course.exercises.length > 0);
+const gradeTotal = sumArrObject(gradedCourses, 'average_grade');
+const overallAverageGrade = gradedCourses.length === 0 ? 0 : Math.round(gradeTotal / gradedCourses.length);
+```
+
+Leave `overallCourseProgress` alone — `calcPercentageWithRounding(completedLessons, totalLessons)` is correct because those are raw counts, not percentages.
+
+All 8 `calcPercentageWithRounding` call sites in the repo were audited — line 948 is the only one that passes already-percentage values. The rest divide raw counts and are correct.
+
+### Dashboard types
+
+Add `apps/dashboard/src/lib/features/audience/utils/types.ts`, following `features/tag/utils/types.ts`:
+
+```ts
+import { classroomio, type InferResponseType } from '$lib/utils/services/api';
+
+export type GetAudienceAnalyticsRequest = (typeof classroomio.organization.audience)[':userId']['analytics']['$get'];
+export type GetAudienceAnalyticsSuccess = Extract<InferResponseType<GetAudienceAnalyticsRequest>, { success: true }>;
+export type AudienceAnalytics = GetAudienceAnalyticsSuccess['data'];
+export type AudienceAnalyticsCourse = AudienceAnalytics['courses'][number];
+export type AudienceAnalyticsExercise = AudienceAnalyticsCourse['exercises'][number];
+```
+
+Then move the inlined types out of `+page.server.ts` and **type the page props from `AudienceAnalytics`**. This matters: `user-analytics.svelte` currently does untyped `let { data } = $props()` and annotates with the hand-written `UserAnalytics`, which silently overrides the inferred shape — the reason the phantom fields went unnoticed for so long.
+
+### Submission status
+
+`status` is a raw FK code with no label in the payload. Use the existing constant, never a literal `3`:
+
+```ts
+import { STATUS } from '$features/course/components/exercise/constants';
+// { PENDING: 0, SUBMITTED: 1, IN_PROGRESS: 2, GRADED: 3 }
+```
+
+`status` is `undefined` when there is no submission — "not submitted" is `!isCompleted`, never `status === 0`.
+
+### URL tab state
+
+Copy `$features/course/pages/exercise.svelte:476-523` verbatim in shape: a `normalizeTab()` that falls back to `courses`, an `onMount` hydrate, a URL→state `$effect`, and a state→URL `$effect` guarded with `untrack` so it cannot self-navigate. Navigate with `goto(…, { replaceState: true, keepFocus: true, noScroll: true })`. No `invalidateAll` — the tab does not change what the loader fetches.
+
+### Removing the page headings
+
+Decision 9 is not a two-line deletion. Two traps:
+
+1. **Keep the browser tab title.** `routes/(app)/org/[slug]/audience/[...params]/+page.svelte` uses `audience.user_analytics.title` in two places — a `<svelte:head><title>` and the `Page.Title`. Only the second goes. The translation key stays in use; do not delete it.
+
+2. **The course page's heading belongs to a shared layout.** `routes/(app)/courses/[id]/people/+layout.svelte` wraps both the people **list** and the person **detail** view, and its `Page.Title` currently contains the back button _inside_ the heading:
+
+   ```svelte
+   <Page.Title>
+     {#if data.personId}
+       <RoleBasedSecurity allowedRoles={[1, 2]}>
+         <IconButton onclick={handleBackNavigation}><ArrowLeftIcon size={16} /></IconButton>
+       </RoleBasedSecurity>
+     {/if}
+     {$t('course.navItem.people.title')}
+   </Page.Title>
+   ```
+
+   Deleting it outright would strip the "People" heading off the list page too. Restructure so the back button is a sibling of the heading rather than a child, and render the heading only when `!data.personId`.
+
+### Failed-load state
+
+Have each loader return a discriminant beside the coalesced data, then branch on it:
+
+```ts
+const result = await safeServerApi<GetAudienceAnalyticsSuccess>(() => /* … */);
+return { userId, orgId, analytics: result.ok ? result.body.data : null, loadFailed: !result.ok };
+```
+
+### Frontend file plan
+
+| File                                                                            | Change                                                                    |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `features/audience/utils/types.ts`                                              | New — inferred types above                                                |
+| `features/audience/components/student-profile-rail.svelte`                       | New — identity rail                                                       |
+| `features/audience/components/student-course-card.svelte`                        | New — Courses tab card                                                    |
+| `features/audience/components/student-grades-table.svelte`                       | New — grouped grades table                                                |
+| `features/audience/components/index.ts`                                          | Export the three                                                          |
+| `features/audience/pages/user-analytics.svelte`                                  | Rewrite to rail + tabs; drop `HeroProfileCard`/`ActivityCard`; add error state |
+| `routes/(app)/org/[slug]/audience/[...params]/+page.server.ts`                   | Import types from the feature; add `loadFailed`                           |
+| `routes/(app)/org/[slug]/audience/[...params]/+page.svelte`                      | Drop `Page.Title`/`Page.Subtitle`; **keep** the `<svelte:head><title>`     |
+| `features/course/components/people/student-course-rail.svelte`                   | New — course-scoped rail                                                  |
+| `features/course/components/people/student-exercise-list.svelte`                 | New — exercise list                                                       |
+| `features/course/components/people/student-actions-menu.svelte`                  | New — 3-dot menu wrapping export + `ResetProgressDialog`                  |
+| `routes/(app)/courses/[id]/people/+layout.svelte`                                | Swap the standing reset button for the menu; widen to `md:max-w-5xl`; heading only when `!data.personId`, back button lifted out of `Page.Title` |
+| `routes/(app)/courses/[id]/people/[personId]/+page.svelte`                       | Rewrite to rail + list; **delete the `console.log` `$effect` at lines 73-75**; add error state |
+| `features/course/utils/export-progress.ts`                                       | New — CSV builder modelled on `marks-utils.ts:151`                        |
+| `lib/utils/translations/en.json`                                                 | New keys (below), then `pnpm translate`                                   |
+
+### Translation keys
+
+Reuse the existing `analytics.*` keys wherever they fit (`exercises`, `graded`, `not_graded`, `average_grade`, `last_seen`, `a_while_ago`, `lessons_completed`, `enrolled_courses`, `overall_course_progress`, `completed`, `incomplete`). New keys needed under `audience.user_analytics.*` and `analytics.*`:
+
+`tabs.courses`, `tabs.grades`, `tabs.activity`, `activity_empty_title`, `activity_empty_description`, `in_progress`, `not_started`, `awaiting_grade`, `not_submitted`, `assignment_completion` (exists), `course_level_exercise`, `score`, `status`, `export_progress`, `student_actions`, `no_courses_title`, `no_courses_description`, `no_exercises_title`, `no_exercises_description`, `no_grades_title`, `no_grades_description`, `load_failed_title`, `load_failed_description`, `retry`.
+
+After editing `en.json`: `cd apps/dashboard && pnpm translate`, then verify `{}` placeholders survived translation in all 9 other locales.
+
+## Implementation Order
+
+1. **API** — add `exercises` to each course in `getUserAnalytics`; fix `overallAverageGrade` per Decision 8. Verify: `pnpm --filter @cio/api^... build && pnpm --filter @cio/api build`.
+2. **Types** — add `features/audience/utils/types.ts`; repoint `+page.server.ts`; type the page props from `AudienceAnalytics`. This is the step that proves step 1 reached the dashboard.
+3. **Org page shell** — rail + tabs + URL sync + Courses tab + empty and failed states.
+4. **Grades tab** — grouped table.
+5. **Course page** — widen the container, rail + exercise list, 3-dot menu with export and reset, delete the debug `$effect`.
+6. **Export progress** — CSV on both pages.
+7. **Translations** — `en.json`, then `pnpm translate`, then review placeholders.
+8. **Verify** — `test -f apps/dashboard/.env || cp apps/dashboard/.env.example apps/dashboard/.env`, then `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`, then `pnpm format:check`.
+
+Node 20 throughout: `export PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH"`.
+
+## Acceptance Criteria
+
+1. Both pages show the student's name, email and last-seen at any scroll position on `lg` and above.
+2. `?tab=grades` deep-links to the Grades tab; an unknown value falls back to Courses; switching tabs adds no browser-history entries and does not scroll the page.
+3. The Grades tab lists every exercise the API returns, grouped by course, with the course's average on the group row.
+4. An ungraded submission renders `—/N`. No screen anywhere renders an unearned `0/N`.
+5. `overallAverageGrade` is a true mean in the range 0–100 — a student with course grades 72/91/45 and one exercise-free course reports `69%`, not `5200%` and not `52%`. A student with no graded exercises anywhere reports `0%` without dividing by zero.
+6. Killing the API makes both pages render an error state with a retry — not a skeleton.
+7. `Reset progress` works from the 3-dot menu with its confirmation dialog, role gate and disabled condition intact.
+8. `Export progress` downloads a CSV whose rows match what is on screen.
+9. The course page renders correctly for an exercise with `lessonId: null`.
+10. Neither page renders a heading or subtitle; the browser tab still titles correctly on the audience page, and the people **list** page keeps its "People" heading.
+11. **Zero regression:** the five other `ActivityCard` consumers and the `HeroProfileCard` consumer render unchanged.
+12. All user-facing copy resolves from translation keys; no literal strings in components; the 9 non-English locales keep every `{}` placeholder.
+13. `pnpm --filter @cio/dashboard build`, `pnpm --filter @cio/api build` and `pnpm format:check` all pass.
+
+## Risks and Mitigations
+
+| Risk                                                                                                   | Mitigation                                                                                                                          |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Two rail implementations drift (Decision 5)                                                             | Build the course rail by copying the audience rail in the same PR, so they start identical; note in both files that they are a pair. |
+| Deleting `ActivityCard`/`HeroProfileCard` breaks six other screens                                      | Neither is deleted. Acceptance criterion 11 covers it.                                                                              |
+| `exercises` bloats the audience payload for a student in many courses                                    | Rows are small and already computed. If it becomes a problem, move the Grades tab to its own endpoint — the tab is already lazy UI.  |
+| The `average_grade` fix changes a number people may have screenshotted or reported on                   | Call it out in the changelog as a correction with both formulas stated. The old value was not a plausible-but-different number — it was out of range — so nothing downstream can have been calibrated to it. |
+| The same percentage-of-percentages defect exists elsewhere                                               | Checked: it does not. All 8 `calcPercentageWithRounding` call sites were audited (`apps/api/src/services/organization.ts`, `packages/core/src/services/course/course.ts`) and line 948 is the only one passing already-percentage values; every other divides raw counts. No follow-up needed. |
+| Hand-written `UserAnalytics` keeps masking type errors elsewhere                                         | Step 2 types these two pages from the API. The legacy interfaces are left for other consumers and flagged for a separate cleanup.    |
+| `status === 3` literals spread further                                                                  | Import `STATUS`; grep for bare `=== 3` in the touched files before opening the PR.                                                   |
+| Both pages qualify for `ScrollToTop`, which does not exist                                              | Explicit Non-Goal, tracked in `prd/scroll-to-top/README.md`. Revisit once that component lands.                                      |

--- a/prd/student-profile-redesign/README.md
+++ b/prd/student-profile-redesign/README.md
@@ -61,11 +61,22 @@ Two dashboard pages answer the same question — "how is this student doing?" �
    ```
 
    - **Double-scaling.** The values are already percentages, so multiplying by 100 again is wrong. Course grades of 72/91/45/0 produce `Math.round((208 / 4) * 100)` = **5200**, and the page renders `5200 %`. Nothing clamps it client-side. It reads as `0 %` only when every course grade is 0 — which is exactly the state the current screenshots happen to be in, which is why it has gone unnoticed.
-   - **Dilution.** A course with no exercises has no grade, but contributes a `0` to the mean. Excluding those, the same data averages **69%**, not 52%.
+   - **Dilution.** A course with no grade contributes a `0` to the mean. Excluding those, the same data averages **69%**, not 52%.
 
    Both are fixed together; `overallCourseProgress` on the line above is correct (it divides raw lesson counts) and must not be touched.
 
 9. **Neither page renders a `Page.Title` or `Page.Subtitle`.** The header carries only the back link and the 3-dot menu; the rail identifies the student. This removes "Student profile / Progress, grades, and activity across their courses." and "People / _course title_". Two consequences that are easy to get wrong — see Technical Design § Removing the page headings.
+
+10. **"No grade" is representable, and is not a grade of zero.** `average_grade` and `overallAverageGrade` become `number | null`; `null` renders as an em dash, never `0%`. Two things force this:
+
+    - `calcPercentageWithRounding(0, 0)` returns `0`, so a course with nothing gradeable already reports a real-looking `0%` today.
+    - **Filtering on `exercises.length > 0` is not sufficient.** An authored exercise whose questions sum to zero points also cannot yield a grade. The test is whether the course has any gradeable points at all — `sum(totalPoints) > 0` — not whether exercises exist.
+
+    Same rule as the existing `—/20` treatment for an ungraded submission: absence of a mark is shown as absence, not as zero.
+
+11. **The grade for an exercise is its latest submission.** `getUserExercisesStats` selects submissions with no `ORDER BY` and then calls `submissions.find(...)`, and there is **no unique constraint on `submission(exerciseId, submittedBy)`** — only foreign keys. So a student with two submissions for one exercise currently gets whichever row Postgres happens to return first. The query must order deterministically and the policy must be stated: **most recent submission by `created_at`, tie-broken by `id`**.
+
+12. **A failed exercise query must not look like an empty one.** `getUserExercisesStats` catches every error and returns `[]` (`packages/db/src/queries/analytics/analytics.ts:213-217`). Exposing that as `exercises: []` would render the Grades tab's "nothing graded yet" empty state on a database failure — the exact confusion this PRD sets out to remove elsewhere. The failure has to reach the caller.
 
 ## Current-State Audit
 
@@ -158,18 +169,57 @@ return {
 };
 ```
 
-And Decision 8. Note that `calcPercentageWithRounding` is **not** the right helper here — its `× 100` is what produces `5200 %`. These values are already percentages, so this is a plain mean:
+Decisions 8 and 10 together. Note that `calcPercentageWithRounding` is **not** the right helper for the aggregate — its `× 100` is what produces `5200 %`. These values are already percentages, so this is a plain mean, and a course with no gradeable points is excluded rather than counted as zero:
 
 ```ts
-// A course with no exercises has no grade, which is not the same as a grade of 0.
-const gradedCourses = coursesWithStats.filter((course) => course.exercises.length > 0);
-const gradeTotal = sumArrObject(gradedCourses, 'average_grade');
-const overallAverageGrade = gradedCourses.length === 0 ? 0 : Math.round(gradeTotal / gradedCourses.length);
+// A course is gradeable only if its exercises carry points. Authored exercises
+// worth 0 points cannot produce a grade any more than no exercises can.
+const gradeablePoints = (exercises: StudentExerciseStat[]) =>
+  exercises.reduce((sum, exercise) => sum + exercise.totalPoints, 0);
+
+const averageGrade = gradeablePoints(userExercisesStats) > 0
+  ? calcPercentageWithRounding(totalEarnedPoints, totalPoints)
+  : null; // per-course, replaces the old `average_grade: 0`
+
+// …then, across courses:
+const graded = coursesWithStats.filter((course) => course.average_grade !== null);
+const gradeTotal = graded.reduce((sum, course) => sum + course.average_grade!, 0);
+const overallAverageGrade = graded.length === 0 ? null : Math.round(gradeTotal / graded.length);
 ```
+
+`sumArrObject` is not used here — it coerces `null` to `0` via `|| 0`, which would reintroduce the dilution this fixes.
 
 Leave `overallCourseProgress` alone — `calcPercentageWithRounding(completedLessons, totalLessons)` is correct because those are raw counts, not percentages.
 
 All 8 `calcPercentageWithRounding` call sites in the repo were audited — line 948 is the only one that passes already-percentage values. The rest divide raw counts and are correct.
+
+### Query-layer changes (Decisions 11 and 12)
+
+`getUserExercisesStats` needs two fixes before its rows can be trusted on a page, in `packages/db/src/queries/analytics/analytics.ts`:
+
+```ts
+// Decision 11 — deterministic submission choice. Latest wins.
+const submissions = await db
+  .select({ /* … */ createdAt: schema.submission.createdAt })
+  .from(schema.submission)
+  .where(and(inArray(/* … */), eq(schema.submission.submittedBy, groupMember[0].id)))
+  .orderBy(desc(schema.submission.createdAt), desc(schema.submission.id));
+// `submissions.find(…)` then returns the newest for that exercise, not an arbitrary row.
+```
+
+```ts
+// Decision 12 — stop swallowing failures.
+} catch (error) {
+  console.error('getUserExerciseStats error:', error);
+  throw new Error('Failed to fetch user exercise stats');
+}
+```
+
+The `throw` matches the repo's query-layer convention (CLAUDE.md § Query error logging), but **the blast radius makes it the wrong first move.** There are two other callers: `packages/core/src/services/course/course.ts:666`, and `course.ts:553` — which calls it **once per student inside a course-wide loop**. Converting the catch to a throw there means one unreadable submission row takes down the entire course analytics page, trading a quiet wrong answer for a loud outage.
+
+Preferred approach: leave the `catch` in place and have `getUserAnalytics` distinguish the two cases itself, so only this feature changes behaviour — e.g. return `exercises: StudentExerciseStat[] | null` per course, with `null` meaning "could not load" and `[]` meaning "none authored", and have the Grades tab render an error row for that course. Revisit the throw as its own hardening PR across all three call sites.
+
+The early `return []` paths (no exercises, course missing, user not a group member) are legitimate empties and stay as they are.
 
 ### Dashboard types
 
@@ -279,22 +329,25 @@ Node 20 throughout: `export PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH"`.
 2. `?tab=grades` deep-links to the Grades tab; an unknown value falls back to Courses; switching tabs adds no browser-history entries and does not scroll the page.
 3. The Grades tab lists every exercise the API returns, grouped by course, with the course's average on the group row.
 4. An ungraded submission renders `—/N`. No screen anywhere renders an unearned `0/N`.
-5. `overallAverageGrade` is a true mean in the range 0–100 — a student with course grades 72/91/45 and one exercise-free course reports `69%`, not `5200%` and not `52%`. A student with no graded exercises anywhere reports `0%` without dividing by zero.
-6. Killing the API makes both pages render an error state with a retry — not a skeleton.
-7. `Reset progress` works from the 3-dot menu with its confirmation dialog, role gate and disabled condition intact.
-8. `Export progress` downloads a CSV whose rows match what is on screen.
-9. The course page renders correctly for an exercise with `lessonId: null`.
-10. Neither page renders a heading or subtitle; the browser tab still titles correctly on the audience page, and the people **list** page keeps its "People" heading.
-11. **Zero regression:** the five other `ActivityCard` consumers and the `HeroProfileCard` consumer render unchanged.
-12. All user-facing copy resolves from translation keys; no literal strings in components; the 9 non-English locales keep every `{}` placeholder.
-13. `pnpm --filter @cio/dashboard build`, `pnpm --filter @cio/api build` and `pnpm format:check` all pass.
+5. `overallAverageGrade` is a true mean in the range 0–100 — a student with course grades 72/91/45 and one exercise-free course reports `69%`, not `5200%` and not `52%`.
+6. A course with no gradeable points renders an em dash, not `0%`. This holds both for a course with no exercises and for a course whose exercises sum to zero points. A student with nothing gradeable anywhere shows an em dash for the overall figure, and nothing divides by zero.
+7. An exercise with two submissions shows the most recent one, deterministically, across repeated loads.
+8. A failed exercise query renders an error, not the "nothing graded yet" empty state.
+9. Killing the API makes both pages render an error state with a retry — not a skeleton.
+10. `Reset progress` works from the 3-dot menu with its confirmation dialog, role gate and disabled condition intact.
+11. `Export progress` downloads a CSV whose rows match what is on screen.
+12. The course page renders correctly for an exercise with `lessonId: null`.
+13. Neither page renders a heading or subtitle; the browser tab still titles correctly on the audience page, and the people **list** page keeps its "People" heading.
+14. **Zero regression:** the five other `ActivityCard` consumers and the `HeroProfileCard` consumer render unchanged.
+15. All user-facing copy resolves from translation keys; no literal strings in components; the 9 non-English locales keep every `{}` placeholder.
+16. `pnpm --filter @cio/dashboard build`, `pnpm --filter @cio/api build` and `pnpm format:check` all pass.
 
 ## Risks and Mitigations
 
 | Risk                                                                                                   | Mitigation                                                                                                                          |
 | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
 | Two rail implementations drift (Decision 5)                                                             | Build the course rail by copying the audience rail in the same PR, so they start identical; note in both files that they are a pair. |
-| Deleting `ActivityCard`/`HeroProfileCard` breaks six other screens                                      | Neither is deleted. Acceptance criterion 11 covers it.                                                                              |
+| Deleting `ActivityCard`/`HeroProfileCard` breaks six other screens                                      | Neither is deleted. Acceptance criterion 14 covers it.                                                                              |
 | `exercises` bloats the audience payload for a student in many courses                                    | Rows are small and already computed. If it becomes a problem, move the Grades tab to its own endpoint — the tab is already lazy UI.  |
 | The `average_grade` fix changes a number people may have screenshotted or reported on                   | Call it out in the changelog as a correction with both formulas stated. The old value was not a plausible-but-different number — it was out of range — so nothing downstream can have been calibrated to it. |
 | The same percentage-of-percentages defect exists elsewhere                                               | Checked: it does not. All 8 `calcPercentageWithRounding` call sites were audited (`apps/api/src/services/organization.ts`, `packages/core/src/services/course/course.ts`) and line 948 is the only one passing already-percentage values; every other divides raw counts. No follow-up needed. |


### PR DESCRIPTION
## Summary

PRD for redesigning the two surfaces that answer "how is this student doing?" — the org-wide audience profile (`/org/[slug]/audience/[profileId]`) and the course-scoped people detail (`/courses/[id]/people/[personId]`) — plus the Storybook prototypes the PRD treats as its UX source of truth.

Both pages today are a stack of KPI cards over a colour-coded list. The redesign gives each a persistent identity rail, moves detail into a scannable column, and surfaces per-exercise grades the API already computes and discards.

- `prd/student-profile-redesign/README.md`
- `packages/storybook/src/templates/student-profile/` — 8 stories across the two surfaces, covering empty, not-started and no-exercises states

**No production code changes.** Docs and Storybook only.

## Reviewing the prototypes

```bash
pnpm --filter @cio/storybook dev   # http://localhost:6006
```

Then **Templates → Student Profile** and **Templates → Course Student Detail**.

⚠️ **This will fail on a fresh install** — see Known issue below.

## Two findings worth a look even if the design is rejected

**1. `overallAverageGrade` can render `5200 %`** — live on the audience page today, `apps/api/src/services/organization.ts:947-948`:

```ts
const allGrades = sumArrObject(coursesWithStats, 'average_grade'); // a SUM of percentages
const overallAverageGrade = calcPercentageWithRounding(allGrades, coursesWithStats.length);
// calcPercentageWithRounding(a, b) === Math.round((a / b) * 100)
```

The values are already percentages, so the `× 100` is applied twice. Course grades of 72/91/45/0 give `Math.round((208 / 4) * 100)` = **5200**, rendered unclamped. It reads as `0 %` only when every course grade is zero — which is the state in the screenshots this work started from, which is why it has gone unnoticed. All 8 `calcPercentageWithRounding` call sites were audited; this is the only bad one.

**2. Per-exercise grade data is fetched and thrown away.** `getUserAnalytics` calls `getUserExercisesStats` per course, averages it, and discards the rows (`organization.ts:856-861`). Returning them is a ~2-line change and is what makes the Grades tab possible without a new endpoint.

## Known issue — Storybook will not start on a fresh install

`@lucide/svelte` is imported by **13 story files** but declared by none, so `pnpm install` prunes it and `@cio/storybook` dies on an unresolved import. This is pre-existing (documented in `CLAUDE.md`) and not introduced here.

I fixed it locally, but backing the fix out of this PR: adding the dependency made `pnpm install` re-resolve unrelated entries in `pnpm-lock.yaml`, including downgrading `typescript@6.0.3` → `5.9.3` for the docs app. That churn does not belong in a docs PR. **It wants its own PR** where the lockfile diff can be reviewed on its own merits.

To review the prototypes before then:

```bash
pnpm add -D -w --filter @cio/storybook @lucide/svelte@^0.562.0   # do not commit
```

## Open questions for reviewers

1. **Prototype medium.** These are Storybook stories, not standalone HTML under `prototypes/` as the `write-prd` process specifies. For two admin pages built entirely from shipped `@cio/ui` primitives, Storybook can't drift from the design system. Flagged in the PRD for veto.
2. **Course context.** Decision 9 removes the page heading from both surfaces, which on the course page also removes the only label naming the course. Assumed the surrounding course shell covers it — say so if the detail view is reachable from somewhere that doesn't.
3. **Two rail implementations, not one shared component** (Decision 5) — deliberate, drift risk accepted.

## Test plan

- [x] `pnpm --filter @cio/storybook build` (exit 0)
- [x] `pnpm format:check`
- [x] All 8 stories render with no console errors
- [ ] Design review of both surfaces in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added student profile views for organization and course details.
  * Added identity, progress, course status, exercise grades, completion metrics, and submission indicators.
  * Added tabbed views for grades and activity.
  * Added course-specific exercise lists and states for empty, not-started, no-course, and no-exercise scenarios.
  * Added Storybook examples covering common student profile experiences.
  * Improved grade displays for unavailable and ungradable work.

* **Documentation**
  * Added requirements for export, reset, localization, URL-synchronized tabs, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR documents the planned student-profile redesign and adds Storybook prototypes for the organization-wide and course-scoped views.
- Adds eight stories covering populated, not-started, empty-course, and no-exercise states.
- Introduces realistic fixtures for course, exercise, submission, progress, and grade data.
- Records UX decisions, data-contract requirements, implementation guidance, and acceptance criteria in the PRD.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/storybook/src/templates/student-profile/course-student.stories.svelte | Adds the course-scoped student-detail prototype; the previously reported unused Award icon import has been removed. |
| packages/storybook/src/templates/student-profile/fixtures.ts | Defines typed prototype fixtures and helpers for student, course, exercise, submission, and grade states. |
| packages/storybook/src/templates/student-profile/student-profile.stories.svelte | Adds organization-wide profile stories for courses, grades, activity, single-course, and no-enrollment states. |
| prd/student-profile-redesign/README.md | Documents the redesign decisions, technical requirements, edge cases, rollout plan, and acceptance criteria. |

<sub>Reviews (2): Last reviewed commit: ["docs: address review findings on student..."](https://github.com/classroomio/classroomio/commit/106b25b8610c89a297de7e70531d0d382092d626) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55977446)</sub>

<!-- /greptile_comment -->