### PR TITLE
ci: add advisory needs-docs-review label workflow

### DIFF
--- a/.github/docs-review/globs.yml
+++ b/.github/docs-review/globs.yml
@@ -1,0 +1,18 @@
+# Source of truth for "does this PR touch the user-facing product surface."
+# Read by .github/workflows/docs-label.yml via dorny/paths-filter.
+#
+# apps/api/** is deliberately not here: the API reference is generated from
+# the OpenAPI spec (see upload-openapi-spec.yml), so it can't go stale the
+# way hand-written docs can. Adding it here would just create noise.
+user_facing:
+  - 'apps/dashboard/src/routes/**/+page.svelte'
+  - 'apps/dashboard/src/routes/**/+layout.svelte'
+  - 'apps/dashboard/src/lib/features/ui/navigation/*.ts'
+  - 'apps/dashboard/src/lib/features/**/components/**'
+  - 'apps/dashboard/src/lib/features/**/pages/**'
+  - 'apps/dashboard/src/lib/components/**'
+  - 'packages/ui/src/custom/**' # not src/base, primitives are too low-signal
+  - 'apps/dashboard/src/lib/utils/translations/en.json' # source copy only, not translations
+  - '!**/*.test.ts'
+  - '!**/*.spec.ts'
+  - '!**/*.stories.*'

--- a/.github/workflows/docs-label.yml
+++ b/.github/workflows/docs-label.yml
@@ -1,0 +1,118 @@
+name: Docs review label
+
+# pull_request_target so labeling/commenting works on fork PRs (plain
+# pull_request gives forks a read-only token). Safe here because we only
+# check out the base branch to read the glob config below, never PR head
+# code.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  docs-label:
+    name: Check for user-facing changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: .github/docs-review/globs.yml
+
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const label = 'needs-docs-review';
+            const marker = '<!-- classroomio-docs-review -->';
+            const guideUrl = `https://github.com/${{ github.repository }}/blob/main/apps/docs/CONTRIBUTING.md`;
+            const pr = context.payload.pull_request;
+            const isUserFacing = '${{ steps.filter.outputs.user_facing }}' === 'true';
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+            const existingComment = comments.find(
+              (c) => c.user.type === 'Bot' && c.body.includes(marker)
+            );
+
+            try {
+              const hasLabel = pr.labels.some((l) => l.name === label);
+
+              if (isUserFacing) {
+                if (!hasLabel) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    labels: [label],
+                  });
+                }
+
+                const body = `${marker}
+            This PR changes a route, nav item, component, or user-visible string, so it's labeled \`${label}\`.
+
+            Please add a [user guide, feature reference, or changelog line](${guideUrl}) before merging, whichever fits. If nothing here needs docs, a maintainer can remove the label.
+
+            This is advisory only. It won't block your merge.`;
+
+                if (existingComment) {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existingComment.id,
+                    body,
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    body,
+                  });
+                }
+
+                // TODO(make-blocking): change core.notice below to core.setFailed
+                // once `needs-docs-review` is a required status check. Don't add
+                // docs-validate.yml to required checks when you do this.
+                // See apps/docs/WORKFLOW.md.
+                core.notice('needs-docs-review applied.');
+              } else {
+                if (hasLabel) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    name: label,
+                  });
+                }
+
+                if (existingComment) {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existingComment.id,
+                    body: `${marker}\nThe user-facing changes that triggered this were removed. \`${label}\` no longer applies.`,
+                  });
+                }
+
+                core.notice('No user-facing changes.');
+              }
+            } catch (error) {
+              core.warning(`docs-label failed to update label/comment: ${error.message}`);
+            }

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -1,0 +1,51 @@
+name: Docs validate
+
+# Plain pull_request, not pull_request_target: this job lints real PR-head
+# content, which is a different risk profile than checking out and running
+# PR code. Fork PRs get a read-only token, so we report via check
+# annotations instead of a PR comment.
+#
+# Scoped to apps/docs/**, so this never runs on code-only PRs. Advisory
+# only. Never add this to branch protection's required checks: a
+# path-filtered required check that never runs on some PRs leaves those
+# PRs stuck pending forever. See apps/docs/WORKFLOW.md.
+
+on:
+  pull_request:
+    paths:
+      - 'apps/docs/**'
+      - '.github/workflows/docs-validate.yml'
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  validate:
+    name: Lint docs content
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: blume validate
+        continue-on-error: true
+        run: pnpm --filter @cio/docs validate
+
+      - name: Vale
+        continue-on-error: true
+        uses: errata-ai/vale-action@v2
+        with:
+          files: apps/docs/content/docs
+          vale_flags: '--config=apps/docs/.vale.ini'
+          reporter: github-pr-check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -1,9 +1,9 @@
 name: Docs validate
 
