### PR TITLE
feat(ci): scope Railway preview seed by organization

### DIFF
--- a/.github/workflows/railway-preview.yml
+++ b/.github/workflows/railway-preview.yml
@@ -343,6 +343,7 @@ jobs:
         run: pnpm --filter @cio/db^... build
 
       - name: Seed the selected demo organization (optional)
+        id: seed
         if: ${{ inputs.action == 'deploy' && inputs.seed_organization != 'none' }}
         # cio-api only carries the private DATABASE_URL; `railway run` executes on this
         # GitHub runner, so seeding needs Postgres's own DATABASE_PUBLIC_URL instead
@@ -353,9 +354,14 @@ jobs:
           PUBLIC_DB_URL=$(railway variables --service Postgres --kv | grep '^DATABASE_PUBLIC_URL=' | cut -d= -f2-)
           if [ -z "$PUBLIC_DB_URL" ]; then
             echo "::warning::Postgres has no DATABASE_PUBLIC_URL in this environment — skipping $SEED_ORGANIZATION seed; only essential seed ran on api boot."
+            echo "status=skipped" >> "$GITHUB_OUTPUT"
           else
-            railway run --service cio-api -- env DATABASE_URL="$PUBLIC_DB_URL" pnpm --filter @cio/db db:setup:seed -- --organization "$SEED_ORGANIZATION" || \
+            if railway run --service cio-api -- env DATABASE_URL="$PUBLIC_DB_URL" pnpm --filter @cio/db db:setup:seed -- --organization "$SEED_ORGANIZATION"; then
+              echo "status=seeded" >> "$GITHUB_OUTPUT"
+            else
               echo "$SEED_ORGANIZATION seed failed (likely DB not reachable from runner) — migrations + essential seed still ran on api boot."
+              echo "status=failed" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Report the preview URL
@@ -365,6 +371,7 @@ jobs:
           BRANCH: ${{ inputs.branch }}
           ENV_NAME: ${{ steps.env.outputs.name }}
           SEED_ORGANIZATION: ${{ inputs.seed_organization }}
+          SEED_STATUS: ${{ steps.seed.outputs.status || 'not requested' }}
         run: |
           railway domain --service cio-dashboard || true
           URL=$(railway variables --service cio-dashboard --kv | grep '^RAILWAY_PUBLIC_DOMAIN=' | cut -d= -f2-)
@@ -378,7 +385,7 @@ jobs:
             echo ""
             echo "- Environment: \`$ENV_NAME\` (branch \`$BRANCH\`)"
             echo "- Dashboard: https://${URL}"
-            echo "- Demo seed: \`$SEED_ORGANIZATION\`"
+            echo "- Demo seed: \`$SEED_ORGANIZATION\` ($SEED_STATUS)"
             echo ""
             echo "> All services passed their Railway deploy/healthcheck before this link was printed, so it should be live now."
             echo ""

--- a/.github/workflows/railway-preview.yml
+++ b/.github/workflows/railway-preview.yml
@@ -17,7 +17,8 @@ name: Railway Preview Environment
 #
 # The DB needs no explicit migration step here: the cio-api image self-migrates on boot
 # (docker/entrypoint-api.sh -> `pnpm --filter @cio/db db:setup`, which runs drizzle
-# migrations + essential seed). The optional `seed` input adds the full demo dataset.
+# migrations + essential seed). The optional organization seed adds only that demo
+# organization's users, memberships, and content.
 
 on:
   workflow_dispatch:
@@ -39,11 +40,16 @@ on:
         options:
           - deploy
           - destroy
-      seed:
-        description: "Seed the full demo dataset (admin@test.com etc.) after deploy"
-        required: false
-        type: boolean
-        default: true
+      seed_organization:
+        description: "Demo organization to seed after deploy"
+        required: true
+        type: choice
+        default: udemy-test
+        options:
+          - udemy-test
+          - coursera-test
+          - skillshare-test
+          - none
 
 # One run per branch at a time; a newer run supersedes an in-flight one.
 concurrency:
@@ -316,38 +322,40 @@ jobs:
         run: bash .github/scripts/railway-preview-deploy.sh
 
       - name: Setup pnpm
