### PR TITLE
fix(tenant-router): stop caching asset failures for a year

### DIFF
--- a/apps/tenant-router/src/index.ts
+++ b/apps/tenant-router/src/index.ts
@@ -346,20 +346,30 @@ export default {
     // `Cache-Control` header on the response alone does NOT, so without this a
     // cold browser cache (new device, or post-deploy hash change) stampedes the
     // origin for every chunk.
+    //
+    // Deliberately NO `cacheTtl`: it caches the response "regardless of what
+    // headers are seen on the response", which includes 404s and 5xx. A chunk
+    // request that lands on a draining instance mid-deploy would then be pinned
+    // as missing for a year, breaking every page that needs it. Both upstreams
+    // already send the right thing on success (`immutable` for chunks,
+    // `max-age=3600` for OG images) and something short or absent on failure,
+    // so honoring origin headers gives us edge caching without pinning errors.
     const isImmutableAsset = url.pathname.startsWith('/_app/immutable/');
-    const edgeCacheTtl = isImmutableAsset ? 31536000 : isOrgSiteOgImage ? 3600 : undefined;
+    const shouldEdgeCache = isImmutableAsset || isOrgSiteOgImage;
 
     const upstreamResponse = await fetch(upstreamUrl.toString(), {
       method: request.method,
       headers: upstreamHeaders,
       body: request.body,
       redirect: 'manual',
-      cf: edgeCacheTtl ? { cacheEverything: true, cacheTtl: edgeCacheTtl } : undefined
+      cf: shouldEdgeCache ? { cacheEverything: true } : undefined
     });
 
     if (isImmutableAsset) {
       const response = new Response(upstreamResponse.body, upstreamResponse);
-      response.headers.set('Cache-Control', 'public, max-age=31536000, immutable');
+      // Only a real chunk is immutable. Telling the browser to keep a 404 for a
+      // year is unrecoverable without a hard reload.
+      response.headers.set('Cache-Control', upstreamResponse.ok ? 'public, max-age=31536000, immutable' : 'no-store');
       return response;
     }
 


### PR DESCRIPTION
## Problem

`cf: { cacheTtl }` caches a response ["regardless of what headers are seen on
the response"](https://developers.cloudflare.com/workers/runtime-apis/request/) —
including 404s and 5xx. Paired with an unconditional
`Cache-Control: public, max-age=31536000, immutable` rewrite, a single failed
request under `/_app/immutable/` gets pinned as missing **for a year**, both at
the Cloudflare edge and in every browser that received it.

Verified against production, using a path that has never existed:

```
1st  GET /_app/immutable/chunks/ZZnotreal1787656015.js
     404   cf-cache-status: MISS   cache-control: public, max-age=31536000, immutable
2nd  404   cf-cache-status: HIT    ← poisoned at the edge for every user
3rd  404   cf-cache-status: HIT
```

A chunk request landing on a draining Render instance mid-deploy is enough to
trigger it. The failure mode is nasty:

- The document returns **200**, so nothing looks broken at the route level.
- A required chunk 404s, so the page never hydrates.
- The request is served from cache, so **the origin never sees it again** —
  nothing appears in Render's logs to point at.
- Pages needing a different chunk set (like `/`) keep working, which makes it
  look route-specific rather than cache-specific.

The OG image path had the same bug at lower severity: `cacheTtl: 3600` cached
its errors for an hour.

## Fix

Both upstreams already send correct headers on success *and* failure:

| path | success | failure |
| --- | --- | --- |
| `/_app/immutable/*` | `public,max-age=31536000,immutable` | 404 → `public, max-age=0, must-revalidate` |
| `/proxy/org-site/og/*` | `public, max-age=3600, stale-while-revalidate=86400` | 302 → no `Cache-Control` |

So `cacheEverything` alone gives identical edge caching on the happy path while
letting failures expire naturally. Drop `cacheTtl`, keep `cacheEverything`, and
gate the browser-facing rewrite on `upstreamResponse.ok` — sending `no-store`
otherwise.

`cacheTtlByStatus` would be the more direct swap, but its plan availability is
murky ([historically Enterprise-only](https://community.cloudflare.com/t/is-cachettlbystatus-still-enterprise-only/361813),
and current docs no longer say so), and honoring origin headers needs no plan
feature at all.

## After merge — deploy + purge

Cloudflare **Workers Builds** is wired to this repo through the Git integration
(not through `.github/workflows`, so it is invisible to a workflow search — my
earlier claim that nothing in CI deploys this Worker was wrong). It already
built `cio-tenant-router` from this branch.

Branch builds do **not** reach production: probing production after this branch
built still returns the old behaviour, so the bug is live until merge.

```
GET /_app/immutable/chunks/ZZprobe1787671291.js
404   cf-cache-status: MISS   cache-control: public, max-age=31536000, immutable
```

So after merging:

1. **Check whether Workers Builds already deployed it** from `main` before
   running `pnpm --filter @cio/tenant-router deploy` by hand — given it builds
   branches, a push to `main` very likely deploys on its own.
2. **Purge `/_app/immutable/*` in Cloudflare.** This step is required either
   way; deploying the Worker does not evict 404s already sitting in the edge
   cache.

Users who already received a poisoned 404 still hold it in their own browser
cache for up to a year — `no-store` only protects them going forward. A hard
reload clears it.

## Verification

- `pnpm --filter @cio/tenant-router typecheck` ✅
- `pnpm format:check` ✅
- Behaviour confirmed against production before the change (transcript above)

Re-run the same three-request probe after deploying: the 404 should come back
`no-store` and stay `MISS`.

## Scope

This is a real, reproducible bug, but it is **not** the cause of the SSR hang in
#972 — a cached 404 breaks hydration while still painting the server-rendered
markup, whereas that issue leaves the document pending with nothing painted.
Kept separate so that one can be reverted without losing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR stops forcing fixed Cloudflare TTLs for immutable dashboard assets and organization-site OG images so edge caching can respect upstream response headers. It also limits year-long browser caching to successful immutable-asset responses and marks failures `no-store`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and directly narrows caching of failed asset responses without changing successful-response cache policy.

Successful immutable assets and OG images retain their intended cache headers, while immutable-asset failures now receive `no-store` and edge caching relies on upstream headers instead of unconditional fixed TTLs.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/tenant-router/src/index.ts | Removes forced edge TTLs and prevents non-successful immutable-asset responses from being cached by browsers; no actionable regression was established. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  R[Asset or OG request] --> F[Fetch upstream with cacheEverything]
  F --> H{Immutable asset?}
  H -->|Yes| O{Upstream response OK?}
  O -->|Yes| I[Return immutable one-year Cache-Control]
  O -->|No| N[Return Cache-Control: no-store]
  H -->|No| G{Successful OG image?}
  G -->|Yes| C[Return one-hour Cache-Control with stale-while-revalidate]
  G -->|No| U[Return upstream response unchanged]
```

<sub>Reviews (1): Last reviewed commit: ["fix(tenant-router): stop caching asset f..."](https://github.com/classroomio/classroomio/commit/78ee5ffc8480094e5036a4b3cff9b2504b86ed27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56683715)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edge caching for immutable assets and organization-site preview images.
  * Failed asset requests are no longer cached, preventing stale error responses.
  * Successful immutable assets retain long-term caching, while other responses now follow origin cache directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
