### PR TITLE
feat(ci): allow seeding all preview organizations

### DIFF
--- a/.github/workflows/railway-preview.yml
+++ b/.github/workflows/railway-preview.yml
@@ -41,11 +41,12 @@ on:
           - deploy
           - destroy
       seed_organization:
-        description: "Demo organization to seed after deploy"
+        description: "Demo data to seed after deploy"
         required: true
         type: choice
         default: udemy-test
         options:
+          - all
           - udemy-test
           - coursera-test
           - skillshare-test
@@ -342,7 +343,7 @@ jobs:
         # deps, not source — they must be built before the seed script can import them.
         run: pnpm --filter @cio/db^... build
 
-      - name: Seed the selected demo organization (optional)
+      - name: Seed the selected demo data (optional)
         id: seed
         if: ${{ inputs.action == 'deploy' && inputs.seed_organization != 'none' }}
         # cio-api only carries the private DATABASE_URL; `railway run` executes on this
@@ -351,12 +352,20 @@ jobs:
         env:
           SEED_ORGANIZATION: ${{ inputs.seed_organization }}
         run: |
+          run_seed() {
+            if [ "$SEED_ORGANIZATION" = "all" ]; then
+              railway run --service cio-api -- env DATABASE_URL="$PUBLIC_DB_URL" pnpm --filter @cio/db db:setup:seed
+            else
+              railway run --service cio-api -- env DATABASE_URL="$PUBLIC_DB_URL" pnpm --filter @cio/db db:setup:seed -- --organization "$SEED_ORGANIZATION"
+            fi
+          }
+
           PUBLIC_DB_URL=$(railway variables --service Postgres --kv | grep '^DATABASE_PUBLIC_URL=' | cut -d= -f2-)
           if [ -z "$PUBLIC_DB_URL" ]; then
             echo "::warning::Postgres has no DATABASE_PUBLIC_URL in this environment — skipping $SEED_ORGANIZATION seed; only essential seed ran on api boot."
             echo "status=skipped" >> "$GITHUB_OUTPUT"
           else
-            if railway run --service cio-api -- env DATABASE_URL="$PUBLIC_DB_URL" pnpm --filter @cio/db db:setup:seed -- --organization "$SEED_ORGANIZATION"; then
+            if run_seed; then
               echo "status=seeded" >> "$GITHUB_OUTPUT"
             else
               echo "$SEED_ORGANIZATION seed failed (likely DB not reachable from runner) — migrations + essential seed still ran on api boot."


### PR DESCRIPTION
## What does this PR do?

Adds an all option to the Railway preview demo-data picker.

- all runs the existing full seed without an organization selector.
- individual organization choices remain scoped.
- none continues to skip demo seeding.
- the picker and seed step labels now describe demo data rather than only one organization.

This PR changes .github/workflows/railway-preview.yml.

## Demo

Not applicable; this is a workflow input change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Dispatch Railway Preview Environment with seed_organization set to all.
- Verify the full demo dataset is seeded and the summary reports all as seeded.
- Verify individual organization choices and none retain their existing behavior.
- Parse the workflow YAML and run pnpm format:check.

## Checklist

### Required

- [x] Filled out the How to test section in this PR
- [x] Self-reviewed my own code
- [x] Commented on hard-to-understand workflow branching
- [ ] Ran pnpm build
- [ ] Checked for warnings, there are none
- [x] Removed unrelated console logs
- [x] Based the branch on latest main
- [x] My changes do not cause responsiveness issues
- [x] Workflow changes are called out above

### Appreciated

- [x] No UI change was made, so screenshots are not applicable
- [x] No documentation update was necessary

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an `all` choice to Railway preview demo-data seeding while preserving scoped organization and skip behavior.

- Runs the existing unscoped full seed when `all` is selected.
- Retains organization-specific seeding for individual choices.
- Generalizes workflow labels from organization seeding to demo-data seeding.

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge with no actionable defects identified.

The new `all` branch invokes the seed command’s documented no-selector behavior, which runs the full dataset, while individual organization choices retain their previous command and status handling.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/railway-preview.yml | Adds the full-seed choice and correctly branches between the established unscoped and organization-scoped seed commands. |

<sub>Reviews (1): Last reviewed commit: ["feat(ci): allow seeding all preview orga..."](https://github.com/classroomio/classroomio/commit/821fd928c135c32fa0bcf9660f0c719698c96566) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56457442)</sub>

<!-- /greptile_comment -->