-        if: ${{ inputs.action == 'deploy' && inputs.seed }}
+        if: ${{ inputs.action == 'deploy' && inputs.seed_organization != 'none' }}
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        if: ${{ inputs.action == 'deploy' && inputs.seed }}
+        if: ${{ inputs.action == 'deploy' && inputs.seed_organization != 'none' }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
 
       - name: Install dependencies
-        if: ${{ inputs.action == 'deploy' && inputs.seed }}
+        if: ${{ inputs.action == 'deploy' && inputs.seed_organization != 'none' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build workspace dependencies
-        if: ${{ inputs.action == 'deploy' && inputs.seed }}
+        if: ${{ inputs.action == 'deploy' && inputs.seed_organization != 'none' }}
         # @cio/db imports compiled output (e.g. @cio/utils/dist/...) from its workspace
         # deps, not source — they must be built before the seed script can import them.
         run: pnpm --filter @cio/db^... build
 
-      - name: Seed the full demo dataset (optional)
-        if: ${{ inputs.action == 'deploy' && inputs.seed }}
+      - name: Seed the selected demo organization (optional)
+        if: ${{ inputs.action == 'deploy' && inputs.seed_organization != 'none' }}
         # cio-api only carries the private DATABASE_URL; `railway run` executes on this
         # GitHub runner, so seeding needs Postgres's own DATABASE_PUBLIC_URL instead
         # (railway.internal isn't reachable from here).
+        env:
+          SEED_ORGANIZATION: ${{ inputs.seed_organization }}
         run: |
           PUBLIC_DB_URL=$(railway variables --service Postgres --kv | grep '^DATABASE_PUBLIC_URL=' | cut -d= -f2-)
           if [ -z "$PUBLIC_DB_URL" ]; then
-            echo "::warning::Postgres has no DATABASE_PUBLIC_URL in this environment — skipping full seed; only essential seed ran on api boot."
+            echo "::warning::Postgres has no DATABASE_PUBLIC_URL in this environment — skipping $SEED_ORGANIZATION seed; only essential seed ran on api boot."
           else
-            railway run --service cio-api -- env DATABASE_URL="$PUBLIC_DB_URL" pnpm --filter @cio/db db:setup:seed || \
-              echo "Demo seed failed (likely DB not reachable from runner) — migrations + essential seed still ran on api boot."
+            railway run --service cio-api -- env DATABASE_URL="$PUBLIC_DB_URL" pnpm --filter @cio/db db:setup:seed -- --organization "$SEED_ORGANIZATION" || \
+              echo "$SEED_ORGANIZATION seed failed (likely DB not reachable from runner) — migrations + essential seed still ran on api boot."
           fi
 
       - name: Report the preview URL
@@ -356,6 +364,7 @@ jobs:
         env:
           BRANCH: ${{ inputs.branch }}
           ENV_NAME: ${{ steps.env.outputs.name }}
+          SEED_ORGANIZATION: ${{ inputs.seed_organization }}
         run: |
           railway domain --service cio-dashboard || true
           URL=$(railway variables --service cio-dashboard --kv | grep '^RAILWAY_PUBLIC_DOMAIN=' | cut -d= -f2-)
@@ -369,6 +378,7 @@ jobs:
             echo ""
             echo "- Environment: \`$ENV_NAME\` (branch \`$BRANCH\`)"
             echo "- Dashboard: https://${URL}"
+            echo "- Demo seed: \`$SEED_ORGANIZATION\`"
             echo ""
             echo "> All services passed their Railway deploy/healthcheck before this link was printed, so it should be live now."
             echo ""

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -98,6 +98,24 @@ pnpm seed
 pnpm seed --all
 ```
 
+### Seed one demo organization
+
+Use the organization's `siteName` to insert only that organization's fixture users,
+memberships, groups, courses, and related content. Required global reference data is
+still inserted.
+
+```bash
+pnpm seed --organization udemy-test
+pnpm seed --organization coursera-test
+pnpm seed --organization skillshare-test
+```
+
+The same selector can be passed through database setup:
+
+```bash
+pnpm db:setup:seed -- --organization coursera-test
+```
+
 ### Run individual seeds
 
 Pass one or more flags to run only specific steps:

--- a/packages/db/src/scripts/db-setup.ts
+++ b/packages/db/src/scripts/db-setup.ts
@@ -14,6 +14,22 @@ const scriptPath = fileURLToPath(import.meta.url);
 const packageRoot = resolve(dirname(scriptPath), '../..');
 const pnpmBinary = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 
+function getArgumentValue(argumentName: string): string | undefined {
+  const inlineArgument = process.argv.find((argument) => argument.startsWith(`${argumentName}=`));
+  if (inlineArgument) {
+    return inlineArgument.slice(`${argumentName}=`.length);
+  }
+
+  const argumentIndex = process.argv.indexOf(argumentName);
+  if (argumentIndex === -1) {
+    return undefined;
+  }
+
+  return process.argv[argumentIndex + 1];
+}
+
+const seedOrganization = getArgumentValue('--organization');
+
 if (!connectionString) {
   console.error('DATABASE_URL or PRIVATE_DATABASE_URL environment variable is required');
   process.exit(1);
@@ -57,7 +73,12 @@ async function runSeedEssential() {
 
 async function runSeed() {
   console.log('Seeding database...');
-  await runPnpmCommand('Seed', ['seed']);
+  const seedArgs = ['seed'];
+  if (seedOrganization) {
+    seedArgs.push('--organization', seedOrganization);
+  }
+
+  await runPnpmCommand('Seed', seedArgs);
 }
 
 async function dbSetup() {

--- a/packages/db/src/scripts/seed.ts
+++ b/packages/db/src/scripts/seed.ts
@@ -39,12 +39,92 @@ const EARLY_ADOPTER_ADMIN_USER_ID = '6e0163ff-9161-4d4b-be9f-3e7fbd913c5e';
 const EARLY_ADOPTER_STUDENT_USER_ID = '7fb274aa-a272-4e5c-cf0a-4f8cce024d6f';
 const EARLY_ADOPTER_GROUP_ID = '8ac385bb-b383-4f6d-d01b-5a9ddf135e7a';
 
-// Parse command line arguments
-function parseFlags(): Set<string> {
+type DemoOrganizationSlug = 'udemy-test' | 'coursera-test' | 'skillshare-test';
+
+interface DemoOrganizationSeedConfig {
+  organizationId: string;
+  userIds: string[];
+  groupIds: string[];
+  seedNames: string[];
+}
+
+const COMMON_ORGANIZATION_SEEDS = [
+  'roles',
+  'submissions',
+  'question-types',
+  'users',
+  'profiles',
+  'accounts',
+  'organizations',
+  'organization-members'
+];
+
+const DEMO_ORGANIZATION_SEEDS: Record<DemoOrganizationSlug, DemoOrganizationSeedConfig> = {
+  'udemy-test': {
+    organizationId: TEST_ORG_ID,
+    userIds: [ADMIN_USER_ID, STUDENT_USER_ID],
+    groupIds: [MVC_GROUP_ID, REACT_GROUP_ID, PANDAS_GROUP_ID],
+    seedNames: [
+      ...COMMON_ORGANIZATION_SEEDS,
+      'groups',
+      'group-members',
+      'courses',
+      'sections',
+      'lessons',
+      'exercises',
+      'questions'
+    ]
+  },
+  'coursera-test': {
+    organizationId: ENTERPRISE_ORG_ID,
+    userIds: [ENTERPRISE_ADMIN_USER_ID, ENTERPRISE_STUDENT_USER_ID],
+    groupIds: [],
+    seedNames: [...COMMON_ORGANIZATION_SEEDS, 'organization-plan', 'compliance', 'newsfeed-threads']
+  },
+  'skillshare-test': {
+    organizationId: EARLY_ADOPTER_ORG_ID,
+    userIds: [EARLY_ADOPTER_ADMIN_USER_ID, EARLY_ADOPTER_STUDENT_USER_ID],
+    groupIds: [EARLY_ADOPTER_GROUP_ID],
+    seedNames: [...COMMON_ORGANIZATION_SEEDS, 'organization-plan', 'groups', 'group-members', 'courses']
+  }
+};
+
+function isDemoOrganizationSlug(value: string): value is DemoOrganizationSlug {
+  return Object.prototype.hasOwnProperty.call(DEMO_ORGANIZATION_SEEDS, value);
+}
+
+function parseCliOptions(): { flags: Set<string>; organization?: DemoOrganizationSlug } {
   const args = process.argv.slice(2);
   const flags = new Set<string>();
+  let organization: DemoOrganizationSlug | undefined;
 
-  for (const arg of args) {
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+
+    if (arg === '--organization') {
+      const organizationValue = args[index + 1];
+      if (!organizationValue || organizationValue.startsWith('-')) {
+        throw new Error('--organization requires a value');
+      }
+      if (!isDemoOrganizationSlug(organizationValue)) {
+        throw new Error(`Unknown seed organization: ${organizationValue}`);
+      }
+
+      organization = organizationValue;
+      index++;
+      continue;
+    }
+
+    if (arg.startsWith('--organization=')) {
+      const organizationValue = arg.slice('--organization='.length);
+      if (!isDemoOrganizationSlug(organizationValue)) {
+        throw new Error(`Unknown seed organization: ${organizationValue}`);
+      }
+
+      organization = organizationValue;
+      continue;
+    }
+
     if (arg.startsWith('--')) {
       flags.add(arg.slice(2));
     } else if (arg.startsWith('-')) {
@@ -52,8 +132,15 @@ function parseFlags(): Set<string> {
     }
   }
 
-  return flags;
+  return { flags, organization };
 }
+
+const cliOptions = parseCliOptions();
+const selectedOrganization = cliOptions.organization;
+const selectedOrganizationConfig = selectedOrganization ? DEMO_ORGANIZATION_SEEDS[selectedOrganization] : undefined;
+const selectedUsersData = selectedOrganizationConfig
+  ? usersData.filter((seedUser) => selectedOrganizationConfig.userIds.includes(seedUser.id))
+  : usersData;
 
 // Show help message
 function showHelp() {
@@ -64,6 +151,7 @@ Usage: pnpm seed [flags]
 
 Flags:
   --all, -a                    Run all seed functions (default if no flags provided)
+  --organization <site-name>  Limit demo data to udemy-test, coursera-test, or skillshare-test
   --roles                      Seed roles
   --submissions                Seed submission statuses
   --question-types             Seed question types
@@ -86,6 +174,7 @@ Flags:
   --help, -h                  Show this help message
 
 Examples:
+  pnpm seed --organization coursera-test
   pnpm seed --users --profiles
   pnpm seed --all
   pnpm seed --roles --submissions --question-types
@@ -108,23 +197,24 @@ const seedFunctions = {
   },
   users: async () => {
     console.log('📝 Seeding users...');
-    await seedUsers({ usersData });
+    await seedUsers({ usersData: selectedUsersData });
   },
   profiles: async () => {
     console.log('📝 Seeding profiles...');
-    await seedProfile({ usersData });
+    await seedProfile({ usersData: selectedUsersData });
   },
   accounts: async () => {
     console.log('📝 Seeding accounts...');
     // @ts-expect-error missing properties
-    await seedAccount({ usersData });
+    await seedAccount({ usersData: selectedUsersData });
   },
   organizations: async () => {
     console.log('📝 Seeding organizations...');
     await seedOrganization({
       testOrgId: TEST_ORG_ID,
       enterpriseOrgId: ENTERPRISE_ORG_ID,
-      earlyAdopterOrgId: EARLY_ADOPTER_ORG_ID
+      earlyAdopterOrgId: EARLY_ADOPTER_ORG_ID,
+      selectedOrganizationId: selectedOrganizationConfig?.organizationId
     });
   },
   'organization-members': async () => {
@@ -138,14 +228,20 @@ const seedFunctions = {
       enterpriseStudentUserId: ENTERPRISE_STUDENT_USER_ID,
       earlyAdopterOrgId: EARLY_ADOPTER_ORG_ID,
       earlyAdopterAdminUserId: EARLY_ADOPTER_ADMIN_USER_ID,
-      earlyAdopterStudentUserId: EARLY_ADOPTER_STUDENT_USER_ID
+      earlyAdopterStudentUserId: EARLY_ADOPTER_STUDENT_USER_ID,
+      selectedOrganizationId: selectedOrganizationConfig?.organizationId
     });
   },
   'organization-plan': async () => {
-    console.log('📝 Seeding enterprise organization plan...');
-    await seedEnterpriseOrganizationPlan({ enterpriseOrgId: ENTERPRISE_ORG_ID });
-    console.log('📝 Seeding early adopter organization plan...');
-    await seedEarlyAdopterOrganizationPlan({ earlyAdopterOrgId: EARLY_ADOPTER_ORG_ID });
+    if (!selectedOrganization || selectedOrganization === 'coursera-test') {
+      console.log('📝 Seeding enterprise organization plan...');
+      await seedEnterpriseOrganizationPlan({ enterpriseOrgId: ENTERPRISE_ORG_ID });
+    }
+
+    if (!selectedOrganization || selectedOrganization === 'skillshare-test') {
+      console.log('📝 Seeding early adopter organization plan...');
+      await seedEarlyAdopterOrganizationPlan({ earlyAdopterOrgId: EARLY_ADOPTER_ORG_ID });
+    }
   },
   groups: async () => {
     console.log('📝 Seeding groups...');
@@ -155,7 +251,8 @@ const seedFunctions = {
       pandasGroupId: PANDAS_GROUP_ID,
       testOrgId: TEST_ORG_ID,
       earlyAdopterGroupId: EARLY_ADOPTER_GROUP_ID,
-      earlyAdopterOrgId: EARLY_ADOPTER_ORG_ID
+      earlyAdopterOrgId: EARLY_ADOPTER_ORG_ID,
+      selectedOrganizationId: selectedOrganizationConfig?.organizationId
     });
   },
   'group-members': async () => {
@@ -168,7 +265,8 @@ const seedFunctions = {
       studentUserId: STUDENT_USER_ID,
       earlyAdopterGroupId: EARLY_ADOPTER_GROUP_ID,
       earlyAdopterAdminUserId: EARLY_ADOPTER_ADMIN_USER_ID,
-      earlyAdopterStudentUserId: EARLY_ADOPTER_STUDENT_USER_ID
+      earlyAdopterStudentUserId: EARLY_ADOPTER_STUDENT_USER_ID,
+      selectedGroupIds: selectedOrganizationConfig?.groupIds
     });
   },
   courses: async () => {
@@ -177,7 +275,8 @@ const seedFunctions = {
       mvcGroupId: MVC_GROUP_ID,
       reactGroupId: REACT_GROUP_ID,
       pandasGroupId: PANDAS_GROUP_ID,
-      earlyAdopterGroupId: EARLY_ADOPTER_GROUP_ID
+      earlyAdopterGroupId: EARLY_ADOPTER_GROUP_ID,
+      selectedGroupIds: selectedOrganizationConfig?.groupIds
     });
   },
   sections: async () => {
@@ -231,9 +330,31 @@ const seedFunctions = {
   }
 };
 
+const orderedSeeds = [
+  'roles',
+  'submissions',
+  'question-types',
+  'users',
+  'profiles',
+  'accounts',
+  'organizations',
+  'organization-members',
+  'organization-plan',
+  'groups',
+  'group-members',
+  'courses',
+  'sections',
+  'lessons',
+  'exercises',
+  'questions',
+  'templates',
+  'compliance',
+  'newsfeed-threads'
+] as const;
+
 async function seed() {
   try {
-    const flags = parseFlags();
+    const { flags } = cliOptions;
 
     // Show help if requested
     if (flags.has('help') || flags.has('h')) {
@@ -241,65 +362,22 @@ async function seed() {
       process.exit(0);
     }
 
-    console.log('🌱 Starting seed...');
+    const scopeLabel = selectedOrganization ? ` for ${selectedOrganization}` : '';
+    console.log(`🌱 Starting seed${scopeLabel}...`);
 
     // If --all flag or no flags provided, run all seeds
     const runAll = flags.size === 0 || flags.has('all') || flags.has('a');
+    const allowedSeeds = selectedOrganizationConfig
+      ? new Set(selectedOrganizationConfig.seedNames)
+      : new Set<string>(orderedSeeds);
 
-    if (runAll) {
-      // Run all seeds in order
-      await seedFunctions.roles();
-      await seedFunctions.submissions();
-      await seedFunctions['question-types']();
-      await seedFunctions.users();
-      await seedFunctions.profiles();
-      await seedFunctions.accounts();
-      await seedFunctions.organizations();
-      await seedFunctions['organization-members']();
-      await seedFunctions['organization-plan']();
-      await seedFunctions.groups();
-      await seedFunctions['group-members']();
-      await seedFunctions.courses();
-      await seedFunctions.sections();
-      await seedFunctions.lessons();
-      await seedFunctions.exercises();
-      await seedFunctions.questions();
-      await seedFunctions.templates();
-      await seedFunctions.compliance();
-      await seedFunctions['newsfeed-threads']();
-    } else {
-      // Run only specified seed functions
-      // Order matters for dependencies, so we maintain the original order
-      const orderedSeeds = [
-        'roles',
-        'submissions',
-        'question-types',
-        'users',
-        'profiles',
-        'accounts',
-        'organizations',
-        'organization-members',
-        'organization-plan',
-        'groups',
-        'group-members',
-        'courses',
-        'sections',
-        'lessons',
-        'exercises',
-        'questions',
-        'templates',
-        'compliance',
-        'newsfeed-threads'
-      ];
-
-      for (const seedName of orderedSeeds) {
-        if (flags.has(seedName)) {
-          const seedFn = seedFunctions[seedName as keyof typeof seedFunctions];
-          if (seedFn) {
-            await seedFn();
-          }
-        }
+    for (const seedName of orderedSeeds) {
+      const wasRequested = runAll || flags.has(seedName);
+      if (!wasRequested || !allowedSeeds.has(seedName)) {
+        continue;
       }
+
+      await seedFunctions[seedName]();
     }
 
     console.log('✅ Seed completed successfully!');

--- a/packages/db/src/scripts/seed.ts
+++ b/packages/db/src/scripts/seed.ts
@@ -39,16 +39,39 @@ const EARLY_ADOPTER_ADMIN_USER_ID = '6e0163ff-9161-4d4b-be9f-3e7fbd913c5e';
 const EARLY_ADOPTER_STUDENT_USER_ID = '7fb274aa-a272-4e5c-cf0a-4f8cce024d6f';
 const EARLY_ADOPTER_GROUP_ID = '8ac385bb-b383-4f6d-d01b-5a9ddf135e7a';
 
+const orderedSeeds = [
+  'roles',
+  'submissions',
+  'question-types',
+  'users',
+  'profiles',
+  'accounts',
+  'organizations',
+  'organization-members',
+  'organization-plan',
+  'groups',
+  'group-members',
+  'courses',
+  'sections',
+  'lessons',
+  'exercises',
+  'questions',
+  'templates',
+  'compliance',
+  'newsfeed-threads'
+] as const;
+
+type SeedName = (typeof orderedSeeds)[number];
 type DemoOrganizationSlug = 'udemy-test' | 'coursera-test' | 'skillshare-test';
 
 interface DemoOrganizationSeedConfig {
   organizationId: string;
   userIds: string[];
   groupIds: string[];
-  seedNames: string[];
+  seedNames: SeedName[];
 }
 
-const COMMON_ORGANIZATION_SEEDS = [
+const COMMON_ORGANIZATION_SEEDS: SeedName[] = [
   'roles',
   'submissions',
   'question-types',
@@ -330,28 +353,6 @@ const seedFunctions = {
   }
 };
 
-const orderedSeeds = [
-  'roles',
-  'submissions',
-  'question-types',
-  'users',
-  'profiles',
-  'accounts',
-  'organizations',
-  'organization-members',
-  'organization-plan',
-  'groups',
-  'group-members',
-  'courses',
-  'sections',
-  'lessons',
-  'exercises',
-  'questions',
-  'templates',
-  'compliance',
-  'newsfeed-threads'
-] as const;
-
 async function seed() {
   try {
     const { flags } = cliOptions;
@@ -373,7 +374,15 @@ async function seed() {
 
     for (const seedName of orderedSeeds) {
       const wasRequested = runAll || flags.has(seedName);
-      if (!wasRequested || !allowedSeeds.has(seedName)) {
+      if (!wasRequested) {
+        continue;
+      }
+
+      if (!allowedSeeds.has(seedName)) {
+        if (!runAll) {
+          console.log(`⏭️  Skipping ${seedName}: not part of the ${selectedOrganization} demo organization.`);
+        }
+
         continue;
       }
 

--- a/packages/db/src/utils/seed/course.ts
+++ b/packages/db/src/utils/seed/course.ts
@@ -7,9 +7,16 @@ interface SeedCourse {
   reactGroupId: string;
   pandasGroupId: string;
   earlyAdopterGroupId: string;
+  selectedGroupIds?: string[];
 }
 
-export async function seedCourses({ mvcGroupId, reactGroupId, pandasGroupId, earlyAdopterGroupId }: SeedCourse) {
+export async function seedCourses({
+  mvcGroupId,
+  reactGroupId,
+  pandasGroupId,
+  earlyAdopterGroupId,
+  selectedGroupIds
+}: SeedCourse) {
   const existingCourses = await db.select().from(course);
   const existingCourseIds = existingCourses.map((c) => c.id);
 
@@ -128,7 +135,11 @@ export async function seedCourses({ mvcGroupId, reactGroupId, pandasGroupId, ear
       },
       status: 'ACTIVE'
     }
-  ].filter((c) => !existingCourseIds.includes(c.id));
+  ].filter(
+    (courseToInsert) =>
+      (!selectedGroupIds || selectedGroupIds.includes(courseToInsert.groupId)) &&
+      !existingCourseIds.includes(courseToInsert.id)
+  );
 
   if (coursesToInsert.length > 0) {
     await db.insert(course).values(coursesToInsert);

--- a/packages/db/src/utils/seed/group.ts
+++ b/packages/db/src/utils/seed/group.ts
@@ -7,6 +7,7 @@ interface SeedGroup {
   testOrgId: string;
   earlyAdopterGroupId: string;
   earlyAdopterOrgId: string;
+  selectedOrganizationId?: string;
 }
 
 export async function seedGroup({
@@ -15,7 +16,8 @@ export async function seedGroup({
   pandasGroupId,
   testOrgId,
   earlyAdopterGroupId,
-  earlyAdopterOrgId
+  earlyAdopterOrgId,
+  selectedOrganizationId
 }: SeedGroup) {
   const existingGroups = await db.select().from(group);
   const existingGroupIds = existingGroups.map((g) => g.id);
@@ -49,7 +51,11 @@ export async function seedGroup({
         'A practical introduction to product management covering roadmaps, prioritization frameworks, user research, and cross-functional collaboration skills needed to ship great products.',
       organizationId: earlyAdopterOrgId
     }
-  ].filter((g) => !existingGroupIds.includes(g.id));
+  ].filter(
+    (groupToInsert) =>
+      (!selectedOrganizationId || groupToInsert.organizationId === selectedOrganizationId) &&
+      !existingGroupIds.includes(groupToInsert.id)
+  );
 
   if (groupsToInsert.length > 0) {
     await db.insert(group).values(groupsToInsert);

--- a/packages/db/src/utils/seed/groupmember.ts
+++ b/packages/db/src/utils/seed/groupmember.ts
@@ -9,6 +9,7 @@ interface SeedGroupmember {
   earlyAdopterGroupId: string;
   earlyAdopterAdminUserId: string;
   earlyAdopterStudentUserId: string;
+  selectedGroupIds?: string[];
 }
 
 export async function seedGroupmembers({
@@ -19,7 +20,8 @@ export async function seedGroupmembers({
   studentUserId,
   earlyAdopterGroupId,
   earlyAdopterAdminUserId,
-  earlyAdopterStudentUserId
+  earlyAdopterStudentUserId,
+  selectedGroupIds
 }: SeedGroupmember) {
   const existingGroupMembers = await db.select().from(groupmember);
   const existingGroupMemberKeys = existingGroupMembers.map((gm) => `${gm.groupId}-${gm.profileId || gm.email}`);
@@ -59,7 +61,13 @@ export async function seedGroupmembers({
       roleId: 3, // STUDENT
       profileId: earlyAdopterStudentUserId
     }
-  ].filter((gm) => !existingGroupMemberKeys.includes(`${gm.groupId}-${gm.profileId || gm.email}`));
+  ].filter(
+    (groupMemberToInsert) =>
+      (!selectedGroupIds || selectedGroupIds.includes(groupMemberToInsert.groupId)) &&
+      !existingGroupMemberKeys.includes(
+        `${groupMemberToInsert.groupId}-${groupMemberToInsert.profileId || groupMemberToInsert.email}`
+      )
+  );
 
   if (groupMembersToInsert.length > 0) {
     await db.insert(groupmember).values(groupMembersToInsert);

--- a/packages/db/src/utils/seed/organization.ts
+++ b/packages/db/src/utils/seed/organization.ts
@@ -3,11 +3,13 @@ import { db, organization } from '@db/drizzle';
 export async function seedOrganization({
   testOrgId,
   enterpriseOrgId,
-  earlyAdopterOrgId
+  earlyAdopterOrgId,
+  selectedOrganizationId
 }: {
   testOrgId: string;
   enterpriseOrgId: string;
   earlyAdopterOrgId: string;
+  selectedOrganizationId?: string;
 }) {
   const existingOrgs = await db.select().from(organization);
   const existingOrgIds = existingOrgs.map((o) => o.id);
@@ -52,7 +54,11 @@ export async function seedOrganization({
         dashboard: { exercise: true, community: true, bannerText: '', bannerImage: '' }
       }
     }
-  ].filter((o) => !existingOrgIds.includes(o.id));
+  ].filter(
+    (organizationToInsert) =>
+      (!selectedOrganizationId || organizationToInsert.id === selectedOrganizationId) &&
+      !existingOrgIds.includes(organizationToInsert.id)
+  );
 
   if (organizationsToInsert.length > 0) {
     await db.insert(organization).values(organizationsToInsert);

--- a/packages/db/src/utils/seed/organizationmember.ts
+++ b/packages/db/src/utils/seed/organizationmember.ts
@@ -10,6 +10,7 @@ interface SeedOrganizationMember {
   earlyAdopterOrgId: string;
   earlyAdopterAdminUserId: string;
   earlyAdopterStudentUserId: string;
+  selectedOrganizationId?: string;
 }
 
 export async function seedOrganizationMember({
@@ -21,7 +22,8 @@ export async function seedOrganizationMember({
   enterpriseStudentUserId,
   earlyAdopterOrgId,
   earlyAdopterAdminUserId,
-  earlyAdopterStudentUserId
+  earlyAdopterStudentUserId,
+  selectedOrganizationId
 }: SeedOrganizationMember) {
   const existingOrgMembers = await db.select().from(organizationmember);
   const existingOrgMemberKeys = existingOrgMembers.map((om) => `${om.organizationId}-${om.profileId}`);
@@ -63,7 +65,13 @@ export async function seedOrganizationMember({
       profileId: earlyAdopterStudentUserId,
       verified: false
     }
-  ].filter((om) => !existingOrgMemberKeys.includes(`${om.organizationId}-${om.profileId}`));
+  ].filter(
+    (organizationMemberToInsert) =>
+      (!selectedOrganizationId || organizationMemberToInsert.organizationId === selectedOrganizationId) &&
+      !existingOrgMemberKeys.includes(
+        `${organizationMemberToInsert.organizationId}-${organizationMemberToInsert.profileId}`
+      )
+  );
 
   if (orgMembersToInsert.length > 0) {
     await db.insert(organizationmember).values(orgMembersToInsert);


### PR DESCRIPTION
## What does this PR do?

Adds organization-scoped demo seeding to Railway preview deployments.

- Replaces the boolean preview seed input with a choice between udemy-test, coursera-test, skillshare-test, and none.
- Adds an --organization selector to the database seed CLI and forwards it through db:setup:seed.
- Filters fixture users, memberships, organizations, groups, courses, and dependent content to the selected organization.
- Keeps required global reference rows such as roles, submission statuses, and question types.
- Documents local organization-scoped seed commands.

The GitHub Actions workflow interface changes from a seed boolean to the seed_organization choice input.

## Demo

Not applicable; this is a CI and seed tooling change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [x] This change requires a documentation update

## How should this be tested?

- Dispatch Railway Preview Environment and select each seed_organization option; verify only the selected demo organization fixtures are inserted.
- Run pnpm --filter @cio/db seed -- --organization coursera-test --help to verify CLI parsing.
- Run pnpm format:check.
- Run pnpm --filter @cio/api^... build && pnpm --filter @cio/api build on Node 20.

## Checklist

### Required

- [x] Filled out the How to test section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran pnpm build
- [ ] Checked for warnings, there are none
- [x] Removed unrelated console logs
- [x] Merged the latest changes from main onto my branch
- [x] My changes do not cause any responsiveness issues
- [x] Workflow changes are called out above

### Appreciated

- [x] No UI change was made, so screenshots are not applicable
- [x] Updated the database package documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preview deployments can seed a specific demo organization: Udemy, Coursera, Skillshare, or none.
  - Organization-specific seeding limits related users, memberships, groups, and courses to the selected demo data.
  - Preview summaries now display the selected seed organization and status.
- **Bug Fixes**
  - Added validation and clearer warnings or failure messages for organization-specific seeding.
- **Documentation**
  - Added guidance for seeding individual demo organizations by site name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds organization-scoped demo seeding for Railway preview environments.
- Replaces the preview seed boolean with an organization selector and reports the resulting seed status.
- Propagates the selector through database setup and limits fixture users, memberships, organizations, groups, courses, and dependent seed steps.
- Documents organization-scoped seed commands.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/railway-preview.yml | Replaces the seed boolean with an organization choice, forwards it to database setup, and reports seed status. |
| packages/db/src/scripts/db-setup.ts | Parses the organization option and forwards it to the standard seed command. |
| packages/db/src/scripts/seed.ts | Defines organization-specific seed plans and filters fixture identities and enabled seed stages accordingly. |
| packages/db/src/utils/seed/organization.ts | Restricts organization fixture insertion to the selected organization when a scope is supplied. |
| packages/db/src/utils/seed/organizationmember.ts | Restricts organization memberships to the selected organization. |
| packages/db/src/utils/seed/group.ts | Restricts group fixtures to the selected organization. |
| packages/db/src/utils/seed/groupmember.ts | Restricts group memberships to groups selected by the organization configuration. |
| packages/db/src/utils/seed/course.ts | Restricts course fixtures to groups selected by the organization configuration. |
| packages/db/README.md | Documents direct and database-setup commands for organization-scoped seeding. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Railway workflow input] --> B{Seed organization selected?}
  B -- none --> C[Skip demo seed]
  B -- organization --> D[db:setup:seed]
  D --> E[Forward organization selector]
  E --> F[Seed global reference rows]
  E --> G[Filter organization fixtures]
  G --> H[Users and profiles]
  G --> I[Organization memberships]
  G --> J[Groups and courses]
  J --> K[Dependent content]
  F --> L[(Preview database)]
  H --> L
  I --> L
  K --> L
```

<sub>Reviews (2): Last reviewed commit: ["fix(ci): report scoped seed outcomes"](https://github.com/classroomio/classroomio/commit/ceeb4b121f1d3a754bd4a3af4104ad36e30f6ea9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56157785)</sub>

<!-- /greptile_comment -->