### PR TITLE
ci: require CLA verification for new contributors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,6 +41,7 @@ Fixes # (place issue number here without bracket)
 - [ ] Removed all `console.logs`
 - [ ] Merged the latest changes from main onto my branch with `git pull origin main`
 - [ ] My changes don't cause any responsiveness issues
+- [ ] If this is my first contribution, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
 - [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description
 
 ### Appreciated

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,7 +41,7 @@ Fixes # (place issue number here without bracket)
 - [ ] Removed all `console.logs`
 - [ ] Merged the latest changes from main onto my branch with `git pull origin main`
 - [ ] My changes don't cause any responsiveness issues
-- [ ] If this is my first contribution, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
+- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
 - [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description
 
 ### Appreciated

--- a/.github/workflows/contributor-license-agreement.yml
+++ b/.github/workflows/contributor-license-agreement.yml
@@ -14,6 +14,7 @@ on:
       - unlabeled
 
 permissions:
+  actions: write
   contents: none
   issues: write
   pull-requests: read
@@ -32,6 +33,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const authorizedSigner = 'rotimi-best';
             const signatureLabel = 'cla: signed';
             const signatureRequiredLabel = 'sign-cla-required';
             const commentMarker = '<!-- classroomio-cla-check -->';
@@ -40,8 +42,46 @@ jobs:
               pullRequest.labels.map((label) => label.name)
             );
             const hasSignedLabel = pullRequestLabels.has(signatureLabel);
+            const labelEvents = await github.paginate(
+              github.rest.issues.listEvents,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                per_page: 100,
+              }
+            );
+            let signatureAppliedBy = null;
 
-            if (hasSignedLabel) {
+            for (const labelEvent of labelEvents) {
+              if (labelEvent.label?.name !== signatureLabel) continue;
+
+              if (labelEvent.event === 'labeled') {
+                signatureAppliedBy = labelEvent.actor?.login ?? null;
+              } else if (labelEvent.event === 'unlabeled') {
+                signatureAppliedBy = null;
+              }
+            }
+
+            const hasAuthorizedSignature =
+              hasSignedLabel && signatureAppliedBy === authorizedSigner;
+
+            if (hasSignedLabel && !hasAuthorizedSignature) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                name: signatureLabel,
+              });
+
+              core.setFailed(
+                `Only @${authorizedSigner} can verify the contributor license agreement.`
+              );
+
+              return;
+            }
+
+            if (hasAuthorizedSignature) {
               if (pullRequestLabels.has(signatureRequiredLabel)) {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
@@ -51,7 +91,33 @@ jobs:
                 });
               }
 
-              core.notice('A maintainer has verified the contributor license agreement.');
+              const pullRequestWorkflowRuns = await github.paginate(
+                github.rest.actions.listWorkflowRunsForRepo,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  event: 'pull_request',
+                  head_sha: pullRequest.head.sha,
+                  per_page: 100,
+                }
+              );
+              const workflowRunsAwaitingApproval = pullRequestWorkflowRuns.filter(
+                (workflowRun) =>
+                  workflowRun.status === 'action_required' ||
+                  workflowRun.conclusion === 'action_required'
+              );
+
+              for (const workflowRun of workflowRunsAwaitingApproval) {
+                await github.rest.actions.approveWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: workflowRun.id,
+                });
+              }
+
+              core.notice(
+                `@${authorizedSigner} verified the contributor license agreement. Approved ${workflowRunsAwaitingApproval.length} CI workflow run(s).`
+              );
 
               return;
             }
@@ -68,7 +134,7 @@ jobs:
             const commentBody = `${commentMarker}
             Thanks for contributing to ClassroomIO, @${pullRequest.user.login}! Because this is a first-time or external contribution, please sign the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7) before it can be merged.
 
-            This pull request has been labeled \`${signatureRequiredLabel}\`. After you submit the form, a maintainer will verify it and add the \`${signatureLabel}\` label. The required label will be removed and this check will pass automatically.`;
+            This pull request has been labeled \`${signatureRequiredLabel}\`. After you submit the form, @${authorizedSigner} will verify it and add the \`${signatureLabel}\` label. The required label will be removed, this check will pass, and the held CI workflows will be approved automatically.`;
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -97,5 +163,5 @@ jobs:
             }
 
             core.setFailed(
-              `The contributor license agreement has not been verified. A maintainer must add the "${signatureLabel}" label after checking the form submission.`
+              `The contributor license agreement has not been verified. @${authorizedSigner} must add the "${signatureLabel}" label after checking the form submission.`
             );

