### PR TITLE
feat(ui): add required prop to Label to auto-render asterisk

### DIFF
--- a/packages/storybook/src/atoms/label/fields.ts
+++ b/packages/storybook/src/atoms/label/fields.ts
@@ -1,1 +1,1 @@
-export const FIELDS = ['children', 'child'] as string[];
+export const FIELDS = ['children', 'child', 'required'] as string[];

--- a/packages/storybook/src/atoms/label/label.stories.svelte
+++ b/packages/storybook/src/atoms/label/label.stories.svelte
@@ -35,11 +35,14 @@
 <Story name="Required">
   {#snippet template()}
     <div class="grid w-full max-w-sm items-center gap-1.5">
-      <Label for="username">
-        Username
-        <span class="text-red-500">*</span>
-      </Label>
+      <Label for="username" required>Username</Label>
       <Input id="username" placeholder="Username" required />
     </div>
+  {/snippet}
+</Story>
+
+<Story name="Required Without Input">
+  {#snippet template()}
+    <Label required>Email</Label>
   {/snippet}
 </Story>

--- a/packages/ui/src/base/label/label.svelte
+++ b/packages/ui/src/base/label/label.svelte
@@ -2,7 +2,11 @@
   import { Label as LabelPrimitive } from 'bits-ui';
   import { cn } from '../../tools';
 
-  let { ref = $bindable(null), class: className, ...restProps }: LabelPrimitive.RootProps = $props();
+  interface Props extends LabelPrimitive.RootProps {
+    required?: boolean;
+  }
+
+  let { ref = $bindable(null), class: className, children, required = false, ...restProps }: Props = $props();
 </script>
 
 <LabelPrimitive.Root
@@ -13,4 +17,9 @@
     className
   )}
   {...restProps}
-/>
+>
+  {@render children?.()}
+  {#if required}
+    <span class="ui:text-red-700" aria-hidden="true">*</span>
+  {/if}
+</LabelPrimitive.Root>

--- a/packages/ui/src/custom/input-field/input-field.svelte
+++ b/packages/ui/src/custom/input-field/input-field.svelte
@@ -77,11 +77,8 @@
 <Field.Field class={className}>
   {#if label}
     <div class="ui:flex ui:items-center ui:justify-between">
-      <Field.Label for={name || 'input-field'} class={labelClassName}>
+      <Field.Label for={name || 'input-field'} class={labelClassName} required={isRequired}>
         {label}
-        {#if isRequired}
-          <span class="ui:text-red-700">*</span>
-        {/if}
       </Field.Label>
       {@render labelAction?.()}
     </div>


### PR DESCRIPTION
## What does this PR do?

Adds an optional `required` prop to the base.
When set, a red asterisk is rendered after the label text, so callers no longer need
to hand-code the indicator:


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #784 

## Demo

<!-- Please upload a video here or attach a link to a video player like Awesome Screenshot or Loom to show the change in action. This speeds up reviews, especially for visual changes. -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

In code, render < Label required >Email</ Label > and verify normal labels without
the prop are unchanged (no asterisk, text renders as before).

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional visual required-field indicator to the shared Label component.
- Extends the Label props with an optional `required` boolean.
- Renders an aria-hidden red asterisk after label content when enabled.
- Updates Storybook fields and stories to demonstrate required labels.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The shared Label preserves ordinary rendering while conditionally adding the documented visual indicator, and the accompanying stories exercise both required and unchanged label states.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/base/label/label.svelte | Adds explicit child rendering and an optional visual required marker without an identified correctness issue. |
| packages/storybook/src/atoms/label/label.stories.svelte | Replaces the manually rendered asterisk and adds a standalone required-label example. |
| packages/storybook/src/atoms/label/fields.ts | Exposes the new required prop in the Storybook field configuration. |

<sub>Reviews (1): Last reviewed commit: ["Added asterisk to the Label component"](https://github.com/classroomio/classroomio/commit/5e5a504d393a2180603ab74febe1af863589dcb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57016821)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Labels can now be marked as required using a dedicated property.
  * Required labels automatically display a red asterisk, with the indicator hidden from screen readers for improved accessibility.
  * Required labels can be used with or without an associated input.
  * Required indicators are now applied consistently across input fields and standalone labels.
* **Documentation**
  * Added examples demonstrating required labels in connected and standalone scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->