### PR TITLE
fix(auth): restrict organization roster access

### DIFF
--- a/apps/api/src/routes/organization/organization.test.ts
+++ b/apps/api/src/routes/organization/organization.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Context, Next } from 'hono';
+import { Hono } from '@api/utils/hono';
+import { ROLE } from '@cio/utils/constants';
+
+const serviceMocks = vi.hoisted(() => ({
+  getOrgAudience: vi.fn(),
+  getOrgTeam: vi.fn()
+}));
+
+vi.mock('@api/middlewares/auth', () => ({
+  authMiddleware: async (context: Context, next: Next) => {
+    const roleId = Number(context.req.header('x-test-role'));
+    const orgId = context.req.header('cio-org-id')!;
+    context.set('user', { id: 'profile-1' });
+    context.set('orgRoles', { [orgId]: roleId });
+    await next();
+  }
+}));
+vi.mock('@api/middlewares/auth-or-api-key', () => ({
+  authOrApiKeyMiddleware: async (_context: Context, next: Next) => next()
+}));
+vi.mock('@api/middlewares/auth-or-automation-key', () => ({
+  authOrAutomationKeyMiddleware: () => async (_context: Context, next: Next) => next()
+}));
+vi.mock('@api/middlewares/org-member-or-automation-key', () => ({
+  orgMemberOrAutomationKeyMiddleware: () => async (_context: Context, next: Next) => next()
+}));
+vi.mock('@api/services/organization', () => serviceMocks);
+vi.mock('@api/services/organization/audience', () => ({}));
+vi.mock('@api/services/organization/automation-usage', () => ({}));
+vi.mock('@api/services/organization/auto-join', () => ({}));
+vi.mock('@api/services/organization/invite', () => ({}));
+vi.mock('@api/services/exercise', () => ({}));
+vi.mock('@api/routes/organization/assets', () => ({ assetsRouter: new Hono() }));
+vi.mock('@api/routes/organization/ai-tutor', () => ({ organizationAiTutorRouter: new Hono() }));
+vi.mock('@api/routes/organization/automation', () => ({ automationRouter: new Hono() }));
+vi.mock('@api/routes/organization/course-import', () => ({ courseImportRouter: new Hono() }));
+vi.mock('@api/routes/organization/member-email-notifications', () => ({
+  organizationMemberEmailNotificationsRouter: new Hono()
+}));
+vi.mock('@api/routes/organization/quiz', () => ({ quizRouter: new Hono() }));
+vi.mock('@api/routes/organization/search', () => ({ searchRouter: new Hono() }));
+vi.mock('@api/routes/organization/tags', () => ({ tagsRouter: new Hono() }));
+vi.mock('@api/routes/organization/widgets', () => ({ widgetsRouter: new Hono() }));
+
+import { organizationRouter } from './organization';
+
+const orgId = 'org-1';
+
+function rosterRequest(path: string, roleId: number) {
+  return organizationRouter.request(path, {
+    headers: {
+      'cio-org-id': orgId,
+      'x-test-role': roleId.toString()
+    }
+  });
+}
+
+describe('organization roster authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    serviceMocks.getOrgTeam.mockResolvedValue([]);
+    serviceMocks.getOrgAudience.mockResolvedValue({ items: [], pagination: {}, query: {} });
+  });
+
+  it.each(['/team', '/audience'])('rejects tutors from GET %s', async (path) => {
+    const response = await rosterRequest(path, ROLE.TUTOR);
+
+    expect(response.status).toBe(403);
+  });
+
+  it.each(['/team', '/audience'])('allows admins to GET %s', async (path) => {
+    const response = await rosterRequest(path, ROLE.ADMIN);
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/apps/api/src/routes/organization/organization.ts
+++ b/apps/api/src/routes/organization/organization.ts
@@ -123,7 +123,7 @@ export const organizationRouter = new Hono()
   /**
    * GET /organization/team
    * Gets organization team members (non-students)
-   * Requires authentication
+   * Requires organization admin access
    */
   /**
    * POST /organization/auto-join
@@ -147,7 +147,7 @@ export const organizationRouter = new Hono()
       return handleError(c, error, 'Failed to auto-join organization');
     }
   })
-  .get('/team', authMiddleware, orgTeamMemberMiddleware, async (c) => {
+  .get('/team', authMiddleware, orgAdminMiddleware, async (c) => {
     try {
       const orgId = c.req.header('cio-org-id')!;
       const team = await getOrgTeam(orgId);
@@ -256,9 +256,9 @@ export const organizationRouter = new Hono()
   /**
    * GET /organization/audience
    * Gets organization audience (students)
-   * Requires authentication
+   * Requires organization admin access
    */
-  .get('/audience', authMiddleware, orgTeamMemberMiddleware, zValidator('query', ZGetAudienceQuery), async (c) => {
+  .get('/audience', authMiddleware, orgAdminMiddleware, zValidator('query', ZGetAudienceQuery), async (c) => {
     try {
       const orgId = c.req.header('cio-org-id')!;
       const query = c.req.valid('query');

--- a/apps/api/src/routes/organization/search.test.ts
+++ b/apps/api/src/routes/organization/search.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Context, Next } from 'hono';
+import { ROLE } from '@cio/utils/constants';
+
+const mocks = vi.hoisted(() => ({
+  searchOrganization: vi.fn()
+}));
+
+vi.mock('@api/middlewares/auth', () => ({
+  authMiddleware: async (context: Context, next: Next) => {
+    const orgId = context.req.header('cio-org-id')!;
+    const roleId = Number(context.req.header('x-test-role'));
+    context.set('user', { id: 'profile-1' });
+    context.set('orgRoles', { [orgId]: roleId });
+    await next();
+  }
+}));
+
+vi.mock('@api/services/organization/search', () => ({
+  searchLmsOrganization: vi.fn(),
+  searchOrganization: mocks.searchOrganization
+}));
+
+import { searchRouter } from './search';
+
+function searchRequest(roleId: number) {
+  return searchRouter.request('/?q=alex&limit=5', {
+    headers: {
+      'cio-org-id': 'org-1',
+      'x-test-role': roleId.toString()
+    }
+  });
+}
+
+describe('organization search audience access', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.searchOrganization.mockResolvedValue({
+      courses: [],
+      cohorts: [],
+      widgets: [],
+      tags: [],
+      audience: []
+    });
+  });
+
+  it('disables audience search for tutors', async () => {
+    const response = await searchRequest(ROLE.TUTOR);
+
+    expect(response.status).toBe(200);
+    expect(mocks.searchOrganization).toHaveBeenCalledWith('org-1', 'alex', 5, false);
+  });
+
+  it('enables audience search for admins', async () => {
+    const response = await searchRequest(ROLE.ADMIN);
+
+    expect(response.status).toBe(200);
+    expect(mocks.searchOrganization).toHaveBeenCalledWith('org-1', 'alex', 5, true);
+  });
+});

--- a/apps/api/src/routes/organization/search.ts
+++ b/apps/api/src/routes/organization/search.ts
@@ -1,6 +1,7 @@
 import { ZSearchOrganization } from '@cio/utils/validation/organization';
 
 import { Hono } from '@api/utils/hono';
+import { ROLE } from '@cio/utils/constants';
 import { authMiddleware } from '@api/middlewares/auth';
 import { handleError } from '@api/utils/errors';
 import { orgMemberMiddleware } from '@api/middlewares/org-member';
@@ -12,8 +13,10 @@ export const searchRouter = new Hono()
   .get('/', authMiddleware, orgTeamMemberMiddleware, zValidator('query', ZSearchOrganization), async (c) => {
     try {
       const orgId = c.req.header('cio-org-id')!;
+      const orgRoles = (c.get('orgRoles') as Record<string, number> | undefined) ?? {};
+      const includeAudience = orgRoles[orgId] === ROLE.ADMIN;
       const { q, limit } = c.req.valid('query');
-      const results = await searchOrganization(orgId, q, limit);
+      const results = await searchOrganization(orgId, q, limit, includeAudience);
 
       return c.json({ success: true, data: results });
     } catch (error) {

--- a/apps/api/src/services/organization/search.test.ts
+++ b/apps/api/src/services/organization/search.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const queryMocks = vi.hoisted(() => ({
+  searchLmsCohorts: vi.fn(),
+  searchLmsCourses: vi.fn(),
+  searchOrgAudience: vi.fn(),
+  searchOrgCohorts: vi.fn(),
+  searchOrgCourses: vi.fn(),
+  searchOrgTagsAndGroups: vi.fn(),
+  searchOrgWidgets: vi.fn()
+}));
+
+vi.mock('@cio/db/queries', () => queryMocks);
+
+import { searchOrganization } from './search';
+
+describe('searchOrganization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryMocks.searchOrgCourses.mockResolvedValue([]);
+    queryMocks.searchOrgCohorts.mockResolvedValue([]);
+    queryMocks.searchOrgWidgets.mockResolvedValue([]);
+    queryMocks.searchOrgTagsAndGroups.mockResolvedValue([]);
+    queryMocks.searchOrgAudience.mockResolvedValue([{ memberId: 1 }]);
+  });
+
+  it('does not query or return audience members when audience access is disabled', async () => {
+    const result = await searchOrganization('org-1', 'alex', 5, false);
+
+    expect(queryMocks.searchOrgAudience).not.toHaveBeenCalled();
+    expect(result.audience).toEqual([]);
+  });
+
+  it('returns audience matches when audience access is enabled', async () => {
+    const result = await searchOrganization('org-1', 'alex', 5, true);
+
+    expect(queryMocks.searchOrgAudience).toHaveBeenCalledWith('org-1', 'alex', 5);
+    expect(result.audience).toEqual([{ memberId: 1 }]);
+  });
+});

--- a/apps/api/src/services/organization/search.ts
+++ b/apps/api/src/services/organization/search.ts
@@ -8,13 +8,14 @@ import {
   searchOrgWidgets
 } from '@cio/db/queries';
 
-export async function searchOrganization(orgId: string, search: string, limit: number) {
+export async function searchOrganization(orgId: string, search: string, limit: number, includeAudience: boolean) {
+  const audiencePromise = includeAudience ? searchOrgAudience(orgId, search, limit) : Promise.resolve([]);
   const [courses, cohorts, widgets, tags, audience] = await Promise.all([
     searchOrgCourses(orgId, search, limit),
     searchOrgCohorts(orgId, search, limit),
     searchOrgWidgets(orgId, search, limit),
     searchOrgTagsAndGroups(orgId, search, limit),
-    searchOrgAudience(orgId, search, limit)
+    audiencePromise
   ]);
 
   return {

--- a/apps/dashboard/src/lib/features/cohort/components/invite-members-modal.svelte
+++ b/apps/dashboard/src/lib/features/cohort/components/invite-members-modal.svelte
@@ -8,7 +8,7 @@
   import { Button } from '@cio/ui/base/button';
   import { ROLE } from '@cio/utils/constants';
   import { t } from '$lib/utils/functions/translations';
-  import { currentOrg, isStudentLimitReached } from '$lib/utils/store/org';
+  import { currentOrg, isOrgAdmin, isStudentLimitReached } from '$lib/utils/store/org';
   import { orgApi } from '$features/org/api/org.svelte';
   import { DEFAULT_ORG_AUDIENCE_QUERY } from '$features/org/utils/audience-query-utils';
   import { BulkEmailSection, ExistingStudentsSection, TutorSelectSection } from '$features/people/components';
@@ -75,7 +75,7 @@
   }
 
   function setTutors(orgId: string | undefined) {
-    if (!orgId) {
+    if (!orgId || !$isOrgAdmin) {
       return;
     }
 
@@ -91,7 +91,7 @@
   }
 
   function loadStudents(orgId: string | undefined) {
-    if (!orgId) {
+    if (!orgId || !$isOrgAdmin) {
       return;
     }
 
@@ -108,7 +108,7 @@
 
   async function handleStudentSearch(value: string) {
     const orgId = $currentOrg.id;
-    if (!orgId) {
+    if (!orgId || !$isOrgAdmin) {
       return;
     }
 
@@ -188,39 +188,45 @@
 
     <UnderlineTabs.Root bind:value={activeTab}>
       <UnderlineTabs.List class="flex flex-wrap">
-        <UnderlineTabs.Trigger value="tutors">
-          {$t(`${INVITE_MODAL}.invite`)}
-        </UnderlineTabs.Trigger>
+        {#if $isOrgAdmin}
+          <UnderlineTabs.Trigger value="tutors">
+            {$t(`${INVITE_MODAL}.invite`)}
+          </UnderlineTabs.Trigger>
+        {/if}
         <UnderlineTabs.Trigger value="students">
           {$t(`${INVITE_MODAL}.invite_students`)}
         </UnderlineTabs.Trigger>
       </UnderlineTabs.List>
 
-      <UnderlineTabs.Content value="tutors">
-        <div class="space-y-3">
-          <TutorSelectSection
-            {tutors}
-            bind:selectedIds
-            isLoading={orgApi.isLoading}
-            helperHref={`/org/${$currentOrg.siteName}/settings/teams`}
-          />
+      {#if $isOrgAdmin}
+        <UnderlineTabs.Content value="tutors">
+          <div class="space-y-3">
+            <TutorSelectSection
+              {tutors}
+              bind:selectedIds
+              isLoading={orgApi.isLoading}
+              helperHref={`/org/${$currentOrg.siteName}/settings/teams`}
+            />
 
-          <div class="mt-5 flex flex-row-reverse items-center gap-2">
-            <Button variant="secondary" type="button" onclick={addTutors} loading={cohortApi.isLoading}>
-              {$t(`${INVITE_MODAL}.finish`)}
-            </Button>
+            <div class="mt-5 flex flex-row-reverse items-center gap-2">
+              <Button variant="secondary" type="button" onclick={addTutors} loading={cohortApi.isLoading}>
+                {$t(`${INVITE_MODAL}.finish`)}
+              </Button>
+            </div>
           </div>
-        </div>
-      </UnderlineTabs.Content>
+        </UnderlineTabs.Content>
+      {/if}
 
       <UnderlineTabs.Content value="students">
         <div class="space-y-6">
-          <ExistingStudentsSection
-            students={availableStudents}
-            isLoading={isLoadingStudents}
-            onSearchValueChange={handleStudentSearch}
-            onAssign={assignExistingStudents}
-          />
+          {#if $isOrgAdmin}
+            <ExistingStudentsSection
+              students={availableStudents}
+              isLoading={isLoadingStudents}
+              onSearchValueChange={handleStudentSearch}
+              onAssign={assignExistingStudents}
+            />
+          {/if}
           {#if $isStudentLimitReached}
             <UpgradeBanner removeParams={['add']}>{$t(`${INVITE_MODAL}.student_limit_reached`)}</UpgradeBanner>
           {/if}

--- a/apps/dashboard/src/lib/features/course/components/people/invitation-modal.svelte
+++ b/apps/dashboard/src/lib/features/course/components/people/invitation-modal.svelte
@@ -9,7 +9,7 @@
   import { ROLE } from '@cio/utils/constants';
   import { t } from '$lib/utils/functions/translations';
   import { courseApi } from '$features/course/api';
-  import { currentOrg, isStudentLimitReached } from '$lib/utils/store/org';
+  import { currentOrg, isOrgAdmin, isStudentLimitReached } from '$lib/utils/store/org';
   import { peopleApi } from '$features/course/api';
   import { orgApi } from '$features/org/api/org.svelte';
   import { DEFAULT_ORG_AUDIENCE_QUERY } from '$features/org/utils/audience-query-utils';
@@ -62,7 +62,7 @@
   }
 
   function setTutors(orgId: string | undefined) {
-    if (!orgId) return;
+    if (!orgId || !$isOrgAdmin) return;
     untrack(async () => {
       await orgApi.getOrgTeam();
       if (orgApi.error) {
@@ -74,7 +74,7 @@
   }
 
   function loadStudents(orgId: string | undefined) {
-    if (!orgId) return;
+    if (!orgId || !$isOrgAdmin) return;
 
     untrack(async () => {
       isLoadingStudents = true;
@@ -88,7 +88,7 @@
 
   async function handleStudentSearch(value: string) {
     const orgId = $currentOrg.id;
-    if (!orgId) {
+    if (!orgId || !$isOrgAdmin) {
       return;
     }
 
@@ -183,39 +183,45 @@
 
     <UnderlineTabs.Root bind:value={activeTab}>
       <UnderlineTabs.List class="flex flex-wrap">
-        <UnderlineTabs.Trigger value="tutors">
-          {$t(`${INVITE_MODAL}.invite`)}
-        </UnderlineTabs.Trigger>
+        {#if $isOrgAdmin}
+          <UnderlineTabs.Trigger value="tutors">
+            {$t(`${INVITE_MODAL}.invite`)}
+          </UnderlineTabs.Trigger>
+        {/if}
         <UnderlineTabs.Trigger value="students">
           {$t(`${INVITE_MODAL}.invite_students`)}
         </UnderlineTabs.Trigger>
       </UnderlineTabs.List>
 
-      <UnderlineTabs.Content value="tutors">
-        <div class="space-y-3">
-          <TutorSelectSection
-            {tutors}
-            bind:selectedIds
-            isLoading={orgApi.isLoading}
-            helperHref={`/org/${$currentOrg.siteName}/settings/teams`}
-          />
+      {#if $isOrgAdmin}
+        <UnderlineTabs.Content value="tutors">
+          <div class="space-y-3">
+            <TutorSelectSection
+              {tutors}
+              bind:selectedIds
+              isLoading={orgApi.isLoading}
+              helperHref={`/org/${$currentOrg.siteName}/settings/teams`}
+            />
 
-          <div class="mt-5 flex flex-row-reverse items-center gap-2">
-            <Button variant="secondary" type="button" onclick={onSubmit} loading={peopleApi.isLoading}>
-              {$t(`${INVITE_MODAL}.finish`)}
-            </Button>
+            <div class="mt-5 flex flex-row-reverse items-center gap-2">
+              <Button variant="secondary" type="button" onclick={onSubmit} loading={peopleApi.isLoading}>
+                {$t(`${INVITE_MODAL}.finish`)}
+              </Button>
+            </div>
           </div>
-        </div>
-      </UnderlineTabs.Content>
+        </UnderlineTabs.Content>
+      {/if}
 
       <UnderlineTabs.Content value="students">
         <div class="space-y-6">
-          <ExistingStudentsSection
-            students={availableStudents}
-            isLoading={isLoadingStudents}
-            onSearchValueChange={handleStudentSearch}
-            onAssign={assignExistingStudents}
-          />
+          {#if $isOrgAdmin}
+            <ExistingStudentsSection
+              students={availableStudents}
+              isLoading={isLoadingStudents}
+              onSearchValueChange={handleStudentSearch}
+              onAssign={assignExistingStudents}
+            />
+          {/if}
 
           {#if $isStudentLimitReached}
             <UpgradeBanner removeParams={['add']}>{$t(`${INVITE_MODAL}.student_limit_reached`)}</UpgradeBanner>

--- a/apps/dashboard/src/routes/(app)/courses/[id]/+layout.server.ts
+++ b/apps/dashboard/src/routes/(app)/courses/[id]/+layout.server.ts
@@ -1,12 +1,34 @@
-export const load = async ({ params }) => {
+import type { GetCourseSuccess } from '$features/course/utils/types';
+import { classroomio, getApiHeaders } from '$lib/utils/services/api';
+import { safeServerApi } from '$lib/utils/services/api/server';
+import { error } from '@sveltejs/kit';
+
+export const load = async ({ params, cookies }) => {
   const courseId = params.id || '';
   if (!courseId) {
-    return {
-      courseId: ''
-    };
+    throw error(404, 'Course not found');
+  }
+
+  const result = await safeServerApi<GetCourseSuccess>(() =>
+    classroomio.course[':courseId'].$get(
+      {
+        param: { courseId },
+        query: {}
+      },
+      getApiHeaders(cookies)
+    )
+  );
+
+  if (!result.ok) {
+    if (result.status === 403 || result.status === 404) {
+      throw error(404, 'Course not found');
+    }
+
+    throw error(500, result.message);
   }
 
   return {
-    courseId
+    courseId,
+    course: result.body.data
   };
 };

--- a/apps/dashboard/src/routes/(app)/org/[slug]/audience/+page.server.ts
+++ b/apps/dashboard/src/routes/(app)/org/[slug]/audience/+page.server.ts
@@ -1,12 +1,9 @@
 import type { InferResponseType } from '$lib/utils/services/api';
 import { classroomio, getApiHeaders } from '$lib/utils/services/api';
 import { safeServerApi } from '$lib/utils/services/api/server';
-import {
-  DEFAULT_ORG_AUDIENCE_QUERY,
-  getAudienceQueryFromSearchParams,
-  toAudienceRequestQuery
-} from '$lib/features/org/utils/audience-query-utils';
+import { getAudienceQueryFromSearchParams, toAudienceRequestQuery } from '$lib/features/org/utils/audience-query-utils';
 import type { OrganizationAudienceSuccess } from '$lib/features/org/utils/types';
+import { error } from '@sveltejs/kit';
 
 type GetOrganizationCoursesRequest = typeof classroomio.organization.courses.$get;
 type GetOrganizationCoursesSuccess = Extract<InferResponseType<GetOrganizationCoursesRequest>, { success: true }>;
@@ -15,12 +12,7 @@ export const load = async ({ parent, cookies, url }) => {
   const { orgId } = await parent();
 
   if (!orgId) {
-    return {
-      audience: [],
-      pagination: null,
-      query: DEFAULT_ORG_AUDIENCE_QUERY,
-      courses: []
-    };
+    throw error(404, 'Audience not found');
   }
 
   const headers = getApiHeaders(cookies, orgId);
@@ -34,8 +26,17 @@ export const load = async ({ parent, cookies, url }) => {
       classroomio.organization.courses.$get({ query: { tags: undefined } }, headers)
     )
   ]);
-  const audience = audienceResult.ok ? audienceResult.body.data : [];
-  const pagination = audienceResult.ok ? audienceResult.body.pagination : null;
+
+  if (!audienceResult.ok) {
+    if (audienceResult.status === 403 || audienceResult.status === 404) {
+      throw error(404, 'Audience not found');
+    }
+
+    throw error(500, audienceResult.message);
+  }
+
+  const audience = audienceResult.body.data;
+  const pagination = audienceResult.body.pagination;
   const courses = coursesResult.ok ? coursesResult.body.data : [];
 
   return {


### PR DESCRIPTION
## What does this PR do?

Restricts organization-wide member enumeration to organization admins and renders inaccessible resources through the existing in-place 404 error page.

- requires admin access for `GET /organization/team` and `GET /organization/audience`
- omits audience-member results from organization search for tutors without executing the audience query
- hides admin-only staff and existing-student roster pickers in course and cohort invite dialogs for tutors; tutors can still invite new students by email
- server-loads course access so API `403`/`404` responses render the root `+error.svelte` 404 page instead of leaving the course spinner active
- maps direct forbidden/not-found audience page requests to the same in-place 404 page
- adds endpoint, route-role-mapping, and service regression coverage

## Demo

Not included. The visible changes are permission-gated: tutor invite dialogs no longer show organization roster selectors, and inaccessible course/audience URLs show the existing 404 page without redirecting.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- As a tutor, open a course you do not belong to and confirm the existing 404 page renders at the requested URL.
- As a tutor, open the organization audience URL directly and confirm the same 404 page renders without a redirect.
- `pnpm --filter @cio/api exec vitest run src/routes/organization/organization.test.ts src/routes/organization/search.test.ts src/services/organization/search.test.ts`
- `pnpm --filter @cio/api^... build && pnpm --filter @cio/api build`
- `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`
- `pnpm format:check`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran the builds relevant to the changed API and dashboard areas
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Based the branch on the latest fetched `origin/main`
- [x] My changes do not cause any responsiveness issues
- [x] Contributor License Agreement is already on file
- [x] This PR does not change `pnpm-lock.yaml`, `.github/workflows/**`, or publish config

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Documentation changes were not necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Access Control**
  - Organization team, audience management, exports, imports, and course assignments are now limited to organization administrators.
  - Organization search includes audience results only for administrators.

- **UI Updates**
  - Non-administrators no longer see tutor invitations or existing-student assignment controls; student invitations remain available.

- **Bug Fixes**
  - Course and audience pages now show appropriate not-found or server-error states instead of empty or incomplete content.
  - Course pages load and display course details more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=57142323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge.

<h3>Summary</h3>

Restricts organization roster enumeration to administrators and renders inaccessible course and audience resources through the existing 404 page.
- Applies admin middleware to organization team and audience endpoints.
- Excludes audience results from tutor organization searches.
- Hides admin-only roster selectors from tutor invitation dialogs.
- Server-loads course access and normalizes forbidden or missing resources to 404 responses.
- Adds route and service regression coverage for the authorization changes.

<sub>Reviews (2) · Last reviewed commit: ["test(auth): cover roster search role map..."](https://github.com/classroomio/classroomio/commit/117c4b2e62badc637d3d11332a866fd5930b8bb9)</sub>

<!-- /greptile_comment -->