### PR TITLE
fix(api): enroll cohort members in their cohort's courses

### DIFF
--- a/apps/api/src/services/organization/audience.ts
+++ b/apps/api/src/services/organization/audience.ts
@@ -8,7 +8,12 @@ import { addGroupMembers, enrollUsersInCourseGroups, getExistingGroupMembers } f
 import { invalidateOrgStats } from '@cio/core/utils/redis/org-stats-cache';
 import { buildEmailFromName, buildEmailBranding } from '@cio/email';
 import { enqueueTransactionalEmail } from '@api/services/jobs';
-import { addCohortMember, getExistingCohortMembers, getCohortsByOrg } from '@cio/db/queries/cohort';
+import {
+  addCohortMember,
+  getCohortsByOrg,
+  getCourseIdsByCohortIds,
+  getExistingCohortMembers
+} from '@cio/db/queries/cohort';
 import {
   createOrganizationInvite,
   createOrganizationInviteAudits,
@@ -290,6 +295,26 @@ async function enrollAudienceStudentProfilesInCohorts(
         })
       )
     );
+  }
+
+  // Enrols every assigned profile, not only new memberships, so re-running repairs
+  // members added before cohort course enrolment existed.
+  const cohortCourseIds = await getCourseIdsByCohortIds(validCohortIds);
+
+  if (cohortCourseIds.length > 0 && validProfiles.length > 0) {
+    const courseGroups = await getCourseGroupIds(cohortCourseIds);
+    const groupIds = courseGroups.map((mapping) => mapping.groupId).filter(Boolean) as string[];
+    const users = validProfiles.map((profileId) => ({
+      profileId,
+      email: profileEmailMap.get(profileId) || undefined
+    }));
+    const enrolledCount = await enrollUsersInCourseGroups(groupIds, users, ROLE.STUDENT);
+
+    if (enrolledCount > 0) {
+      await invalidateOrgStats(orgId);
+    }
+
+    await ensureComplianceEnrollmentRecordsForProfiles(cohortCourseIds, validProfiles);
   }
 
   let emailsSent = 0;

--- a/apps/api/src/services/organization/invite.ts
+++ b/apps/api/src/services/organization/invite.ts
@@ -23,7 +23,7 @@ import {
 import { getCourseGroupIds } from '@cio/db/queries/course';
 import { enrollUsersInCourseGroups } from '@cio/db/queries/group';
 import { invalidateOrgStats } from '@cio/core/utils/redis/org-stats-cache';
-import { addCohortMember, getExistingCohortMembers } from '@cio/db/queries/cohort';
+import { addCohortMember, getCourseIdsByCohortIds, getExistingCohortMembers } from '@cio/db/queries/cohort';
 
 import { ROLE } from '@cio/utils/constants';
 import type { TNewOrganizationInviteAudit } from '@db/types';
@@ -454,6 +454,25 @@ export async function acceptOrganizationInvite(token: string, user: TAuthUser, c
             })
           )
         );
+
+        const cohortCourseIds = await getCourseIdsByCohortIds(cohortIds);
+        const courseIdsToEnroll = cohortCourseIds.filter((courseId) => !courseIds.includes(courseId));
+
+        if (courseIdsToEnroll.length > 0) {
+          const cohortCourseGroups = await getCourseGroupIds(courseIdsToEnroll);
+          const cohortGroupIds = cohortCourseGroups.map((mapping) => mapping.groupId).filter(Boolean) as string[];
+          const cohortEnrolledCount = await enrollUsersInCourseGroups(
+            cohortGroupIds,
+            [{ profileId: user.id, email: normalizedEmail }],
+            invite.invite.roleId
+          );
+
+          if (cohortEnrolledCount > 0 && invite.invite.roleId === ROLE.STUDENT) {
+            await invalidateOrgStats(invite.invite.organizationId);
+          }
+
+          await ensureComplianceEnrollmentRecordsForProfiles(courseIdsToEnroll, [user.id]);
+        }
       } catch (error) {
         console.error('acceptOrganizationInvite cohort enrollment error:', error);
       }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -71,6 +71,7 @@
     "db:sync-orphaned-profiles": "tsx src/scripts/sync-orphaned-profiles.ts",
     "db:backfill-profile-email-verification": "tsx src/scripts/backfill-profile-email-verification.ts",
     "db:backfill-member-email-notifications": "tsx src/scripts/backfill-member-email-notifications-from-profile.ts",