--- a/.github/workflows/contributor-license-agreement.yml
+++ b/.github/workflows/contributor-license-agreement.yml
@@ -1,0 +1,81 @@
+name: Contributor License Agreement
+
+# pull_request_target is used so the check can comment on pull requests from forks.
+# SAFE ONLY because this workflow never checks out or executes pull request code.
+# Do not add actions/checkout, pnpm install, build, or cache steps here.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: none
+  issues: write
+  pull-requests: read
+
+jobs:
+  cla:
+    name: CLA signed
+    if: >-
+      github.event.pull_request.user.type != 'Bot' &&
+      contains(fromJSON('["FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "NONE"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check contributor license agreement
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const signatureLabel = 'cla: signed';
+            const commentMarker = '<!-- classroomio-cla-check -->';
+            const pullRequest = context.payload.pull_request;
+            const hasSignedLabel = pullRequest.labels.some(
+              (label) => label.name === signatureLabel
+            );
+
+            if (hasSignedLabel) {
+              core.notice('A maintainer has verified the contributor license agreement.');
+
+              return;
+            }
+
+            const commentBody = `${commentMarker}
+            Thanks for contributing to ClassroomIO, @${pullRequest.user.login}! Before we can merge your first contribution, please sign the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7).
+
+            After you submit the form, a maintainer will verify it and add the \`${signatureLabel}\` label to this pull request. This check will then pass automatically.`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequest.number,
+              per_page: 100,
+            });
+            const existingComment = comments.find(
+              (comment) =>
+                comment.user.type === 'Bot' && comment.body.includes(commentMarker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: commentBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                body: commentBody,
+              });
+            }
+
+            core.setFailed(
+              `The contributor license agreement has not been verified. A maintainer must add the "${signatureLabel}" label after checking the form submission.`
+            );

--- a/.github/workflows/contributor-license-agreement.yml
+++ b/.github/workflows/contributor-license-agreement.yml
@@ -33,22 +33,42 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const signatureLabel = 'cla: signed';
+            const signatureRequiredLabel = 'sign-cla-required';
             const commentMarker = '<!-- classroomio-cla-check -->';
             const pullRequest = context.payload.pull_request;
-            const hasSignedLabel = pullRequest.labels.some(
-              (label) => label.name === signatureLabel
+            const pullRequestLabels = new Set(
+              pullRequest.labels.map((label) => label.name)
             );
+            const hasSignedLabel = pullRequestLabels.has(signatureLabel);
 
             if (hasSignedLabel) {
+              if (pullRequestLabels.has(signatureRequiredLabel)) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullRequest.number,
+                  name: signatureRequiredLabel,
+                });
+              }
+
               core.notice('A maintainer has verified the contributor license agreement.');
 
               return;
             }
 
+            if (!pullRequestLabels.has(signatureRequiredLabel)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                labels: [signatureRequiredLabel],
+              });
+            }
+
             const commentBody = `${commentMarker}
             Thanks for contributing to ClassroomIO, @${pullRequest.user.login}! Before we can merge your first contribution, please sign the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7).
 
-            After you submit the form, a maintainer will verify it and add the \`${signatureLabel}\` label to this pull request. This check will then pass automatically.`;
+            This pull request has been labeled \`${signatureRequiredLabel}\`. After you submit the form, a maintainer will verify it and add the \`${signatureLabel}\` label. The required label will be removed and this check will pass automatically.`;
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/contributor-license-agreement.yml
+++ b/.github/workflows/contributor-license-agreement.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Check contributor license agreement
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -66,7 +66,7 @@ jobs:
             }
 
             const commentBody = `${commentMarker}
-            Thanks for contributing to ClassroomIO, @${pullRequest.user.login}! Before we can merge your first contribution, please sign the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7).
+            Thanks for contributing to ClassroomIO, @${pullRequest.user.login}! Because this is a first-time or external contribution, please sign the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7) before it can be merged.
 
             This pull request has been labeled \`${signatureRequiredLabel}\`. After you submit the form, a maintainer will verify it and add the \`${signatureLabel}\` label. The required label will be removed and this check will pass automatically.`;
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We invite innovative minds to contribute to the evolution of ClassroomIO. If you
 
 Ready to dive into the code and make a real impact? Here's your path:
 