-# Plain pull_request, not pull_request_target: this job lints real PR-head
-# content, which is a different risk profile than checking out and running
-# PR code. Fork PRs get a read-only token, so we report via check
-# annotations instead of a PR comment.
+# Uses pull_request_target so fork PRs get a write-capable token to publish
+# Vale check annotations. The workflow file itself runs from the base branch
+# (safe from injection), while we explicitly check out the PR head to lint
+# the correct docs content.
 #
 # Scoped to apps/docs/**, so this never runs on code-only PRs. Advisory
 # only. Never add this to branch protection's required checks: a
@@ -11,7 +11,7 @@ name: Docs validate
 # PRs stuck pending forever. See apps/docs/WORKFLOW.md.
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'apps/docs/**'
       - '.github/workflows/docs-validate.yml'
@@ -26,6 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -1,17 +1,24 @@
 name: Docs validate
 
-# Uses pull_request_target so fork PRs get a write-capable token to publish
-# Vale check annotations. The workflow file itself runs from the base branch
-# (safe from injection), while we explicitly check out the PR head to lint
-# the correct docs content.
+# Plain pull_request, not pull_request_target: this job checks out and runs
+# PR-head content (pnpm install, blume, Vale), which pull_request_target
+# must never do — that trigger runs with a repo-write token even for fork
+# PRs, and executing untrusted install scripts there is a real hole (see
+# root CONTRIBUTING.md's warning against pull_request_target workflows that
+# check out or build PR code).
+#
+# Trade-off of staying on plain pull_request: fork PRs get a read-only
+# token, so Vale's github-pr-check reporter can't publish annotations there
+# (continue-on-error hides the failure). Same-repo PRs are unaffected.
+# Known v1 limitation, not fixed here — see apps/docs/WORKFLOW.md.
 #
 # Scoped to apps/docs/**, so this never runs on code-only PRs. Advisory
 # only. Never add this to branch protection's required checks: a
 # path-filtered required check that never runs on some PRs leaves those
-# PRs stuck pending forever. See apps/docs/WORKFLOW.md.
+# PRs stuck pending forever.
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'apps/docs/**'
       - '.github/workflows/docs-validate.yml'
@@ -26,9 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
 
       - uses: pnpm/action-setup@v4
 

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -15,3 +15,6 @@ node_modules
 # Fetched at build time by scripts/fetch-openapi.mjs.
 /openapi/
 .blume-verify/
+
+# Vale style packages, fetched by `vale sync`.
+/styles/

--- a/apps/docs/.vale.ini
+++ b/apps/docs/.vale.ini
@@ -1,0 +1,13 @@
+# Advisory prose linter. Every rule is capped at "warning" so this can
+# never fail a build. v1 uses the off-the-shelf styles only. The
+# task-first-heading rule in CONTRIBUTING.md isn't linted yet, see
+# apps/docs/WORKFLOW.md.
+
+StylesPath = styles
+MinAlertLevel = suggestion
+Packages = Google, write-good
+
+[*.mdx]
+BasedOnStyles = Google, write-good
+Google.* = warning
+write-good.* = warning

--- a/apps/docs/CONTRIBUTING.md
+++ b/apps/docs/CONTRIBUTING.md
@@ -42,6 +42,28 @@ So in practice, "prefer a description" means the page's own opening line does th
 - **Self-Hosting**: running ClassroomIO on your own infrastructure.
 - **API**: the OpenAPI reference, generated. Don't hand-write pages here.
 