+    "db:backfill-cohort-course-enrollment": "tsx src/scripts/backfill-cohort-course-enrollment.ts",
     "db:update-user-email": "tsx src/scripts/update-user-email.ts",
     "db:ban-user": "tsx src/scripts/ban-user.ts",
     "db:notify-students-over-limit": "tsx src/scripts/notify-students-over-limit.ts",

--- a/packages/db/src/queries/cohort/cohort.ts
+++ b/packages/db/src/queries/cohort/cohort.ts
@@ -513,6 +513,22 @@ export async function getCoursesByCohort(
   }
 }
 
+export async function getCourseIdsByCohortIds(cohortIds: string[]): Promise<string[]> {
+  try {
+    if (cohortIds.length === 0) return [];
+
+    const rows = await db
+      .selectDistinct({ courseId: schema.cohortCourse.courseId })
+      .from(schema.cohortCourse)
+      .where(inArray(schema.cohortCourse.cohortId, cohortIds));
+
+    return rows.map((row) => row.courseId).filter((courseId): courseId is string => !!courseId);
+  } catch (error) {
+    console.error('getCourseIdsByCohortIds error:', error);
+    throw new Error(`Failed to get cohort course IDs: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
 export async function isCohortCourse(cohortId: string, courseId: string): Promise<boolean> {
   try {
     const [row] = await db

--- a/packages/db/src/scripts/backfill-cohort-course-enrollment.ts
+++ b/packages/db/src/scripts/backfill-cohort-course-enrollment.ts
@@ -21,13 +21,12 @@ if (!connectionString) {
   process.exit(1);
 }
 
-const STUDENT_ROLE_ID = 3;
-
 /** Members linked to a profile and missing a groupmember row for an ACTIVE cohort course. */
 function buildAffectedSql(limitToOrg: boolean) {
   return `
     SELECT DISTINCT
       cm.profile_id,
+      cm.role_id,
       cm.email,
       c.group_id,
       c.id AS course_id,
@@ -66,18 +65,25 @@ async function main() {
 
     if (!shouldExecute) {
       console.log('Dry run only. Re-run with --execute to apply.');
+      const staff = affected.filter((row) => Number(row.role_id) !== 3);
+      console.log(`  of which non-student cohort roles: ${staff.length}`);
       console.log('Sample (up to 10):');
       for (const row of affected.slice(0, 10)) {
-        console.log(`  profile=${row.profile_id}  course=${row.course_id}  cohort=${row.cohort_id}`);
+        console.log(
+          `  profile=${row.profile_id}  course=${row.course_id}  cohort=${row.cohort_id}  role=${row.role_id}`
+        );
       }
       return;
     }
 
+    // Carries the cohort role across: a cohort tutor or admin must not become a
+    // student. Where one profile holds several cohort roles for the same course,
+    // ORDER BY takes the most privileged so the result is deterministic.
     const insertSql = `
       INSERT INTO groupmember (group_id, role_id, profile_id, email)
       SELECT DISTINCT ON (c.group_id, cm.profile_id)
         c.group_id,
-        $${orgId ? '2' : '1'}::bigint,
+        cm.role_id,
         cm.profile_id,
         cm.email
       FROM cohort_member cm
@@ -90,13 +96,12 @@ async function main() {
         AND c.status = 'ACTIVE'
         AND gm.id IS NULL
         ${orgId ? 'AND co.organization_id = $1' : ''}
+      ORDER BY c.group_id, cm.profile_id, cm.role_id ASC
       ON CONFLICT DO NOTHING
       RETURNING id
     `;
 
-    const inserted = orgId
-      ? await sql.unsafe(insertSql, [orgId, STUDENT_ROLE_ID])
-      : await sql.unsafe(insertSql, [STUDENT_ROLE_ID]);
+    const inserted = orgId ? await sql.unsafe(insertSql, [orgId]) : await sql.unsafe(insertSql);
 
     const remainingRows = orgId ? await sql.unsafe(affectedSql, [orgId]) : await sql.unsafe(affectedSql);
 

--- a/packages/db/src/scripts/backfill-cohort-course-enrollment.ts
+++ b/packages/db/src/scripts/backfill-cohort-course-enrollment.ts
@@ -21,41 +21,74 @@ if (!connectionString) {
   process.exit(1);
 }
 
-/** Members linked to a profile and missing a groupmember row for an ACTIVE cohort course. */
-function buildAffectedSql(limitToOrg: boolean) {
-  return `
-    SELECT DISTINCT
-      cm.profile_id,
-      cm.role_id,
-      cm.email,
-      c.group_id,
-      c.id AS course_id,
-      co.id AS cohort_id,
-      co.organization_id
-    FROM cohort_member cm
-    INNER JOIN cohort co ON co.id = cm.cohort_id
-    INNER JOIN cohort_course cc ON cc.cohort_id = co.id
-    INNER JOIN course c ON c.id = cc.course_id
-    LEFT JOIN groupmember gm ON gm.group_id = c.group_id AND gm.profile_id = cm.profile_id
-    WHERE cm.profile_id IS NOT NULL
-      AND c.group_id IS NOT NULL
-      AND c.status = 'ACTIVE'
-      AND gm.id IS NULL
-      ${limitToOrg ? 'AND co.organization_id = $1' : ''}
-  `;
+// Without this, `--org=` would silently widen an intended single-org run to every org.
+if (orgArg && !orgId) {
+  console.error('--org was passed with no value. Provide --org=<orgId> or omit it to run for every organization.');
+  process.exit(1);
 }
+
+const ORG_FILTER = orgId ? 'AND co.organization_id = $1' : '';
+
+/** Members linked to a profile and missing a groupmember row for an ACTIVE cohort course. */
+const AFFECTED_SQL = `
+  SELECT DISTINCT
+    cm.profile_id,
+    cm.role_id,
+    cm.email,
+    c.group_id,
+    c.id AS course_id,
+    co.id AS cohort_id,
+    co.organization_id
+  FROM cohort_member cm
+  INNER JOIN cohort co ON co.id = cm.cohort_id
+  INNER JOIN cohort_course cc ON cc.cohort_id = co.id
+  INNER JOIN course c ON c.id = cc.course_id
+  LEFT JOIN groupmember gm ON gm.group_id = c.group_id AND gm.profile_id = cm.profile_id
+  WHERE cm.profile_id IS NOT NULL
+    AND c.group_id IS NOT NULL
+    AND c.status = 'ACTIVE'
+    AND gm.id IS NULL
+    ${ORG_FILTER}
+`;
+
+/**
+ * Carries the cohort role across: a cohort tutor or admin must not become a
+ * student. Where one profile holds several cohort roles for the same course,
+ * ORDER BY takes the most privileged so the result is deterministic.
+ */
+const INSERT_SQL = `
+  INSERT INTO groupmember (group_id, role_id, profile_id, email)
+  SELECT DISTINCT ON (c.group_id, cm.profile_id)
+    c.group_id,
+    cm.role_id,
+    cm.profile_id,
+    cm.email
+  FROM cohort_member cm
+  INNER JOIN cohort co ON co.id = cm.cohort_id
+  INNER JOIN cohort_course cc ON cc.cohort_id = co.id
+  INNER JOIN course c ON c.id = cc.course_id
+  LEFT JOIN groupmember gm ON gm.group_id = c.group_id AND gm.profile_id = cm.profile_id
+  WHERE cm.profile_id IS NOT NULL
+    AND c.group_id IS NOT NULL
+    AND c.status = 'ACTIVE'
+    AND gm.id IS NULL
+    ${ORG_FILTER}
+  ORDER BY c.group_id, cm.profile_id, cm.role_id ASC
+  ON CONFLICT DO NOTHING
+  RETURNING id
+`;
 
 async function main() {
   const sql = postgres(connectionString);
+  const params = orgId ? [orgId] : [];
 
   try {
-    const affectedSql = buildAffectedSql(!!orgId);
-    const affected = orgId ? await sql.unsafe(affectedSql, [orgId]) : await sql.unsafe(affectedSql);
+    const affected = await sql.unsafe(AFFECTED_SQL, params);
 
     const cohorts = new Set(affected.map((row) => row.cohort_id));
-    const students = new Set(affected.map((row) => row.profile_id));
+    const profiles = new Set(affected.map((row) => row.profile_id));
     console.log(
-      `Found ${affected.length} missing enrolment(s) across ${cohorts.size} cohort(s) and ${students.size} student(s).`
+      `Found ${affected.length} missing enrolment(s) across ${cohorts.size} cohort(s) and ${profiles.size} member(s).`
     );
 
     if (affected.length === 0) {
@@ -64,9 +97,9 @@ async function main() {
     }
 
     if (!shouldExecute) {
-      console.log('Dry run only. Re-run with --execute to apply.');
       const staff = affected.filter((row) => Number(row.role_id) !== 3);
       console.log(`  of which non-student cohort roles: ${staff.length}`);
+      console.log('Dry run only. Re-run with --execute to apply.');
       console.log('Sample (up to 10):');
       for (const row of affected.slice(0, 10)) {
         console.log(
@@ -76,38 +109,16 @@ async function main() {
       return;
     }
 
-    // Carries the cohort role across: a cohort tutor or admin must not become a
-    // student. Where one profile holds several cohort roles for the same course,
-    // ORDER BY takes the most privileged so the result is deterministic.
-    const insertSql = `
-      INSERT INTO groupmember (group_id, role_id, profile_id, email)
-      SELECT DISTINCT ON (c.group_id, cm.profile_id)
-        c.group_id,
-        cm.role_id,
-        cm.profile_id,
-        cm.email
-      FROM cohort_member cm
-      INNER JOIN cohort co ON co.id = cm.cohort_id
-      INNER JOIN cohort_course cc ON cc.cohort_id = co.id
-      INNER JOIN course c ON c.id = cc.course_id
-      LEFT JOIN groupmember gm ON gm.group_id = c.group_id AND gm.profile_id = cm.profile_id
-      WHERE cm.profile_id IS NOT NULL
-        AND c.group_id IS NOT NULL
-        AND c.status = 'ACTIVE'
-        AND gm.id IS NULL
-        ${orgId ? 'AND co.organization_id = $1' : ''}
-      ORDER BY c.group_id, cm.profile_id, cm.role_id ASC
-      ON CONFLICT DO NOTHING
-      RETURNING id
-    `;
-
-    const inserted = orgId ? await sql.unsafe(insertSql, [orgId]) : await sql.unsafe(insertSql);
-
-    const remainingRows = orgId ? await sql.unsafe(affectedSql, [orgId]) : await sql.unsafe(affectedSql);
+    const inserted = await sql.unsafe(INSERT_SQL, params);
+    const remaining = await sql.unsafe(AFFECTED_SQL, params);
 
     console.log(`Inserted ${inserted.length} groupmember row(s).`);
-    console.log(`Remaining missing enrolment(s): ${remainingRows.length}`);
-    console.log('Course lists are cached per org; org stats caches refresh on their own TTL.');
+    console.log(`Remaining missing enrolment(s): ${remaining.length}`);
+
+    if (remaining.length > 0) {
+      console.error('Some enrolments could not be created. Investigate before treating this as complete.');
+      process.exitCode = 1;
+    }
   } finally {
     await sql.end({ timeout: 5 });
   }

--- a/packages/db/src/scripts/backfill-cohort-course-enrollment.ts
+++ b/packages/db/src/scripts/backfill-cohort-course-enrollment.ts
@@ -1,0 +1,114 @@
+/**
+ * Enrols existing cohort members into their cohort's courses, for members added
+ * before joining a cohort granted course access. Idempotent.
+ *
+ * Usage:
+ *   pnpm db:backfill-cohort-course-enrollment                      # dry run (default)
+ *   pnpm db:backfill-cohort-course-enrollment -- --execute         # apply
+ *   pnpm db:backfill-cohort-course-enrollment -- --org=<orgId>     # limit to one org
+ */
+import 'dotenv/config';
+
+import postgres from 'postgres';
+
+const connectionString = process.env.DATABASE_URL ?? process.env.PRIVATE_DATABASE_URL ?? '';
+const shouldExecute = process.argv.includes('--execute');
+const orgArg = process.argv.find((arg) => arg.startsWith('--org='));
+const orgId = orgArg ? orgArg.slice('--org='.length).trim() : '';
+
+if (!connectionString) {
+  console.error('DATABASE_URL or PRIVATE_DATABASE_URL environment variable is required');
+  process.exit(1);
+}
+
+const STUDENT_ROLE_ID = 3;
+
+/** Members linked to a profile and missing a groupmember row for an ACTIVE cohort course. */
+function buildAffectedSql(limitToOrg: boolean) {
+  return `
+    SELECT DISTINCT
+      cm.profile_id,
+      cm.email,
+      c.group_id,
+      c.id AS course_id,
+      co.id AS cohort_id,
+      co.organization_id
+    FROM cohort_member cm
+    INNER JOIN cohort co ON co.id = cm.cohort_id
+    INNER JOIN cohort_course cc ON cc.cohort_id = co.id
+    INNER JOIN course c ON c.id = cc.course_id
+    LEFT JOIN groupmember gm ON gm.group_id = c.group_id AND gm.profile_id = cm.profile_id
+    WHERE cm.profile_id IS NOT NULL
+      AND c.group_id IS NOT NULL
+      AND c.status = 'ACTIVE'
+      AND gm.id IS NULL
+      ${limitToOrg ? 'AND co.organization_id = $1' : ''}
+  `;
+}
+
+async function main() {
+  const sql = postgres(connectionString);
+
+  try {
+    const affectedSql = buildAffectedSql(!!orgId);
+    const affected = orgId ? await sql.unsafe(affectedSql, [orgId]) : await sql.unsafe(affectedSql);
+
+    const cohorts = new Set(affected.map((row) => row.cohort_id));
+    const students = new Set(affected.map((row) => row.profile_id));
+    console.log(
+      `Found ${affected.length} missing enrolment(s) across ${cohorts.size} cohort(s) and ${students.size} student(s).`
+    );
+
+    if (affected.length === 0) {
+      console.log('Nothing to do.');
+      return;
+    }
+
+    if (!shouldExecute) {
+      console.log('Dry run only. Re-run with --execute to apply.');
+      console.log('Sample (up to 10):');
+      for (const row of affected.slice(0, 10)) {
+        console.log(`  profile=${row.profile_id}  course=${row.course_id}  cohort=${row.cohort_id}`);
+      }
+      return;
+    }
+
+    const insertSql = `
+      INSERT INTO groupmember (group_id, role_id, profile_id, email)
+      SELECT DISTINCT ON (c.group_id, cm.profile_id)
+        c.group_id,
+        $${orgId ? '2' : '1'}::bigint,
+        cm.profile_id,
+        cm.email
+      FROM cohort_member cm
+      INNER JOIN cohort co ON co.id = cm.cohort_id
+      INNER JOIN cohort_course cc ON cc.cohort_id = co.id
+      INNER JOIN course c ON c.id = cc.course_id
+      LEFT JOIN groupmember gm ON gm.group_id = c.group_id AND gm.profile_id = cm.profile_id
+      WHERE cm.profile_id IS NOT NULL
+        AND c.group_id IS NOT NULL
+        AND c.status = 'ACTIVE'
+        AND gm.id IS NULL
+        ${orgId ? 'AND co.organization_id = $1' : ''}
+      ON CONFLICT DO NOTHING
+      RETURNING id
+    `;
+
+    const inserted = orgId
+      ? await sql.unsafe(insertSql, [orgId, STUDENT_ROLE_ID])
+      : await sql.unsafe(insertSql, [STUDENT_ROLE_ID]);
+
+    const remainingRows = orgId ? await sql.unsafe(affectedSql, [orgId]) : await sql.unsafe(affectedSql);
+
+    console.log(`Inserted ${inserted.length} groupmember row(s).`);
+    console.log(`Remaining missing enrolment(s): ${remainingRows.length}`);
+    console.log('Course lists are cached per org; org stats caches refresh on their own TTL.');
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+main().catch((error) => {
+  console.error('backfill-cohort-course-enrollment failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
Hotfix for a production report: a teacher invited a cohort, then turned off new self-enrollment on the course. The invited students can neither join nor see the course in their LMS.

## Root cause

The toggle is not the cause. It removed the workaround that was hiding a cohort bug.

**Joining a cohort never enrolled you in the cohort's courses.** `cohort_course` exists, but neither path that adds a cohort member read it:

- `acceptOrganizationInvite` (`apps/api/src/services/organization/invite.ts`) — the `cohortIds` branch called `addCohortMember` and stopped. The `courseIds` branch immediately above it resolves groups and calls `enrollUsersInCourseGroups`. The cohort branch had no equivalent.
- `enrollAudienceStudentProfilesInCohorts` (`apps/api/src/services/organization/audience.ts`) — same.

The student LMS lists courses by group or program membership, never by cohort (`packages/db/src/queries/course/course.ts`, which joins `groupmember` then `programCourse → program → programMember`). So a cohort member had zero course access and the course could not appear in their LMS.

Until the toggle was flipped, students recovered by self-enrolling from the course page, which quietly papered over the missing enrollment. Turning it off closed that path, and `getExploreCourses` excludes courses with self-enrollment off, so the course was not even discoverable to try.

## Fix

Both paths now enroll in the cohort's courses via `getCourseIdsByCohortIds` → `getCourseGroupIds` → `enrollUsersInCourseGroups`, plus compliance records and org-stats invalidation, mirroring the `courseIds` branch.

The audience assign path deliberately enrolls **every** assigned profile rather than only newly inserted memberships. Affected students are already cohort members, so scoping to new rows would repair nobody; this way re-running "assign students to cohort" fixes an existing cohort. `enrollUsersInCourseGroups` filters against existing members, so it is idempotent.

## Remediation for existing data

`pnpm db:backfill-cohort-course-enrollment` inserts the missing `groupmember` rows. Dry run by default, `--execute` to apply, optional `--org=<orgId>` to scope it. Idempotent.

Verified against local data: found 29 missing enrollments across 3 cohorts and 27 students, inserted 29, re-ran to 0 remaining. The `--org` path was exercised separately with a synthesized missing row, since its INSERT uses shifted placeholders and the earlier run short-circuited before reaching it.

Only members with a `profile_id` and courses with `status = 'ACTIVE'` are touched. Invited-but-unregistered rows have no profile to enroll and are picked up on acceptance by the code fix.

## Verification

`pnpm --filter @cio/api^... build && pnpm --filter @cio/api build` clean, 79 API tests passing (the 6 file-load failures are the pre-existing subpath issue noted in CLAUDE.md), `pnpm format:check` clean.

Not covered by tests: neither cohort enrollment path had coverage before this change and still does not.

## Suggested rollout

1. Merge and deploy.
2. Run the backfill as a dry run, confirm the counts, then `--execute`.
3. The reporting teacher can leave their self-enrollment toggle off; the affected students get access from the backfill.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Students are automatically enrolled in courses associated with their cohorts when cohorts are assigned.
  - Invited users are enrolled in courses linked to their invited cohorts.
  - Required compliance records are created for applicable course enrollments.
  - Existing enrollments are recognized to prevent duplicates.

- **Bug Fixes**
  - Organization statistics refresh when new course-group memberships are created.

- **Chores**
  - Added a safe, dry-run-capable tool to identify and backfill missing cohort course enrollments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR enrolls cohort assignees and accepted invitees into courses linked to their cohorts, creates associated compliance records, invalidates organization statistics, and adds a dry-run-first remediation backfill.
- Adds a cohort-to-course ID query and uses it in both cohort membership entry paths.
- Adds an operator-invoked script for restoring missing course-group memberships.
- The backfill’s revised role repair can grant cohort staff course-management privileges.

<h3>Confidence Score: 3/5</h3>

The PR is not safe to merge until the backfill stops granting cohort tutors and administrators course-team privileges.

Copying cohort staff roles into groupmember makes those profiles pass course-team authorization, unlike the established cohort enrollment path that enrolls only students.

**Files Needing Attention:** packages/db/src/scripts/backfill-cohort-course-enrollment.ts

<details open><summary><h3>Security Review</h3></summary>

The backfill copies cohort administrator and tutor roles into course-group memberships. Because those roles satisfy course-team authorization, executing the remediation can grant course-management access to staff whose cohort membership should not independently confer it.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/services/organization/audience.ts | Enrolls assigned profiles into course groups linked through their cohorts and creates corresponding side effects. |
| apps/api/src/services/organization/invite.ts | Extends accepted cohort invitations to enroll the invitee in cohort-linked courses. |
| packages/db/src/queries/cohort/cohort.ts | Adds a distinct cohort-to-course ID lookup used by the new service flows. |
| packages/db/src/scripts/backfill-cohort-course-enrollment.ts | Restores missing group memberships but can promote cohort staff into privileged course-team roles. |
| packages/db/package.json | Exposes the remediation script through a package command. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Cohort assignment or invite acceptance] --> B[Resolve cohort courses]
  B --> C[Resolve course groups]
  C --> D[Create group memberships]
  D --> E[Create compliance records]
  D --> F[Invalidate organization statistics]
  G[Backfill existing cohort members] --> H[Insert missing group memberships]
```

<sub>Reviews (3): Last reviewed commit: ["fix(db): reject an empty --org and fail ..."](https://github.com/classroomio/classroomio/commit/36b06da6bfb6d09d5afa295b8347899fde47a2e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56034697)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Data and identity](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/data-and-identity.md)

<!-- /greptile_comment -->