-1. **Sign the Contributor License Agreement:** Before your first contribution can be merged, sign the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7). Our pull request workflow will remind new contributors and wait for a maintainer to verify the submission.
+1. **Sign the Contributor License Agreement:** If you are a first-time or external contributor, sign the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7) before your contribution can be merged. Our pull request workflow will remind you and wait for a maintainer to verify the submission.
 
 2. **Fork the Repository:** Fork our repository
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,17 +14,23 @@ We invite innovative minds to contribute to the evolution of ClassroomIO. If you
 
 Ready to dive into the code and make a real impact? Here's your path:
 
-1. **Fork the Repository:** Fork our repository
+1. **Sign the Contributor License Agreement:** Before your first contribution can be merged, sign the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7). Our pull request workflow will remind new contributors and wait for a maintainer to verify the submission.
 
-2. **Implementation:** Code it out, test it and apply your changes.
+2. **Fork the Repository:** Fork our repository
 
-3. **Pull Request:** If you're ready to go, create a new pull request following our PR template
+3. **Implementation:** Code it out, test it and apply your changes.
+
+4. **Pull Request:** If you're ready to go, create a new pull request following our PR template
 
 Would you prefer a chat before you dive into a lot of work? Our [Discord server](https://dub.sh/ciodiscord) is your harbor. Share your thoughts, and we'll meet you there with open arms. We're responsive and friendly, promise!
 
 ## Dependency and workflow changes
 
 PRs that touch `pnpm-lock.yaml`, `.github/workflows/**`, or npm publish config get extra review. Prefer the smallest lockfile diff that matches your change, and do not add `pull_request_target` workflows that check out or build untrusted PR code.
+
+### Verifying contributor license agreements
+
+When the Contributor License Agreement check fails, compare the pull request author's GitHub username with the submitted form responses. After confirming their submission, add the `cla: signed` label to the pull request. Repository administrators should make the `Contributor License Agreement / CLA signed` status check required in the branch ruleset for `main` so an unverified contribution cannot be merged.
 
 ## Features
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ PRs that touch `pnpm-lock.yaml`, `.github/workflows/**`, or npm publish config g
 
 ### Verifying contributor license agreements
 
-When the Contributor License Agreement check fails, compare the pull request author's GitHub username with the submitted form responses. After confirming their submission, add the `cla: signed` label to the pull request. Repository administrators should make the `Contributor License Agreement / CLA signed` status check required in the branch ruleset for `main` so an unverified contribution cannot be merged.
+The Contributor License Agreement workflow adds the `sign-cla-required` label while a new contributor's signature is outstanding. When the check fails, compare the pull request author's GitHub username with the submitted form responses. After confirming their submission, add the `cla: signed` label to the pull request; the workflow will remove `sign-cla-required` automatically. Repository administrators should make the `Contributor License Agreement / CLA signed` status check required in the branch ruleset for `main` so an unverified contribution cannot be merged.
 
 ## Features
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ PRs that touch `pnpm-lock.yaml`, `.github/workflows/**`, or npm publish config g
 
 ### Verifying contributor license agreements
 
-The Contributor License Agreement workflow adds the `sign-cla-required` label while a new contributor's signature is outstanding. When the check fails, compare the pull request author's GitHub username with the submitted form responses. After confirming their submission, add the `cla: signed` label to the pull request; the workflow will remove `sign-cla-required` automatically. Repository administrators should make the `Contributor License Agreement / CLA signed` status check required in the branch ruleset for `main` so an unverified contribution cannot be merged.
+The Contributor License Agreement workflow adds the `sign-cla-required` label while a new contributor's signature is outstanding. Only [@rotimi-best](https://github.com/rotimi-best) is authorized to verify submissions and add the `cla: signed` label; unauthorized applications are removed automatically. After `cla: signed` is applied, the workflow removes `sign-cla-required`, passes the CLA check, and approves the contributor's held CI workflow runs. Repository administrators should make the `Contributor License Agreement / CLA signed` status check required in the branch ruleset for `main` so an unverified contribution cannot be merged.
 
 ## Features
 


### PR DESCRIPTION
## Summary

- add a fork-safe CLA status check for first-time and external contributors
- automatically apply sign-cla-required while a signature is outstanding
- accept cla: signed only when it was applied by rotimi-best
- remove unauthorized cla: signed applications automatically
- approve held pull-request CI runs after authorized CLA verification
- remove sign-cla-required after verification
- direct contributors to the ClassroomIO Contributor License Agreement
- document the maintainer verification flow

## Testing

- pnpm format:changed
- pnpm format:check
- git diff --check
- parsed the workflow YAML and embedded GitHub Script JavaScript
- exercised unsigned, unauthorized signer, and authorized signer paths with mocked GitHub API calls
- verified authorized approval releases only action_required workflow runs