### PR TITLE
fix: pass active plan into normalizeWidgetConfig on publish

### DIFF
--- a/apps/api/src/services/widget.ts
+++ b/apps/api/src/services/widget.ts
@@ -204,7 +204,7 @@ export async function deleteOrganizationWidget(orgId: string, widgetId: string, 
 
 export async function publishOrganizationWidget(orgId: string, widgetId: string, userId: string) {
   try {
-    const widget = await getWidgetById(orgId, widgetId);
+    const [widget, activePlan] = await Promise.all([getWidgetById(orgId, widgetId), getActiveOrganizationPlan(orgId)]);
     if (!widget) {
       throw new AppError('Widget not found', ErrorCodes.WIDGET_NOT_FOUND, 404);
     }
@@ -214,7 +214,7 @@ export async function publishOrganizationWidget(orgId: string, widgetId: string,
     const version = await createWidgetVersion({
       widgetId: widget.id,
       version: nextVersion,
-      configSnapshot: normalizeWidgetConfig(widget.config as Record<string, unknown>),
+      configSnapshot: normalizeWidgetConfig(widget.config as Record<string, unknown>, activePlan?.planName ?? null),
       payloadSnapshot: payload,
       runtimeManifest: {
         version: 'v1',


### PR DESCRIPTION
`publishOrganizationWidget` in `apps/api/src/services/widget.ts` calls `normalizeWidgetConfig(widget.config)` with no plan name. `normalizeWidgetConfig`'s second argument controls `canUseCustomColors`/`canUseCustomCss`, and omitting it means those are always forced `false`. Every publish stamped the version's `configSnapshot` with free-plan colors/CSS, even for paid orgs.

`updateOrganizationWidget` a few lines above already does this correctly, fetching `getActiveOrganizationPlan(orgId)` and passing `activePlan?.planName ?? null`. This applies the same pattern to `publishOrganizationWidget`.

Fixes #970

No test added: no existing test exercises `publishOrganizationWidget` or the other widget service functions directly (the widget test files only cover the pure validation layer), and mocking the DB query layer for one function felt disproportionate to a 6-line fix.

Verified `pnpm --filter @cio/api build` and `pnpm format:check` pass.


## Demo
[Video recording](https://www.awesomescreenshot.com/video/56096639?key=b425cbf1263f2d57532602205bbbff67)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Widget publishing now applies the active plan when normalizing configuration and creating version snapshots.
- Published widget versions consistently reflect plan-based configuration.
- If no active plan is available, the published configuration now uses a clear default value instead of relying on plan-independent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes paid-plan widget publishing by passing the active organization plan into configuration normalization.
- Fetches the widget and active plan concurrently during publishing.
- Preserves paid-plan custom colors and CSS in the published version’s configuration snapshot.
- Aligns snapshot normalization with the existing payload-building path.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/services/widget.ts | Publishing now normalizes the configuration snapshot using the active organization plan, matching the existing plan-aware payload behavior. |

<sub>Reviews (2): Last reviewed commit: ["fix: pass active plan into normalizeWidg..."](https://github.com/classroomio/classroomio/commit/d1df8b9547263d9e7f01f0cfccf6914dcc152b96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56670891)</sub>

<!-- /greptile_comment -->