### PR TITLE
fix: gate primary widget color behind custom-colors plan check

### DIFF
--- a/apps/dashboard/src/lib/features/widget/panels/design-panel.svelte
+++ b/apps/dashboard/src/lib/features/widget/panels/design-panel.svelte
@@ -51,7 +51,8 @@
           <input
             type="color"
             bind:value={draftConfig.colors.primaryColor}
-            class="ui:h-9 ui:w-9 ui:cursor-pointer ui:rounded ui:border ui:bg-transparent ui:p-0.5"
+            disabled={!canUseCustomColors}
+            class="ui:h-9 ui:w-9 ui:cursor-pointer ui:rounded ui:border ui:bg-transparent ui:p-0.5 disabled:ui:cursor-not-allowed disabled:ui:opacity-50"
           />
           <span class="ui:text-muted-foreground ui:font-mono ui:text-sm">{draftConfig.colors.primaryColor}</span>
         </div>


### PR DESCRIPTION
Fixes #902.

Background, text, and border color in the widget theme editor already disable when `canUseCustomColors` is false. The primary color input did not, so on a free plan you could drag the swatch and see it change, but `normalizeWidgetConfig` resets all four colors to defaults on save when `canUseCustomColors` is false. The edit looked like it took effect and then silently reverted.

Added the same `disabled`/styling the other three inputs use to the primary color input, so the UI's gating matches what the backend actually persists.

No dashboard component test infra exists for this panel (jest config is broken here per the repo's own notes, unrelated to this change), so I didn't add one. The plan-gating logic itself (`resolveWidgetPlanGatedFields`) already has coverage in `apps/api/src/__tests__/widget-validation.test.ts`.

Verified with `pnpm --filter @cio/dashboard build` and `pnpm format:check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the primary color picker to respect custom-color availability.
  * Added disabled styling when custom colors aren’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the primary widget color control with the existing custom-color plan restrictions.
- Disables the primary color input when `canUseCustomColors` is false.
- Adds disabled cursor and opacity styling consistent with the other widget color controls.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The changed native color input is effectively disabled for plans without custom-color access, matches all sibling color controls, and introduces no alternate mutation or persistence path.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/widget/panels/design-panel.svelte | The primary color input now uses the same plan gate and disabled styling as the background, text, and border color inputs. |

<sub>Reviews (1): Last reviewed commit: ["fix: gate primary widget color behind cu..."](https://github.com/classroomio/classroomio/commit/62ecc7357a2d99b42cb639e6a90abcc29498be4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56299781)</sub>

<!-- /greptile_comment -->