### PR TITLE
fix(ui): render landing-page embeds on direct load and hard reload

### DIFF
--- a/packages/ui/src/custom/org-landing-page/embed-frame.svelte
+++ b/packages/ui/src/custom/org-landing-page/embed-frame.svelte
@@ -1,17 +1,10 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { browser } from '$app/environment';
   import { sanitizeEmbedHtml } from '../../tools/sanitize';
   import { parseEmbedIframeDimensions } from './landing-page-utils';
 
   let { code }: { code: string } = $props();
-
   const dimensions = $derived(parseEmbedIframeDimensions(code));
-  let isMounted = $state(false);
-  const sanitizedCode = $derived(isMounted ? sanitizeEmbedHtml(code) : '');
-
-  onMount(() => {
-    isMounted = true;
-  });
 </script>
 
 <div
@@ -19,9 +12,11 @@
   style:width={dimensions.width}
   style:max-width="100%"
 >
-  <div class="landing-embed-frame ui:w-full" style:height={dimensions.height}>
-    {@html sanitizedCode}
-  </div>
+  {#if browser}
+    <div class="landing-embed-frame ui:w-full" style:height={dimensions.height}>
+      {@html sanitizeEmbedHtml(code)}
+    </div>
+  {/if}
 </div>
 
 <style>

--- a/packages/ui/src/custom/org-landing-page/embed-frame.svelte
+++ b/packages/ui/src/custom/org-landing-page/embed-frame.svelte
@@ -1,11 +1,17 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { sanitizeEmbedHtml } from '../../tools/sanitize';
   import { parseEmbedIframeDimensions } from './landing-page-utils';
 
   let { code }: { code: string } = $props();
 
   const dimensions = $derived(parseEmbedIframeDimensions(code));
-  const sanitizedCode = $derived(sanitizeEmbedHtml(code));
+  let isMounted = $state(false);
+  const sanitizedCode = $derived(isMounted ? sanitizeEmbedHtml(code) : '');
+
+  onMount(() => {
+    isMounted = true;
+  });
 </script>
 
 <div


### PR DESCRIPTION
## What does this PR do?

Embedded snippets (e.g. YouTube iframes) added through the landing page editor were
missing from the DOM whenever an organization landing page was opened via direct URL
or hard browser refresh.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #865 

## Demo
https://www.awesomescreenshot.com/video/55840947?key=c66d1cf3a0ae89a80a9bf0ae642d7904
<!-- Please upload a video here or attach a link to a video player like Awesome Screenshot or Loom to show the change in action. This speeds up reviews, especially for visual changes. -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. As an admin, open **Settings → Landing Page → Edit**, enable the Embed section,
   paste any standard embed snippet (e.g. a YouTube iframe), and publish.
2. Open the organization landing page directly in a new tab. Before this PR the embed section rendered its heading/description but the snippet itself was absent from the DOM; it now appears right after load.
3. Confirm in-app navigation still renders the embed as before.


## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedded content rendering by sanitizing embed HTML in the browser.
  * Prevented sanitized embed content from being generated during server-side rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes landing-page embeds on direct loads and hard refreshes by rendering sanitized embed HTML through a browser-only branch.
- Replaces the derived sanitized value with client-side sanitization at the HTML sink.
- Omits the embed frame during server rendering and creates it in the browser.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/custom/org-landing-page/embed-frame.svelte | Moves sanitized embed rendering into a browser-only conditional so direct-load hydration can populate the embed. |

<sub>Reviews (2): Last reviewed commit: ["changed using onMount to call sanitize t..."](https://github.com/classroomio/classroomio/commit/da7792046879ed9e2e472285f5d4818340f0f21c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56213740)</sub>

<!-- /greptile_comment -->