+## Documentation types
+
+Every page is one of three types:
+
+- **User guide**: task-based, "how to do X." Help Center, or Developers for contributor and integrator tasks.
+- **Feature reference**: what something is and how it behaves. Features (Platform tab) or the relevant Developers section.
+- **Changelog entry**: one line, no page.
+
+If a change doesn't cleanly fit a user guide or a feature reference, it gets a changelog line, not a page. Most PRs that touch the product surface warrant a line, not a new file.
+
+The API reference is generated from the OpenAPI spec (`upload-openapi-spec.yml` regenerates it on every push to `main`), so it sits outside this taxonomy. Never hand-write pages there.
+
+## Voice and style
+
+Second person, present tense. Headings name what the reader does, not the feature's internal name: "See your food," not "Food viewing feature."
+
+Vale (`docs-validate.yml`) checks prose for passive voice and wordiness on every PR touching `apps/docs/**`, advisory only. It doesn't check the heading rule above yet: that's still a review call, not a lint rule.
+
+## Staying current
+
+Give pages a `last_reviewed: YYYY-MM-DD` frontmatter field. Run `pnpm docs:check-stale` to list pages missing that date or older than 90 days.
+
 ## Before you move or rename a page
 
 - Navigation lives in exactly one place: `blume.config.ts`. Don't add a second sidebar or route list anywhere else.

--- a/apps/docs/WORKFLOW.md
+++ b/apps/docs/WORKFLOW.md
@@ -36,6 +36,10 @@ vale sync && vale content/docs
 pnpm docs:check-stale
 ```
 
+## Known limitation
+
+`docs-validate.yml` runs on plain `pull_request`, not `pull_request_target`, because it checks out and builds PR content, and doing that under `pull_request_target` would hand a repo-write token to whatever install scripts a PR's `package.json` declares (see the comment in that file). The cost: fork PRs get a read-only token, so Vale's `github-pr-check` reporter can't publish inline annotations there, and the step's `continue-on-error` hides that silently. Same-repo PRs are unaffected. Fixing this properly means a `pull_request` job that safely lints PR content and saves the results as an artifact, plus a separate `workflow_run` job with elevated permissions that only reads that artifact and posts the annotations, never touching PR code. Worth doing if fork contributions to `apps/docs` become common; not built now.
+
 ## Deferred for later
 
 - A Vale rule for the task-first-heading style. Google and write-good don't catch it.

--- a/apps/docs/WORKFLOW.md
+++ b/apps/docs/WORKFLOW.md
@@ -1,0 +1,42 @@
+# Docs-drift prevention
+
+Docs drift because the "does this need docs?" checklist defaults to "no," and ship mode leaves authors to self-assess. This replaces that self-assessment with automatic detection from the diff.
+
+## Two mechanisms
+
+The API reference is generated from the OpenAPI spec. `upload-openapi-spec.yml` regenerates and republishes it on every push to `main`, so it can't drift: there's nothing hand-written to forget.
+
+Everything else user-facing (routes, nav, components, copy) is hand-written and can drift. That's what `needs-docs-review` is for.
+
+`apps/api/**` should never end up in `.github/docs-review/globs.yml`. It would just relabel PRs whose docs already regenerate themselves.
+
+## The pieces
+
+| File | Does what |
+|---|---|
+| `.github/docs-review/globs.yml` | Defines "user-facing." Edit this to tune the label. |
+| `.github/workflows/docs-label.yml` | Labels/comments on PRs matching the globs. Advisory. |
+| `.github/workflows/docs-validate.yml` | Lints `apps/docs/**` PRs (links + prose). Advisory. |
+| `apps/docs/.vale.ini` | Vale config: Google + write-good, warnings only. |
+| `apps/docs/CONTRIBUTING.md` | Placement rules, doc types, voice/style. |
+| `apps/docs/scripts/check-stale-docs.mjs` | `pnpm docs:check-stale`: stale-page worklist. |
+
+## Making it blocking later
+
+`docs-label.yml` has a `TODO(make-blocking)` comment marking the one line to change. Don't add `docs-validate.yml` to required checks, ever: it's path-filtered to `apps/docs/**`, so a required check there would leave code-only PRs stuck pending forever.
+
+## Running things locally
+
+```
+cd apps/docs
+vale sync && vale content/docs
+```
+
+```
+pnpm docs:check-stale
+```
+
+## Deferred for later
+
+- A Vale rule for the task-first-heading style. Google and write-good don't catch it.
+- A scheduled bot that opens an issue from the staleness script instead of someone running it by hand.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,8 @@
     "build": "blume build && node scripts/package-assets.mjs",
     "preview": "pnpm run build && wrangler dev --port 4173",
     "deploy": "pnpm run build && wrangler deploy",
-    "validate": "blume validate"
+    "validate": "blume validate",
+    "check-stale": "node scripts/check-stale-docs.mjs"
   },
   "dependencies": {
     "@astrojs/mdx": "7.0.3",

--- a/apps/docs/scripts/check-stale-docs.mjs
+++ b/apps/docs/scripts/check-stale-docs.mjs
@@ -1,0 +1,67 @@
+/**
+ * Lists doc pages missing `last_reviewed` frontmatter or older than 90 days.
+ * Run by hand: `pnpm docs:check-stale`.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const content = resolve(root, 'content/docs');
+const STALE_AFTER_DAYS = 90;
+
+function findMdxFiles(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) return findMdxFiles(full);
+    return entry.isFile() && entry.name.endsWith('.mdx') ? [full] : [];
+  });
+}
+
+// Frontmatter here is flat key: value pairs, so a small regex is enough.
+// No need for a full YAML parser for one field.
+function parseFrontmatter(source) {
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+
+  const data = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const field = line.match(/^([A-Za-z0-9_]+):\s*(.*)$/);
+    if (field) data[field[1]] = field[2].trim().replace(/^["']|["']$/g, '');
+  }
+  return data;
+}
+
+function daysSince(dateString) {
+  const parsed = new Date(dateString);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return Math.floor((Date.now() - parsed.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+const stale = [];
+
+for (const file of findMdxFiles(content)) {
+  const data = parseFrontmatter(readFileSync(file, 'utf8'));
+  const path = relative(root, file);
+
+  if (!data.last_reviewed) {
+    stale.push({ path, reason: 'missing last_reviewed' });
+    continue;
+  }
+
+  const age = daysSince(data.last_reviewed);
+  if (age === null) {
+    stale.push({ path, reason: `unparseable last_reviewed: "${data.last_reviewed}"` });
+  } else if (age > STALE_AFTER_DAYS) {
+    stale.push({ path, reason: `last reviewed ${age} days ago` });
+  }
+}
+
+if (stale.length === 0) {
+  console.log('Nothing stale. Every page has a last_reviewed date within 90 days.');
+} else {
+  console.log(`${stale.length} page(s) need a look:\n`);
+  for (const { path, reason } of stale) {
+    console.log(`  ${path}: ${reason}`);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "docs:dev": "pnpm --filter @cio/docs dev",
     "docs:build": "pnpm --filter @cio/docs build",
     "docs:validate": "pnpm --filter @cio/docs validate",
+    "docs:check-stale": "pnpm --filter @cio/docs check-stale",
     "website:dev": "pnpm --filter=@cio/website run dev",
     "embeds:dev": "pnpm --filter=@cio/embeds --filter=@cio/ui run dev",
     "storybook:dev": "pnpm --filter=@cio/storybook --filter=@cio/ui --filter=@cio/question-types run dev",


### PR DESCRIPTION
## What does this PR do?

Detect docs-worthy PRs automatically from the diff instead of relying on authors to self-assess in ship mode. Adds `needs-docs-review` (and an idempotent reminder comment) when a PR touches the user-facing surface, scoped by `.github/docs-review/globs.yml`. Advisory only; `docs-validate.yml` lints doc-only PRs separately without touching the code release pipeline. Also adds the doc-type taxonomy, voice/style notes, and a `last_reviewed` staleness script to `apps/docs`.

This PR touches `.github/workflows/**` (two new workflows: `docs-label.yml`, `docs-validate.yml`), flagging per the checklist below.

Fixes # (add issue number if there is one)

## Demo

No video, not a UI change. Demonstrated instead via two example commits on this branch: one adds a new page under `apps/dashboard/src/routes` and gets `needs-docs-review` applied automatically; one only touches a `+server.ts` file and gets nothing.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Open this PR (or push a commit matching `.github/docs-review/globs.yml`, e.g. a new `+page.svelte`) and confirm `needs-docs-review` gets added with a comment linking `apps/docs/CONTRIBUTING.md`.
- Push a commit that only touches an internal file (e.g. a `+server.ts` endpoint) and confirm the label is not added.
- Remove the triggering change with a follow-up push and confirm the label is removed and the bot comment updates in place.
- Push a docs-only change under `apps/docs/**` and confirm `docs-validate.yml` runs (and only that workflow, not the dashboard build).
- Run `pnpm docs:check-stale` locally and confirm it lists pages missing `last_reviewed`.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` — not run; no application code changed, only CI workflows, docs, and a standalone script
- [ ] Checked for warnings, there are none — pre-existing `Unsupported engine` pnpm warning appears repo-wide, unrelated to this change
- [x] Removed all `console.logs` — the two `console.log` calls in `check-stale-docs.mjs` are the script's intended CLI output, not debug leftovers
- [ ] Merged the latest changes from main onto my branch with `git pull origin main` — base branch is `fix/seperate-help-dev`, not `main`
- [x] My changes don't cause any responsiveness issues — no UI changes
- [ ] If I am a first-time or external contributor, I signed the CLA — not applicable
- [x] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description — called out above

### Appreciated

- [ ] Screen recording — not applicable, no UI change
- [x] Updated the ClassroomIO Docs — `apps/docs/CONTRIBUTING.md` and `apps/docs/WORKFLOW.md`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds advisory automation for identifying user-facing changes, validating documentation, and reporting stale documentation metadata.
- Adds a base-branch-safe label and reminder workflow for user-facing pull requests.
- Adds Blume and Vale validation for documentation changes.
- Documents the documentation taxonomy and review process.
- Adds a CLI worklist for missing or outdated `last_reviewed` metadata.

<h3>Confidence Score: 4/5</h3>

The fork-PR annotation path should be corrected before merging because the workflow cannot publish its promised Vale feedback with a read-only fork token.

The label workflow avoids executing pull-request code, but docs validation relies on a write-capable checks token that is unavailable for the fork pull requests the workflow explicitly claims to support.

**Files Needing Attention:** .github/workflows/docs-validate.yml

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/docs-label.yml | Safely evaluates fork PR filenames against trusted base-branch globs and reconciles an advisory label and bot comment. |
| .github/workflows/docs-validate.yml | Adds advisory docs validation, but its check-annotation reporting cannot use write permissions on fork pull requests. |
| apps/docs/scripts/check-stale-docs.mjs | Recursively scans MDX frontmatter and reports missing, invalid, or older-than-90-day review dates. |
| apps/docs/.vale.ini | Configures Google and write-good prose checks at warning severity. |
| .github/docs-review/globs.yml | Defines the dashboard and shared-UI changes considered user-facing while excluding tests, specs, and stories. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  PR[Pull request] --> F{Changed files}
  F -->|User-facing product files| L[Apply needs-docs-review label and reminder]
  F -->|Documentation files| V[Run Blume and Vale validation]
  V --> A[Publish advisory annotations]
  S[pnpm docs:check-stale] --> M[Scan MDX last_reviewed metadata]
  M --> W[Print stale-page worklist]
```

<sub>Reviews (1): Last reviewed commit: ["ci: add advisory needs-docs-review label..."](https://github.com/classroomio/classroomio/commit/dfc84b175bc132ce9f01dc4edf1b9831a76f1807) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57069045)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->