### PR TITLE
docs: add slide builder PRD and prototypes

### DIFF
--- a/PRD-TRACKER.md
+++ b/PRD-TRACKER.md
@@ -29,6 +29,7 @@ Use this file to keep a single prioritized view of all PRDs.
 | - | - | `prd/events` | draft |
 | - | - | `prd/youtube-embed-transcripts` | draft |
 | - | - | `prd/scroll-to-top` | draft |
+| - | - | `prd/slide-builder` | draft (prototyped; absorbs `prototypes/slide-embed-picker` as the `embed` mode of the Slide tab) |
 
 ## DONE (Completed PRDs)
 

--- a/prd/slide-builder/README.md
+++ b/prd/slide-builder/README.md
@@ -1,0 +1,616 @@
+# Slide Builder PRD
+
+## Status
+
+- Draft (prototyped, ready for engineering review)
+
+## Prototypes — the UX source of truth
+
+**The UX of this feature must be taken from the prototype folder.** Interactive HTML prototypes for every surface live in [`prototypes/slide-builder/`](../../prototypes/slide-builder/) and are the approved design reference for layout, states (draft / generating / overflowing / locked / empty), copy, and navigation flow. When this document and a prototype disagree on a UI detail, the prototype wins.
+
+**Start here:**
+
+```
+prototypes/slide-builder/index.html
+```
+
+Open it in a browser (`open prototypes/slide-builder/index.html`) — it maps all three journeys (teacher → learner → public visitor) and every page cross-links so you can click through each flow end to end. Each page has a light/dark toggle.
+
+The prototypes are built on the real design tokens: `app-theme.css` mirrors `packages/ui/src/index.css` (OKLCH palette, Geist, `--radius: 0.625rem`, and the Button / Badge / Item / Progress / Sidebar recipes), and `deck.css` owns the 1920×1080 canvas, the slide themes as `--slide-*` token sets, and the editor chrome. The public course page uses the same app tokens because `PublicCourseShell` does — it is not an org-landing surface. `deck-data.js` holds the sample deck and a small renderer, so every screen draws from one slide document and cannot drift.
+
+| Surface | Files |
+| --- | --- |
+| Entry | `index.html` |
+| Teacher — authoring | `deck-library.html`, `lesson-slide-tab.html`, `deck-editor.html`, `deck-editor-free.html`, `deck-themes.html` |
+| Teacher — AI & import | `deck-ai.html`, `deck-import.html` |
+| Teacher — output | `deck-export.html`, `presenter.html` |
+| Learner (LMS) | `lesson-deck-player.html` |
+| Public (org site) | `public-course-lesson.html` |
+
+## Purpose
+
+Give teachers a **native slide deck** they author, theme, and present inside ClassroomIO — no round trip to Google Slides, Canva, or PowerPoint — where the deck is structured data the platform can generate, edit, export, and measure. The reference experience is [open-slide](https://open-slide.dev/) (MIT, React): a fixed 1920×1080 canvas, token-driven themes, and agent-first authoring. We keep that feel and replace its core primitive — arbitrary React code per slide — with a typed, validated slide document, because tenant-authored code cannot execute in a multi-tenant Svelte app.
+
+## Problem Statement
+
+- The entire slides feature today is **one URL and one `<iframe>`**: `lesson.slideUrl` (`packages/db/src/schema.ts:972`) rendered by a 53-line component (`apps/dashboard/src/lib/features/course/components/lesson/slide/slide.svelte`). The only transform in the codebase is a Canva `?embed` special case.
+- Teachers author decks in a **different product**, then paste a link back. Decks drift out of sync with the lesson, break when sharing settings change, and show a sign-in wall to students.
+- **Slides never reach the public course page.** `packages/db/src/queries/course/public-course.ts:358-368` does not select `slideUrl`, so a public/marketing course page shows no deck at all.
+- The platform can measure video watch time (`lessonVideoProgress`) but knows **nothing** about a deck — no completion, no gating, no analytics — because the content lives on someone else's server.
+- The AI assistant can author sections, lessons, exercises, questions, and landing pages (20 tools in `packages/core/src/services/agent/chat-tools.ts:473-1058`) but **cannot make a slide**, which is the artifact teachers spend the most time on.
+- Teachers with an existing library of `.pptx` decks have **no migration path**. PowerPoint is rejected by the document uploader (`packages/utils/src/validation/constants.ts:12-16`) and only reachable through the AI course-import parser.
+- The editor's existing IFrame extension **silently loses data**: the server sanitizer strips `iframe` on every lesson save (`packages/utils/src/functions/sanitize.ts:1-15`, applied at `packages/core/src/services/lesson-language.ts:71`), so in-editor embeds are non-functional today.
+
+## Confirmed Decisions
+
+1. **Slide tab becomes two modes**: the existing Slide tab gains an explicit mode — `embed` (the current `slideUrl`, plus the platform picker specced in `prototypes/slide-embed-picker/`) or `deck` (a native ClassroomIO deck). Both coexist; no migration of existing `slideUrl` values. The embed-picker PRD is folded in as the `embed` mode of this surface rather than shipped as a standalone flow.
+2. **Decks are an org-level library**: `slide_deck` is org-scoped with a nullable `lessonId`. Decks are reusable across lessons and courses, listable and duplicable from a library page, and addressable by id from AI and MCP.
+3. **Four surfaces ship in v1**: teacher deck editor (dashboard), learner deck player (authenticated LMS), public course page rendering (org site), and presenter mode.
+4. **Authoring model is layout slots plus a free-position escape hatch**: a slide picks a named layout whose slots own geometry, and any block may be detached to an explicit `{x, y, w, h}` box on the 1920×1080 canvas. `layout: 'free'` means every block carries a box.
+5. **Exports in v1 are PDF and PPTX.** Standalone HTML and per-slide PNG are deferred, except that the PNG screenshot path is built because PPTX depends on it.
+6. **All four AI surfaces ship in v1**: dashboard chat tools, PPTX import to native deck, MCP tools, and in-canvas comment-pin to AI apply.
+7. **Theming is built-ins plus an org branding seed**: a fixed set of themes in `@cio/slides` plus one derived from `organization.theme` and `organization.avatarUrl`. No theme-builder UI in v1.
+8. **A deck renders from one renderer, not two.** Svelte components are the single source of truth; server-side export drives a headless render route with a real browser rather than a parallel HTML-string renderer.
+9. **Heavy slide tools are gated to durable run mode** at the API layer. This feature implements the gate that `apps/dashboard/src/lib/features/ai-assistant/CHAT_VS_RUN.md:87` recommends and that `RUN_ONLY_TOOL_NAMES` (`chat-tools.ts:1066`) currently leaves empty.
+10. **Deck content is never written into a sanitized HTML column.** Blocks are structured jsonb rendered by components, following the `lesson.videos` precedent (`packages/ui/src/custom/media-player/media-player.svelte:29-72`), not the note-body precedent.
+11. **PPTX import extracts text and media, not layout.** Text per slide is mapped onto layouts by the agent; `ppt/media/*` files are extracted into the asset library and offered as an unplaced-assets tray. Original positioning is not reconstructed. *(Product call made without an explicit answer — flagged for veto.)*
+12. **Deck version history is written explicitly by the service layer.** We do not copy the `lesson_language_history` pattern: nothing in app code writes to that table — it is fed by a legacy Supabase-era trigger absent from the Drizzle migrations.
+
+## Current-State Audit
+
+| Capability | Current State | Notes |
+| --- | --- | --- |
+| Slides on a lesson | `lesson.slideUrl varchar` (`packages/db/src/schema.ts:972`), `z.url()` at `packages/utils/src/validation/lesson/lesson.ts:35` | Keep untouched as `embed` mode. A pasted `<iframe>` fails validation today. |
+| Slide UI | `components/lesson/slide/slide.svelte` (53 lines), tab slot 2 in `components/lesson/constants.ts:28-33` | Tab registry, badge counts, and `lessonTabsOrder` already have a slot to extend. |
+| Data-object → render precedent | `@cio/certificates`: `renderCertificate(design, data)` + `RENDERERS` registry (`packages/certificates/src/render.ts:11`) | Exact architecture to mirror for `@cio/slides`: typed design + template registry. |
+| Server-side PDF/PNG | `getCloudflarePdfBuffer` / `getCloudflarePngBuffer` (`apps/api/src/utils/cloudflare.ts`) | Both take `html` only. Needs a `url` variant — the Cloudflare endpoints accept `url`, `waitForSelector`, and `cookies`. |
+| Theme token system | `--landing-*` vars in `packages/ui/src/custom/org-landing-page/theme-vars-base.ts`, per-theme `vars.ts` | Direct precedent for `--slide-*` tokens and a theme registry. |
+| Org brand inputs | `organization.theme text default 'blue'` (`schema.ts:2172`), `organization.avatarUrl`, shade generation via `color2k` in `apps/dashboard/src/lib/utils/functions/theme.ts:22-35` | Enough to derive a branded slide theme with no new columns. |
+| AI authoring tools | Schemas `packages/core/src/services/agent/agent-tool-schemas.ts`; impls `chat-tools.ts:473-1058`; prompt `packages/ai-assistant/src/prompt/teacher.ts` | `packages/ai-assistant/src/tools/*` is dead code — imported by nothing. Do not add tools there. |
+| Run-mode gate | `filterToolsForChatMode` is the identity fn; `RUN_ONLY_TOOL_NAMES` is empty (`chat-tools.ts:1066-1070`) | The hook exists and is unused. This feature implements it. |
+| MCP server | `packages/mcp`, 17 tools, `StdioServerTransport` only (`packages/mcp/src/index.ts:18`) | Laptop-only. No hosted remote MCP; out of scope here. |
+| PPTX parsing | `extractPptxText` (`packages/core/src/services/agent/document.ts:227-256`) — JSZip, tag-stripped text per slide | Text only. JSZip is already loaded, so `ppt/media/*` extraction is incremental. |
+| Public course content | `PublicLessonContent` carries `body` + `video` only (`packages/db/src/queries/course/public-course.ts:284-311`) | Net-new plumbing: query select, type, and mapper (`public-course-mappers.ts:66-77`). |
+| Lesson HTML sanitizer | `FORBID_TAGS` includes `iframe`, `object`, `embed` (`packages/utils/src/functions/sanitize.ts:1-15`) | Hard constraint: decks must not travel as HTML through `lesson_language.content`. |
+| Editor image upload | Insert is a bare `prompt()` (`editor/ui/components/ImagePlaceholder.svelte:9-14`); paste handler's `onload` is commented out (`editor/utils.ts:37-41`) | The upload pipeline exists (`utils/services/upload.ts` → `POST /media/image`) but the editor is not wired to it. |
+| Background jobs | `QUEUE_NAMES`/`JOB_NAMES` in `packages/jobs/src/queues/names.ts`, enqueue in `packages/jobs/src/enqueue/`, workers in `apps/jobs/src/workers/` | A `slide-exports` queue drops straight in. |
+| Client-side export deps | `html-to-image` and `jspdf` already in `apps/dashboard/package.json` | Available as a fallback path; server path is preferred for fidelity. |
+
+## Product Goals
+
+1. A teacher creates, edits, reorders, themes, and presents a deck entirely inside ClassroomIO.
+2. A deck looks on-brand by default, without the teacher choosing a single colour.
+3. The AI assistant can build and revise a deck through the same tools a human uses, with no separate code path.
+4. A teacher's existing PowerPoint library becomes native decks in one upload.
+5. A deck exports to PDF and PPTX with fidelity good enough to hand to a colleague.
+6. Learners view decks in the LMS and on public course pages, and the platform records progress through them.
+7. Everything that works today — external embeds via `slideUrl`, lesson notes, videos, documents — continues to work exactly as before (zero regression).
+
+## Non-Goals (v1)
+
+- **Arbitrary code slides** — the open-slide primitive. Tenant-authored JSX or `<script>` in a multi-tenant app is remote code execution. Non-negotiable, not a phasing decision.
+- **A theme builder UI** — org-scoped custom token editing. Built-ins plus the brand seed only.
+- **Morph transitions** between slides. Simple `none | fade | slide` only.
+- **Real-time multiplayer editing.** Single-editor with explicit version history.
+- **Text-native PPTX** (editable text boxes in PowerPoint). v1 exports full-bleed images per slide.
+- **Standalone HTML export** and **per-slide PNG download** as user-facing features.
+- **A hosted remote MCP transport.** MCP tools ship, but stdio-only, matching the existing server.
+- **Reconstructing PowerPoint layout on import.** Text and media only.
+- **Charts and data-bound blocks.** Deferred; `kpi` covers the common case.
+- Fixing the TipTap editor's unrelated image-insert gap beyond what the deck editor itself needs.
+
+## Data Sources Checked
+
+- `https://open-slide.dev/` and `github.com/1weiho/open-slide` — canvas model, `Page` contract, theme tokens, `export-pdf.ts` print CSS, `export-pptx.ts` rasterization, the `slide-authoring` skill's vertical-budget rules.
+- `https://developers.cloudflare.com/browser-rendering/rest-api/pdf-endpoint/` — confirmed `url` is accepted as an alternative to `html`; 50 MB body cap; 4,500 ms default page-load timeout.
+- `pptxgenjs` v4.0.1 (MIT) — PPTX assembly from images in Node.
+- `prototypes/slide-embed-picker/PRD.md` — the ten-platform embed picker this PRD absorbs as `embed` mode.
+
+---
+
+## Functional Requirements
+
+### 1. Deck Library (`/org/[slug]/decks`)
+
+Mirrors the media manager (`apps/dashboard/src/lib/features/media/pages/media.svelte`) — see `deck-library.html`.
+
+- Grid of deck cards: thumbnail (first slide render), title, slide count, theme chip, updated-at, and the lesson it is attached to (or `Unattached`).
+- Filters bar: search by title, filter by course, by status (`Draft` / `Published`), by attachment (`Attached` / `Unattached`).
+- Card actions: Open, Duplicate, Export, Detach from lesson, Delete.
+- **Empty state**: an explanatory panel with three entry points — *Start from blank*, *Generate with AI*, *Import a .pptx*.
+- **Generating state**: a deck created by a durable agent run shows a progress card in place of the thumbnail, with slide-count progress and a Cancel action, matching the run monitor in the AI panel.
+
+### 2. Lesson Slide Tab — two modes (`/courses/[id]/lessons/[lessonId]`)
+
+See `lesson-slide-tab.html`.
+
+- When the lesson has neither `slideUrl` nor `slideDeckId`, the tab shows a **mode chooser**: *Embed an existing deck* or *Build a deck here*.
+- **Embed mode**: the platform picker from `prototypes/slide-embed-picker/` — visual platform gallery, per-platform input, paste normalization (link transform or `<iframe>` src extraction), live preview, inline validation, docs deep-link. Persists a resolved embed URL to `slideUrl`, unchanged from today's contract.
+- **Deck mode**: a deck summary card — thumbnail, slide count, theme, last edited — with *Open editor*, *Present*, *Export*, and *Replace with a library deck*.
+- Switching modes never destroys the other mode's data: `slideUrl` and `slideDeckId` both persist; `slideMode` decides what renders.
+- **Badge count** on the tab reflects whichever mode is active (`1` for an embed, slide count for a deck).
+
+### 3. Deck Editor (`/org/[slug]/decks/[deckId]`)
+
+The core surface. See `deck-editor.html` (layout mode) and `deck-editor-free.html` (free mode).
+
+- **Three-pane shell**, mirroring the certificate editor (`features/course/components/ceritficate/editor/`): slide rail (left), 1920×1080 canvas scaled to fit (centre), inspector (right).
+- **Slide rail**: ordered thumbnails, drag to reorder, add-slide button with a layout picker, per-slide context menu (Duplicate, Delete, Add note). A slide whose free-positioned blocks exceed the canvas shows an **overflow warning dot**.
+- **Canvas**: click a block to select it; selected block shows a bounding box. In layout mode, blocks snap to their slot and cannot be dragged. In free mode, blocks are draggable and resizable with snap guides at canvas thirds and centre lines.
+- **Inspector**, tabbed: *Slide* (layout picker, background, transition, presenter notes), *Block* (kind-specific fields — text, level, bullets, image picker, code language, alignment, emphasis), *Detach to free position* toggle on any slotted block.
+- **Text auto-fit**: text inside a slot or an explicit box shrinks within the theme's type range to fit its box. A block that cannot fit at minimum size surfaces an inline warning rather than clipping silently.
+- **Save**: `Page.SettingsActions` docked at the bottom, appearing only when `hasChanges` is true, per the repo's settings-page rule.
+- **States shown in the prototype**: layout mode with a block selected, free mode with an overflowing block and Save blocked, drag-reorder, and the layout picker. The version-history drawer is specified here but not prototyped — build it to match the editor's inspector panels.
+
+### 4. Themes (`deck-themes.html`)
+
+- A theme gallery showing each built-in rendered on a real sample slide, not a swatch.
+- The org's seeded theme appears first, labelled *Your brand*, derived from `organization.theme` and `organization.avatarUrl`.
+- Applying a theme is instant and non-destructive — themes carry no content.
+- A small set of per-deck overrides (accent colour, heading font pairing) without a full token editor.
+
+### 5. AI Authoring (`deck-ai.html`)
+
+- **From the AI panel**: "Build a deck for this lesson" produces a plan card, then a durable run that streams slides into the rail as they are created.
+- **In-canvas comment pin**: the teacher clicks a block, drops a pin, and types a change ("tighten this to three bullets", "make this the cover"). Pins collect in a sidebar; *Apply all* hands them to the agent, which edits the addressed blocks. This is open-slide's `@slide-comment` loop.
+- Pin states: open, applying, applied (with a diff summary), failed (with a retry).
+- Every AI write goes through the same routes a human uses, and appears in version history attributed to `agent`.
+
+### 6. PPTX Import (`deck-import.html`)
+
+- Upload a `.pptx`; the file is unzipped and slide text extracted per slide, media files extracted to the asset library.
+- A **mapping review step** shows, per source slide, the extracted text and the layout the agent proposes, with a layout override dropdown.
+- An **unplaced assets tray** holds every extracted image; the teacher drags one onto a slide, or dismisses the tray.
+- The import banner states plainly that original positioning and fonts are not reconstructed.
+
+### 7. Export (`deck-export.html`)
+
+- Export dialog with PDF and PPTX, each showing what the teacher will get (PDF: vector text where possible; PPTX: one full-bleed image per slide, not editable text).
+- Export enqueues a job and shows progress; completion yields a signed download URL.
+- A deck longer than a threshold warns about export duration before starting.
+
+### 8. Presenter Mode (`presenter.html`)
+
+- Full-screen current slide, next-slide preview, presenter notes, elapsed timer, and slide position.
+- Keyboard: arrows/space to advance, `O` for overview grid, `B` for blackout, `F` for fullscreen, `Esc` to exit.
+- Opens in a new window so the teacher can put the deck on the projector and notes on the laptop.
+
+### 9. Learner Player (`lesson-deck-player.html`)
+
+- The deck renders in the lesson's Slide slot, scaled to the content column, with keyboard and click navigation and an overview grid.
+- **Progress**: the furthest slide reached is recorded per learner. Where the lesson's `completionPolicy` requires it, the deck must be advanced to the last slide before the lesson can complete — following the `videoWatchThreshold` precedent.
+- **Locked state**: a locked lesson shows the deck's first slide blurred with the existing lock treatment, consistent with locked video.
+
+### 10. Public Course Page (`public-course-lesson.html`)
+
+- On the org site, a public lesson renders its deck inline, themed by the deck's theme (not the landing theme), inside the landing page's content column.
+- Anonymous visitors get navigation and overview but no progress recording.
+- A deck on a locked lesson is not sent to the client at all — same rule as `body` and `video` today.
+
+---
+
+## Technical Design
+
+### Data Model
+
+#### New Table: `slide_deck`
+
+```typescript
+// packages/db/src/schema.ts
+export const slideDeck = pgTable(
+  'slide_deck',
+  {
+    id: uuid().default(sql`gen_random_uuid()`).primaryKey().notNull(),
+    organizationId: uuid('organization_id').notNull(),
+    lessonId: uuid('lesson_id'),
+    title: varchar().notNull(),
+    themeId: varchar('theme_id').notNull().default('classic'),
+    themeOverrides: jsonb('theme_overrides').default({}).$type<Record<string, string>>(),
+    status: slideDeckStatus().default('DRAFT').notNull(),
+    slideCount: integer('slide_count').default(0).notNull(),
+    thumbnailUrl: text('thumbnail_url'),
+    createdBy: uuid('created_by'),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' }).defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' }).defaultNow()
+  },
+  (table) => [
+    foreignKey({ columns: [table.organizationId], foreignColumns: [organization.id] }).onDelete('cascade'),
+    foreignKey({ columns: [table.lessonId], foreignColumns: [lesson.id] }).onDelete('set null'),
+    index('slide_deck_org_updated_idx').on(table.organizationId, table.updatedAt),
+    index('slide_deck_lesson_idx').on(table.lessonId)
+  ]
+);
+```
+
+`slideCount` is a denormalized counter for list rendering only; it is recomputed inside the same transaction as any slide insert or delete, never read as truth by the editor.
+
+#### New Table: `slide`
+
+```typescript
+export const slide = pgTable(
+  'slide',
+  {
+    id: uuid().default(sql`gen_random_uuid()`).primaryKey().notNull(),
+    deckId: uuid('deck_id').notNull(),
+    order: integer().notNull(),
+    layout: varchar().default('title-body').notNull(),
+    blocks: jsonb().default([]).notNull().$type<TSlideBlock[]>(),
+    notes: text(),
+    transition: varchar().default('fade').notNull(),
+    background: jsonb().default({}).$type<TSlideBackground>(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' }).defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' }).defaultNow()
+  },
+  (table) => [
+    foreignKey({ columns: [table.deckId], foreignColumns: [slideDeck.id] }).onDelete('cascade'),
+    index('slide_deck_order_idx').on(table.deckId, table.order)
+  ]
+);
+```
+
+**One row per slide, not one jsonb document per deck.** This is deliberate: `CHAT_VS_RUN.md:75` records that `update_lesson_content` "writes full lesson HTML — a single call can be 5–20k tokens of output." A per-slide row makes `update_slide` a surgical edit of a few hundred tokens and `reorder_slides` an order update.
+
+An image block references an asset by `assetId`, never by copying a URL — per the repo rule that persisted columns store relationships, not derived values. The public URL is resolved at render time.
+
+#### New Table: `slide_deck_version`
+
+```typescript
+export const slideDeckVersion = pgTable(
+  'slide_deck_version',
+  {
+    id: uuid().default(sql`gen_random_uuid()`).primaryKey().notNull(),
+    deckId: uuid('deck_id').notNull(),
+    snapshot: jsonb().notNull(),
+    actorId: uuid('actor_id'),
+    actorKind: varchar('actor_kind').default('user').notNull(),
+    label: varchar(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' }).defaultNow()
+  },
+  (table) => [
+    foreignKey({ columns: [table.deckId], foreignColumns: [slideDeck.id] }).onDelete('cascade'),
+    index('slide_deck_version_deck_idx').on(table.deckId, table.createdAt)
+  ]
+);
+```
+
+`actorKind` is one of `user | agent | mcp | import`, so history shows who changed a deck. Snapshots are written by the service layer on every mutating operation — explicitly, in app code. Do not model this on `lesson_language_history`, which no app code writes to.
+
+#### New Table: `slide_progress`
+
+```typescript
+export const slideProgress = pgTable(
+  'slide_progress',
+  {
+    id: uuid().default(sql`gen_random_uuid()`).primaryKey().notNull(),
+    deckId: uuid('deck_id').notNull(),
+    lessonId: uuid('lesson_id').notNull(),
+    profileId: uuid('profile_id').notNull(),
+    furthestSlideOrder: integer('furthest_slide_order').default(0).notNull(),
+    completedAt: timestamp('completed_at', { withTimezone: true, mode: 'string' }),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' }).defaultNow()
+  },
+  (table) => [unique('slide_progress_unique').on(table.deckId, table.lessonId, table.profileId)]
+);
+```
+
+#### New Enum
+
+```typescript
+export const slideDeckStatus = pgEnum('slide_deck_status', ['DRAFT', 'PUBLISHED']);
+```
+
+#### Modified Table: `lesson`
+
+```typescript
+// Added to the existing lesson table. slideUrl is NOT touched.
+slideDeckId: uuid('slide_deck_id'),                      // FK slide_deck.id, on delete set null
+slideMode: varchar('slide_mode').default('embed').notNull() // 'embed' | 'deck'
+```
+
+`slideMode` is stored rather than derived so that a lesson holding both a legacy `slideUrl` and a new deck has one unambiguous answer about what renders.
+
+#### Relationship Diagram
+
+```
+organization
+└── slide_deck  (org-scoped library)
+    ├── slide                (1..n, ordered)
+    ├── slide_deck_version   (0..n, explicit history)
+    └── slide_progress       (0..n, per learner per lesson)
+
+lesson
+├── slideUrl      ──> embed mode  (unchanged)
+└── slideDeckId   ──> deck mode   ──> slide_deck
+```
+
+### The Slide Document
+
+```typescript
+// packages/utils/src/validation/slide/slide.ts
+// Gemini's schema validator rejects z.literal on numbers and booleans
+// (see agent-tool-schemas.ts:277-278) — discriminate on STRING literals only.
+
+export const ZSlideBox = z.object({
+  x: z.number().min(0).max(1920),
+  y: z.number().min(0).max(1080),
+  w: z.number().min(16).max(1920),
+  h: z.number().min(16).max(1080)
+});
+
+const ZBlockBase = z.object({
+  id: z.string(),
+  slot: z.string().optional(),  // set when the layout owns geometry
+  box: ZSlideBox.optional(),    // set when the block owns geometry (free / detached)
+  align: z.enum(['start', 'center', 'end']).default('start'),
+  emphasis: z.enum(['default', 'muted', 'accent']).default('default')
+});
+
+export const ZSlideBlock = z.discriminatedUnion('kind', [
+  ZBlockBase.extend({ kind: z.literal('heading'), text: z.string().max(200), level: z.enum(['hero', 'section', 'page']).default('page') }),
+  ZBlockBase.extend({ kind: z.literal('text'), text: z.string().max(1200) }),
+  ZBlockBase.extend({ kind: z.literal('bullets'), items: z.array(z.string().max(200)).min(1).max(8) }),
+  ZBlockBase.extend({ kind: z.literal('image'), assetId: z.string(), alt: z.string().max(200), fit: z.enum(['cover', 'contain']).default('cover') }),
+  ZBlockBase.extend({ kind: z.literal('code'), code: z.string().max(4000), language: z.string().max(24).default('text') }),
+  ZBlockBase.extend({ kind: z.literal('quote'), text: z.string().max(600), attribution: z.string().max(120).optional() }),
+  ZBlockBase.extend({ kind: z.literal('kpi'), value: z.string().max(24), label: z.string().max(80) }),
+  ZBlockBase.extend({ kind: z.literal('divider') })
+]);
+
+export const ZSlideLayout = z.enum([
+  'cover', 'title-body', 'two-col', 'bullets', 'image-left',
+  'image-right', 'quote', 'code', 'kpi-row', 'section-break', 'free'
+]);
+
+export const ZSlide = z
+  .object({
+    layout: ZSlideLayout,
+    blocks: z.array(ZSlideBlock).max(24),
+    notes: z.string().max(4000).optional(),
+    transition: z.enum(['none', 'fade', 'slide']).default('fade'),
+    background: ZSlideBackground.optional()
+  })
+  .superRefine((slide, ctx) => {
+    // Free-position overflow is pure arithmetic — reject it at the boundary
+    // so neither a human nor an agent can persist a cropped slide.
+    for (const block of slide.blocks) {
+      if (!block.box) continue;
+
+      const { x, y, w, h } = block.box;
+      if (x + w > 1920 || y + h > 1080) {
+        ctx.addIssue({ code: 'custom', path: ['blocks'], message: `Block ${block.id} extends past the 1920×1080 canvas.` });
+      }
+    }
+  });
+```
+
+This is the answer to the vertical-budget problem that open-slide's `slide-authoring` skill spends most of its length teaching an agent to solve by hand. Slotted blocks cannot overflow because slots own geometry and text auto-fits; free blocks declare their box, so canvas overflow is arithmetic the schema rejects.
+
+### New Package: `@cio/slides`
+
+Mirrors `@cio/certificates` in shape.
+
+```
+packages/slides/src/
+  types.ts          TSlideDeck, TSlide, TSlideBlock, TSlideTheme
+  theme-vars-base.ts  --slide-* token names + base values (mirrors theme-vars-base.ts
+                      in packages/ui/src/custom/org-landing-page/)
+  themes/
+    classic/vars.ts   editorial/vars.ts   bold/vars.ts   mono/vars.ts
+    index.ts          THEMES registry + resolveTheme(id, overrides)
+  brand-theme.ts    seedThemeFromOrg({ theme, avatarUrl }) -> TSlideTheme
+  layouts/
+    index.ts        LAYOUTS registry: layout id -> slot definitions (name, box, role)
+  index.ts
+```
+
+Rendering components live in `packages/ui/src/custom/slide-deck/` — `deck-canvas.svelte`, `slide-frame.svelte`, `block-*.svelte`, `deck-player.svelte`, `presenter-view.svelte`. All Tailwind classes there carry the `ui:` prefix.
+
+### Export Pipeline
+
+There is exactly one renderer. The API never builds slide HTML itself.
+
+```
+POST /slide/deck/:deckId/export {format}
+  -> enqueue slide-exports job
+  -> worker mints a short-lived signed render token
+  -> worker calls Cloudflare Browser Rendering with a URL:
+       pdf:  /pdf        { url: <dashboard>/render/deck/:id?token=…, waitForSelector: '[data-deck-ready]' }
+       pptx: /screenshot per slide index, then pptxgenjs assembles full-bleed images
+  -> upload artifact to object storage, return a signed download URL
+```
+
+Constraints that shape this: Cloudflare's default page-load timeout is 4,500 ms, so the render route must be self-contained and must not wait on client-side data fetching; the request body cap is 50 MB, which the `url` form avoids entirely. `apps/api/src/utils/cloudflare.ts` currently accepts only `html` and needs a `url` variant.
+
+The render route serves the deck at true 1920×1080 with print CSS (`@page { size: 1920px 1080px; margin: 0 }`), one frame per slide, and sets `data-deck-ready` once fonts have loaded and animations are settled.
+
+### API and Route Plan
+
+#### Validation Layer
+
+`packages/utils/src/validation/slide/` — `ZSlideBlock`, `ZSlide`, `ZSlideDeckCreate`, `ZSlideDeckUpdate`, `ZSlideCreate`, `ZSlideUpdate`, `ZSlideReorder`, `ZSlideDeckExport`, `ZSlideDeckImport`, plus param schemas. Exported as `@cio/utils/validation/slide` via the existing wildcard export.
+
+#### Query Layer
+
+| Function | Description |
+| --- | --- |
+| `createSlideDeck(data)` | Insert a deck row |
+| `getSlideDeckById(deckId, orgId)` | Deck + ordered slides |
+| `listSlideDecks(orgId, filters)` | Paginated library listing |
+| `updateSlideDeck(deckId, orgId, data)` | Title, theme, overrides, status |
+| `deleteSlideDeck(deckId, orgId)` | Cascade slides and versions |
+| `createSlide(deckId, data)` | Insert at an order, shifting successors |
+| `updateSlide(slideId, deckId, data)` | Patch layout / blocks / notes / background |
+| `deleteSlide(slideId, deckId)` | Delete and compact order |
+| `reorderSlides(deckId, slideIds)` | Bulk order update in one transaction |
+| `createSlideDeckVersion(deckId, snapshot, actor)` | Append history |
+| `upsertSlideProgress(deckId, lessonId, profileId, order)` | Monotonic furthest-slide write |
+| `getPublicDeckForLesson(lessonId)` | Deck for the org-site path |
+
+#### Service Layer
+
+`apps/api/src/services/slide/` — `deck.ts`, `slide.ts`, `export.ts`, `import.ts`, `theme.ts`. Services compose query functions, own transactions, snapshot history, and raise `AppError`. No Drizzle in services.
+
+#### Route Layer
+
+Mounted as a single root segment, per the repo rule against nested mounts in `app.ts`. Sub-routers compose in `apps/api/src/routes/slide/index.ts`.
+
+| Method | Path | Middleware | Description |
+| --- | --- | --- | --- |
+| `GET` | `/slide/deck` | `authMiddleware` | List org decks |
+| `POST` | `/slide/deck` | `authMiddleware` | Create a deck |
+| `GET` | `/slide/deck/:deckId` | `authMiddleware` | Deck + slides + resolved theme |
+| `PUT` | `/slide/deck/:deckId` | `authMiddleware` | Update deck meta |
+| `DELETE` | `/slide/deck/:deckId` | `authMiddleware` | Delete a deck |
+| `POST` | `/slide/deck/:deckId/duplicate` | `authMiddleware` | Clone into the library |
+| `POST` | `/slide/deck/:deckId/slide` | `authMiddleware` | Add a slide |
+| `PUT` | `/slide/deck/:deckId/slide/:slideId` | `authMiddleware` | Update a slide |
+| `DELETE` | `/slide/deck/:deckId/slide/:slideId` | `authMiddleware` | Delete a slide |
+| `PUT` | `/slide/deck/:deckId/reorder` | `authMiddleware` | Reorder slides |
+| `GET` | `/slide/deck/:deckId/version` | `authMiddleware` | Version history |
+| `POST` | `/slide/deck/:deckId/version/:versionId/restore` | `authMiddleware` | Restore a snapshot |
+| `POST` | `/slide/deck/:deckId/export` | `authMiddleware` | Enqueue export, return `jobId` |
+| `GET` | `/slide/deck/:deckId/export/:jobId` | `authMiddleware` | Job status + signed URL |
+| `POST` | `/slide/deck/import` | `authMiddleware` | PPTX → deck |
+| `GET` | `/slide/deck/:deckId/comment` | `authMiddleware` | List comment pins |
+| `POST` | `/slide/deck/:deckId/comment` | `authMiddleware` | Create a pin |
+| `POST` | `/slide/deck/:deckId/comment/apply` | `authMiddleware` | Hand pins to the agent, return `runId` |
+| `POST` | `/slide/progress` | `authMiddleware` | Record furthest slide |
+
+The existing org-site route `GET /org-site/course/:courseSlug/item/:itemSlug` is extended to include `deck` on `PublicLessonContent`; locked lessons omit it, matching `body` and `video`.
+
+#### AI Tool Surface
+
+Schemas go in `packages/core/src/services/agent/agent-tool-schemas.ts`; implementations in `chat-tools.ts`; prompt guidance in `packages/ai-assistant/src/prompt/teacher.ts`. **Nothing is added to `packages/ai-assistant/src/tools/` — that directory is dead code.**
+
+| Tool | Mode | Notes |
+| --- | --- | --- |
+| `get_slide_deck` | chat | Read deck and slides |
+| `update_slide` | chat | One row, surgical |
+| `reorder_slides` | chat | Array of slide ids |
+| `apply_deck_theme` | chat | Theme id plus overrides |
+| `create_slide_deck` | **run** | Emits N slides |
+| `add_slides` | **run** | Emits N slides |
+| `generate_deck_from_lesson` | **run** | Reads `lesson_language.content` |
+| `import_pptx_deck` | **run** | Reuses `document.ts` extraction |
+
+`orgId` and `courseId` are never tool parameters — they are injected from the authed request (`agent-tool-schemas.ts:17`, `:29`). `deckId` is a parameter, re-verified against the org on every call. The four run-mode tools seed `RUN_ONLY_TOOL_NAMES` and are added to `DURABLE_AGENT_TOOL_NAMES` (`chat-tools.ts:74-90`); `deckId` is added to `extractOutputIds` (`:228-239`) so run events carry it.
+
+#### MCP Tools
+
+`packages/mcp/src/tools/slide-decks.ts`, registered from `src/index.ts`, wrapping the same validation schemas over the public API. Required alongside:
+
+- A `course:slides:write` scope added to **both** `packages/utils/src/validation/organization/automation-key.ts:6-17` and the `mcp` defaults at `apps/api/src/services/organization/automation-key.ts:21-35`, or existing keys 403.
+- Credit costs in `MCP_TOOL_CREDIT_COST` (`packages/utils/src/plans/automation.ts:15-33`) and a category in `getMcpAutomationCategory` — this is type-enforced at the `assertMcpAutomationUsageAllowed` call site.
+- Tool list updated in both `packages/mcp/README.md` and `apps/docs/content/docs/mcp.mdx`.
+
+### Frontend Plan (Dashboard)
+
+Follow `CLAUDE.md` layering strictly.
+
+- **Feature folder**: `apps/dashboard/src/lib/features/slides/` with `api/`, `components/`, `pages/`, `store/`, `utils/`.
+- **Request types** in `utils/types.ts`, inferred from the RPC client (`typeof classroomio.slide.deck.$get`), never imported from `@cio/db/queries`, never declared in a `.svelte.ts` file.
+- **API class** `api/slide-deck.svelte.ts` extending `BaseApiWithErrors`, using `this.execute<RequestType>()`. Components stay thin.
+- **Editor state** in `store/deck-editor.store.svelte.ts` — selection, dirty tracking, undo stack. Use `SvelteSet`/`SvelteMap` for reactive collections; reset on explicit handlers, never in an `$effect` tied to a steady boolean.
+- **Routes**: `(app)/org/[slug]/decks/+page.svelte` (library) and `(app)/org/[slug]/decks/[deckId]/+page.svelte` (editor); `routes/render/deck/[deckId]/+page.svelte` for the headless render target.
+- **Navigation**: add a Decks entry to `apps/dashboard/src/lib/features/ui/navigation/org-navigation.ts`.
+- **Image insertion** in the deck editor uses the existing pipeline (`$lib/utils/services/upload.ts` → `POST /media/image`) plus a media-manager picker. This is new wiring; the TipTap editor's own gap is out of scope.
+- **Translations**: every string in `apps/dashboard/src/lib/utils/translations/en.json`, then `cd apps/dashboard && pnpm translate` for the other nine locales, including the `ai_assistant.tool.{pending,done}.*` keys for each new tool.
+- **Tool labels**: register each tool in `features/ai-assistant/utils/tool-labels.ts` — `TOOLS_WITH_PENDING_COPY`, a case in `getCompletedToolLine`, and `MUTATION_TOOLS`.
+- **Scroll to top**: the deck library is a long catalog and mounts `ScrollToTop` from `@cio/ui/custom/scroll-to-top`.
+
+---
+
+## Implementation Order
+
+### Phase 1: Schema and Package
+
+1. Add `slideDeckStatus` enum and `slideDeck`, `slide`, `slideDeckVersion`, `slideProgress` tables to `packages/db/src/schema.ts`; add `slideDeckId` and `slideMode` to `lesson`.
+2. Generate and review the migration in `packages/db/src/migrations/`.
+3. Create `packages/slides` with types, `theme-vars-base.ts`, four built-in themes, `brand-theme.ts`, and the layout registry.
+4. Add `packages/utils/src/validation/slide/` with the schemas above.
+5. Run `pnpm --filter @cio/db build && pnpm --filter @cio/utils build`.
+
+### Phase 2: Query, Service, Route
+
+1. Add `packages/db/src/queries/slide/` per the query table; every catch logs `console.error('functionName error:', error)`.
+2. Add `apps/api/src/services/slide/` — deck, slide, theme; history snapshot on every mutation.
+3. Add `apps/api/src/routes/slide/` and compose in `routes/slide/index.ts`; mount `app.ts` at `/slide`.
+4. Run `pnpm --filter @cio/api^... build && pnpm --filter @cio/api build`.
+
+### Phase 3: Render and Player
+
+1. Add `packages/ui/src/custom/slide-deck/` components with `ui:`-prefixed classes and Storybook stories for every block kind, layout, and player state.
+2. Add the headless render route and the `data-deck-ready` signal.
+3. Wire the learner player into the lesson view and `slide_progress`.
+4. Run `pnpm --filter @cio/ui prefix` and `pnpm --filter @cio/dashboard build`.
+
+### Phase 4: Editor
+
+1. Build the deck library page and the three-pane editor with layout mode.
+2. Add free-position mode: drag, resize, snap guides, and the schema-backed overflow guard.
+3. Add the theme gallery and the org brand seed.
+4. Add version history drawer and restore.
+5. Wire the lesson Slide tab's two modes, folding in the embed picker from `prototypes/slide-embed-picker/`.
+
+### Phase 5: Export and Import
+
+1. Add a `slide-exports` queue to `packages/jobs/src/queues/names.ts`, an enqueue helper, and `apps/jobs/src/workers/slide-exports.ts`.
+2. Add the `url` variant to `apps/api/src/utils/cloudflare.ts`.
+3. Implement PDF export, then PNG-per-slide, then PPTX assembly with `pptxgenjs`.
+4. Implement PPTX import: text extraction, `ppt/media/*` extraction to assets, mapping review, unplaced-assets tray.
+
+### Phase 6: AI, MCP, and Public
+
+1. Add tool schemas and implementations; seed `RUN_ONLY_TOOL_NAMES` and implement the chat-mode gate.
+2. Update the teacher prompt; register tool labels and all translation keys.
+3. Add comment pins and the apply-to-agent flow.
+4. Add MCP tools, the new scope in both places, and credit costs; update both docs surfaces.
+5. Extend `PublicLessonContent`, the public-course query, and the mapper; render decks on the org site.
+6. Add presenter mode.
+7. Run `pnpm format:check`, `pnpm --filter @cio/api build`, `pnpm --filter @cio/dashboard build`.
+
+## Acceptance Criteria
+
+1. A teacher creates a deck from the library, adds slides across every layout, reorders by drag, and saves.
+2. A block can be detached to free position, dragged, and resized; a block pushed past the canvas is rejected with a specific message rather than silently cropped.
+3. Text that would overflow its slot or box auto-fits within the theme's type range, and surfaces a warning when it cannot.
+4. Applying a theme changes every slide's appearance and changes no content.
+5. The org's seeded theme appears first in the gallery and reflects `organization.theme` and `organization.avatarUrl`.
+6. A deck attached to a lesson renders in the Slide tab in deck mode; switching to embed mode restores the previous `slideUrl` unchanged.
+7. A learner advances a deck in the LMS, and `slide_progress.furthestSlideOrder` increases monotonically; a completion-gated lesson does not complete until the last slide is reached.
+8. A public course page renders a deck for an unlocked public lesson and omits it entirely for a locked one.
+9. Presenter mode opens in a new window showing current slide, next slide, notes, and timer, and responds to every documented key.
+10. PDF export produces one 1920×1080 page per slide with correct fonts and theme colours.
+11. PPTX export opens in PowerPoint and Keynote with one image-backed slide per source slide.
+12. A `.pptx` upload produces a deck with one slide per source slide, extracted media in the asset tray, and a mapping review step before commit.
+13. The AI assistant builds a deck from a lesson via a durable run, streams slides into the rail, and can be cancelled mid-run.
+14. A heavy slide tool invoked in chat mode is rejected by the API-layer gate and routed to a run.
+15. A comment pin applied by the agent edits only the addressed block and appears in version history with `actorKind = 'agent'`.
+16. An MCP client with a `course:slides:write` key can create and update a deck; a key without the scope receives 403.
+17. Version history records every mutation with the correct actor, and restore returns the deck to that snapshot.
+18. External embeds via `slideUrl`, lesson notes, videos, and documents behave exactly as before (zero regression).
+19. All user-facing strings use translation keys and are present in all ten locale files.
+20. `pnpm format:check`, `pnpm --filter @cio/api build`, and `pnpm --filter @cio/dashboard build` pass.
+
+## Risks and Mitigations
+
+- **Risk**: The Svelte player and the export renderer drift, so a deck looks different in the LMS than in its PDF.
+  - **Mitigation**: There is only one renderer. Export drives the same Svelte components through a headless render route in a real browser, rather than a parallel HTML-string renderer. Acceptance criterion 10 compares them directly.
+- **Risk**: Cloudflare's 4,500 ms default page-load timeout kills exports for large decks.
+  - **Mitigation**: The render route is server-rendered and self-contained, waits on no client fetch, and signals readiness with `data-deck-ready` so `waitForSelector` gates the capture. PPTX captures per slide, so per-request work stays constant regardless of deck length. Long decks run as a background job with progress, never inline.
+- **Risk**: Free-position mode reintroduces the cropped-slide problem that layouts solve, especially for AI output.
+  - **Mitigation**: Every free block declares an explicit box, so canvas overflow is arithmetic rejected by `ZSlide.superRefine` at the API boundary. The editor shows an overflow dot on the slide rail, and tool results return the validation error so the agent self-corrects.
+- **Risk**: A deck stored as HTML anywhere would be destroyed by the lesson sanitizer, which strips `iframe`, `object`, and `embed`.
+  - **Mitigation**: Decks never travel through `lesson_language.content`. Blocks are structured jsonb rendered by components — the `lesson.videos` pattern, which already works around this.
+- **Risk**: Heavy deck generation runs inline in chat, where there is no retry, resume, progress, or cancel.
+  - **Mitigation**: Implement the API-layer gate that `CHAT_VS_RUN.md:87` recommends, and seed `RUN_ONLY_TOOL_NAMES` with the four generating tools. Acceptance criterion 14 tests the rejection path.
+- **Risk**: PPTX import disappoints because layout and fonts are not reconstructed, and teachers expect a faithful copy.
+  - **Mitigation**: The import banner states the limitation before upload, the mapping review step lets the teacher fix every layout choice, and extracted media is offered rather than dropped. Framed as "bring your content across", not "open your PowerPoint".
+- **Risk**: PPTX export ships image-only slides, and a teacher expecting editable text feels misled.
+  - **Mitigation**: The export dialog states what each format produces before the teacher commits. Text-native PPTX is an explicit v2.
+- **Risk**: Scope. This is a product, not a feature, and it overlaps `prototypes/slide-embed-picker/`.
+  - **Mitigation**: The embed picker ships as `embed` mode inside this surface rather than as separate work, so the tab is designed once. Phases 1–4 deliver a usable authoring product before AI, MCP, export, and public rendering land.
+- **Risk**: MCP tools are stdio-only, so "edit decks with Claude" works on a laptop but not from Claude on the web.
+  - **Mitigation**: Documented as a v1 limitation in both `packages/mcp/README.md` and `apps/docs/content/docs/mcp.mdx`. A hosted transport is tracked separately and is not a dependency of this feature.
+- **Risk**: Deck deletion orphans a lesson that points at it.
+  - **Mitigation**: `lesson.slideDeckId` is `on delete set null`, and the Slide tab falls back to the mode chooser. The library warns when deleting a deck attached to lessons and names them.

--- a/prototypes/slide-builder/app-theme.css
+++ b/prototypes/slide-builder/app-theme.css
@@ -1,0 +1,1178 @@
+/*
+ * app-theme.css — shared theme for the slide-builder prototypes.
+ *
+ * Tokens mirror packages/ui/src/index.css (shadcn-svelte) exactly:
+ * OKLCH palette, Geist, --radius: 0.625rem, shadow-2xs, and the component
+ * recipes from @cio/ui base components (Button, Badge, Item, Progress, Sidebar).
+ * Dark mode uses the same `.dark` class convention as the app.
+ */
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.488 0.243 264.376);
+  --primary-foreground: oklch(0.97 0.014 254.604);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+
+  /* Semantic states from @cio/ui Badge variants (emerald / amber) */
+  --success: oklch(0.596 0.145 163.225); /* emerald-600 */
+  --success-foreground: #fff;
+  --success-soft: oklch(0.596 0.145 163.225 / 0.12);
+  --warning: oklch(0.666 0.179 58.318); /* amber-600 */
+  --warning-foreground: #fff;
+  --warning-soft: oklch(0.666 0.179 58.318 / 0.14);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  --shadow-2xs: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.424 0.199 265.638);
+  --primary-foreground: oklch(0.97 0.014 254.604);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+
+  --success: oklch(0.696 0.17 162.48); /* emerald-500 */
+  --success-foreground: oklch(0.262 0.051 172.552); /* emerald-950 */
+  --success-soft: oklch(0.696 0.17 162.48 / 0.16);
+  --warning: oklch(0.769 0.188 70.08); /* amber-500 */
+  --warning-foreground: oklch(0.279 0.077 45.635); /* amber-950 */
+  --warning-soft: oklch(0.769 0.188 70.08 / 0.16);
+}
+
+/* ============ base ============ */
+* {
+  box-sizing: border-box;
+  border-color: var(--border);
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+body {
+  font-family:
+    'Geist',
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+  background: var(--background);
+  color: var(--foreground);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+button {
+  font: inherit;
+}
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+.text-muted {
+  color: var(--muted-foreground);
+}
+.text-primary {
+  color: var(--primary);
+}
+
+/* ============ app shell ============ */
+.app {
+  display: grid;
+  grid-template-columns: 256px 1fr;
+  min-height: 100vh;
+}
+.main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.content {
+  padding: 28px 28px 64px;
+}
+.wrap {
+  max-width: 960px;
+  margin: 0 auto;
+}
+.wrap-narrow {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+/* sidebar (mirrors @cio/ui base/sidebar) */
+.sidebar {
+  background: var(--sidebar);
+  border-right: 1px solid var(--sidebar-border);
+  padding: 16px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px 14px;
+}
+.brand-mark {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-md);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 14px;
+}
+.brand-name {
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: -0.01em;
+}
+.nav-label {
+  font-size: 11px;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  padding: 12px 8px 4px;
+}
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px;
+  border-radius: var(--radius-md);
+  color: var(--sidebar-foreground);
+  font-weight: 400;
+  font-size: 14px;
+  transition: background 0.1s;
+}
+.nav-item svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+  color: var(--muted-foreground);
+  flex-shrink: 0;
+}
+.nav-item:hover {
+  background: var(--sidebar-accent);
+}
+.nav-item.active {
+  background: var(--sidebar-accent);
+  color: var(--sidebar-accent-foreground);
+  font-weight: 500;
+}
+.nav-item.active svg {
+  color: var(--sidebar-accent-foreground);
+}
+.nav-tail {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+.nav-badge {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+.sidebar-foot {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px;
+  border-top: 1px solid var(--sidebar-border);
+}
+.avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.who {
+  min-width: 0;
+}
+.who .nm {
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.who .rl {
+  font-size: 11.5px;
+  color: var(--muted-foreground);
+}
+
+/* path identity block (teacher path sidebar) */
+.back-link {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--muted-foreground);
+  padding: 6px 8px;
+  border-radius: var(--radius-md);
+  margin-bottom: 4px;
+}
+.back-link:hover {
+  background: var(--sidebar-accent);
+  color: var(--foreground);
+}
+.back-link svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+}
+.path-id {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 8px 14px;
+  border-bottom: 1px solid var(--sidebar-border);
+  margin-bottom: 6px;
+}
+.path-id .ico {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.path-id .ico svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+}
+.path-id .nm {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+.path-id .st {
+  font-size: 11.5px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 2px;
+}
+.path-id .st .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+}
+.st-active {
+  color: var(--success);
+}
+.st-active .dot {
+  background: var(--success);
+}
+.st-draft {
+  color: var(--warning);
+}
+.st-draft .dot {
+  background: var(--warning);
+}
+
+/* topbar */
+.topbar {
+  height: 56px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in oklab, var(--background) 90%, transparent);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 24px;
+}
+.crumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13.5px;
+  color: var(--muted-foreground);
+  min-width: 0;
+}
+.crumbs a:hover {
+  color: var(--foreground);
+}
+.crumbs .sep {
+  color: var(--border);
+}
+.crumbs .here {
+  color: var(--foreground);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.top-title {
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+.top-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ============ buttons (mirrors @cio/ui base/button) ============ */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: var(--radius-md);
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  height: 36px;
+  padding: 0 16px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    border-color 0.12s,
+    color 0.12s;
+  box-shadow: var(--shadow-2xs);
+  user-select: none;
+}
+.btn svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+  flex-shrink: 0;
+}
+.btn-primary {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+.btn-primary:hover {
+  background: color-mix(in oklab, var(--primary) 90%, transparent);
+}
+.btn-outline {
+  background: var(--background);
+  border-color: var(--input);
+  color: var(--foreground);
+}
+.btn-outline:hover {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+.btn-secondary {
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+}
+.btn-secondary:hover {
+  background: color-mix(in oklab, var(--secondary) 80%, transparent);
+}
+.btn-ghost {
+  background: transparent;
+  box-shadow: none;
+  color: var(--foreground);
+}
+.btn-ghost:hover {
+  background: var(--accent);
+}
+.btn-destructive {
+  background: var(--destructive);
+  color: #fff;
+}
+.btn-success {
+  background: var(--success);
+  color: var(--success-foreground);
+}
+.btn-sm {
+  height: 32px;
+  padding: 0 12px;
+  font-size: 13px;
+  gap: 6px;
+}
+.btn-sm svg {
+  width: 15px;
+  height: 15px;
+}
+.btn-lg {
+  height: 40px;
+  padding: 0 24px;
+}
+.btn[disabled],
+.btn.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+.btn-icon {
+  width: 36px;
+  padding: 0;
+}
+.btn-icon.btn-sm {
+  width: 32px;
+}
+
+/* ============ badges (mirrors @cio/ui base/badge) ============ */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: fit-content;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.badge svg {
+  width: 12px;
+  height: 12px;
+  stroke-width: 2.4;
+}
+.badge-default {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+.badge-secondary {
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+}
+.badge-success {
+  background: var(--success);
+  color: var(--success-foreground);
+}
+.badge-warning {
+  background: var(--warning);
+  color: var(--warning-foreground);
+}
+.badge-outline {
+  border-color: var(--border);
+  color: var(--foreground);
+  background: transparent;
+}
+.badge-success-soft {
+  background: var(--success-soft);
+  color: var(--success);
+}
+.badge-primary-soft {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+  color: var(--primary);
+}
+.badge-muted {
+  background: var(--muted);
+  color: var(--muted-foreground);
+}
+
+/* ============ cards ============ */
+.card {
+  background: var(--card);
+  color: var(--card-foreground);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-2xs);
+}
+.card-pad {
+  padding: 20px;
+}
+
+/* ============ item rows (mirrors @cio/ui base/item) ============ */
+.item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  padding: 16px;
+  font-size: 14px;
+  transition:
+    background 0.1s,
+    border-color 0.1s;
+}
+.item-muted {
+  background: color-mix(in oklab, var(--muted) 50%, transparent);
+}
+.item-outline {
+  border-color: var(--border);
+}
+.item-done {
+  opacity: 0.6;
+}
+.item-done .item-title,
+.item-done .item-desc {
+  color: var(--muted-foreground);
+  text-decoration: line-through;
+}
+.item-current {
+  background: var(--card);
+  border-color: var(--primary);
+  box-shadow: var(--shadow-sm);
+}
+.item-dashed {
+  border: 1px dashed var(--border);
+  background: transparent;
+}
+a.item:hover {
+  background: color-mix(in oklab, var(--accent) 50%, transparent);
+}
+
+.item-media-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  background: var(--muted);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin-top: 2px;
+  color: var(--muted-foreground);
+}
+.item-media-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+}
+.item-media-icon.is-done {
+  background: var(--success);
+  border-color: var(--success);
+  color: var(--success-foreground);
+}
+.item-media-icon.is-current {
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  border-color: color-mix(in oklab, var(--primary) 30%, transparent);
+  color: var(--primary);
+}
+.item-media-lg {
+  width: 40px;
+  height: 40px;
+}
+.item-media-lg svg {
+  width: 19px;
+  height: 19px;
+}
+.item-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.item-title {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+}
+.item-title-lg {
+  font-size: 15px;
+  font-weight: 600;
+}
+.item-desc {
+  font-size: 13px;
+  color: var(--muted-foreground);
+  line-height: 1.45;
+}
+.item-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.item-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+
+/* ============ progress (mirrors @cio/ui base/progress) ============ */
+.progress {
+  height: 8px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: color-mix(in oklab, var(--primary) 20%, transparent);
+  flex: 1;
+}
+.progress > span {
+  display: block;
+  height: 100%;
+  background: var(--primary);
+  border-radius: var(--radius-md);
+  transition: width 0.3s;
+}
+.progress-success > span {
+  background: var(--success);
+}
+.progress-thin {
+  height: 6px;
+}
+
+/* progress ring (mirrors @cio/ui custom/percent-ring-progress) */
+.ring {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  flex-shrink: 0;
+}
+.ring-sm {
+  width: 40px;
+  height: 40px;
+}
+.ring svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+  display: block;
+}
+.ring .track {
+  stroke: var(--border);
+}
+.ring .arc {
+  stroke: var(--success);
+  transition: stroke-dashoffset 0.7s ease-out;
+}
+.ring .lbl {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--foreground);
+}
+.ring-sm .lbl {
+  font-size: 10px;
+}
+
+/* completion dots (setup page pattern) */
+.dots {
+  display: flex;
+  gap: 4px;
+}
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--border);
+}
+.dot.on {
+  background: var(--success);
+}
+
+/* ============ forms ============ */
+.input,
+.textarea,
+.select {
+  width: 100%;
+  font: inherit;
+  font-size: 14px;
+  color: var(--foreground);
+  background: transparent;
+  border: 1px solid var(--input);
+  border-radius: var(--radius-md);
+  padding: 7px 12px;
+  outline: none;
+  box-shadow: var(--shadow-2xs);
+  transition:
+    border-color 0.12s,
+    box-shadow 0.12s;
+}
+.input:focus,
+.textarea:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 50%, transparent);
+}
+.textarea {
+  resize: vertical;
+  min-height: 76px;
+  line-height: 1.55;
+}
+.label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+.hint {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  margin-top: 5px;
+}
+.field {
+  margin-bottom: 18px;
+}
+.field:last-child {
+  margin-bottom: 0;
+}
+
+/* switch */
+.switch {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  flex-shrink: 0;
+  cursor: pointer;
+  display: inline-block;
+}
+.switch input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  margin: 0;
+  cursor: pointer;
+  z-index: 1;
+}
+.switch .track {
+  position: absolute;
+  inset: 0;
+  background: var(--input);
+  border-radius: 999px;
+  transition: background 0.15s;
+}
+.switch .knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--background);
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.15s;
+}
+.switch input:checked + .track {
+  background: var(--primary);
+}
+.switch input:checked ~ .knob {
+  transform: translateX(16px);
+}
+
+/* ============ tables ============ */
+.thead,
+.trow {
+  display: grid;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 16px;
+}
+.thead {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  border-bottom: 1px solid var(--border);
+}
+.trow {
+  border-bottom: 1px solid var(--border);
+  font-size: 14px;
+}
+.trow:last-child {
+  border-bottom: none;
+}
+a.trow:hover {
+  background: color-mix(in oklab, var(--accent) 50%, transparent);
+}
+
+/* ============ misc components ============ */
+.icon-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--input);
+  background: var(--background);
+  display: grid;
+  place-items: center;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  box-shadow: var(--shadow-2xs);
+}
+.icon-btn:hover {
+  color: var(--foreground);
+  background: var(--accent);
+}
+.icon-btn svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+}
+
+.seg-toggle {
+  display: inline-flex;
+  padding: 3px;
+  background: var(--muted);
+  border-radius: var(--radius-lg);
+  gap: 2px;
+}
+.seg-toggle a,
+.seg-toggle button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: var(--radius-md);
+  border: none;
+  background: transparent;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+.seg-toggle .on {
+  background: var(--background);
+  color: var(--foreground);
+  box-shadow: var(--shadow-2xs);
+}
+.seg-toggle svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2;
+}
+
+.stat-card {
+  padding: 16px 18px;
+}
+.stat-card .k {
+  font-size: 13px;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.stat-card .k svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+}
+.stat-card .v {
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin-top: 4px;
+}
+.stat-card .s {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  margin-top: 2px;
+}
+
+/* page headers */
+.page-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin: 8px 0 20px;
+}
+.page-title {
+  font-size: 24px;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+  margin: 0 0 4px;
+}
+.page-sub {
+  color: var(--muted-foreground);
+  font-size: 14px;
+  margin: 0;
+}
+.sec-title {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+.sec-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 28px 0 14px;
+}
+.sec-head .count {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  background: var(--muted);
+  padding: 1px 8px;
+  border-radius: 999px;
+}
+.sec-head .more {
+  margin-left: auto;
+  font-size: 13.5px;
+  color: var(--primary);
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.sec-head .more svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2;
+}
+
+/* segmented path progress (course-count segments) */
+.segs {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+}
+.seg {
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--primary) 15%, transparent);
+  position: relative;
+  overflow: hidden;
+}
+.seg.done {
+  background: var(--success);
+}
+.seg.half::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: 45%;
+  background: var(--primary);
+  border-radius: 999px;
+}
+
+/* lock veil for thumbnails */
+.lock-veil {
+  position: absolute;
+  inset: 0;
+  background: oklch(0.145 0 0 / 0.35);
+  display: grid;
+  place-items: center;
+}
+.lock-veil svg {
+  width: 18px;
+  height: 18px;
+  color: #fff;
+  stroke-width: 2.2;
+}
+
+/* ============ journey spine (learner path detail) ============ */
+.journey {
+  position: relative;
+  margin-top: 16px;
+}
+.step {
+  position: relative;
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 16px;
+  padding-bottom: 16px;
+}
+.step:last-child {
+  padding-bottom: 0;
+}
+.rail {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+.rail::before {
+  content: '';
+  position: absolute;
+  top: 38px;
+  bottom: -16px;
+  width: 2px;
+  background: var(--border);
+  border-radius: 2px;
+}
+.step:last-child .rail::before,
+.step.no-rail .rail::before {
+  display: none;
+}
+.step.s-done .rail::before {
+  background: var(--success);
+}
+.step.s-current .rail::before {
+  background: linear-gradient(180deg, var(--success) 0%, var(--border) 70%);
+}
+.node {
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 13px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  border: 1px solid var(--border);
+}
+.node svg {
+  width: 17px;
+  height: 17px;
+  stroke-width: 2.4;
+}
+.step.s-done .node {
+  background: var(--success);
+  border-color: var(--success);
+  color: var(--success-foreground);
+}
+.step.s-current .node {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+  box-shadow: 0 0 0 4px color-mix(in oklab, var(--primary) 15%, transparent);
+}
+
+/* horizontal stepper (in-course ribbon) */
+.stepper {
+  display: flex;
+  align-items: center;
+}
+.snode {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  width: 110px;
+  text-align: center;
+}
+.sdot {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 12px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  border: 1px solid var(--border);
+}
+.sdot svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2.6;
+}
+.snode.done .sdot {
+  background: var(--success);
+  border-color: var(--success);
+  color: var(--success-foreground);
+}
+.snode.current .sdot {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--primary) 15%, transparent);
+}
+.slabel {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  line-height: 1.25;
+}
+.snode.current .slabel {
+  color: var(--foreground);
+  font-weight: 600;
+}
+.sbar {
+  flex: 1;
+  height: 2px;
+  background: var(--border);
+  min-width: 12px;
+  margin: 0 -14px 18px;
+}
+.sbar.filled {
+  background: var(--success);
+}
+
+/* ============ responsive ============ */
+@media (max-width: 860px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+  .sidebar {
+    display: none;
+  }
+  .item {
+    flex-wrap: wrap;
+  }
+  .item-actions {
+    width: 100%;
+  }
+  .item-actions .btn {
+    flex: 1;
+  }
+}

--- a/prototypes/slide-builder/deck-ai.html
+++ b/prototypes/slide-builder/deck-ai.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Deck editor — AI · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="deck.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      body { overflow: hidden; }
+      .ed-head { height: 56px; border-bottom: 1px solid var(--border); background: var(--background); display: flex; align-items: center; gap: 10px; padding: 0 12px; flex-shrink: 0; }
+      .ed-head .t { font-size: 15px; letter-spacing: -0.01em; }
+      .ed-head .sp { flex: 1; }
+      .deck-shell { grid-template-columns: 232px 1fr 340px; }
+      .ai { border-left: 1px solid var(--border); display: flex; flex-direction: column; min-height: 0; background: var(--background); }
+      .ai-head { padding: 10px 12px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 500; }
+      .ai-body { flex: 1; overflow-y: auto; padding: 12px; display: grid; gap: 12px; align-content: start; }
+      .ai-foot { border-top: 1px solid var(--border); padding: 10px 12px; display: grid; gap: 8px; }
+      .msg { font-size: 13px; line-height: 1.6; }
+      .msg.me { justify-self: end; background: var(--muted); border-radius: var(--radius-md); padding: 8px 11px; max-width: 88%; }
+      .tool { border: 1px solid var(--border); border-radius: var(--radius-md); padding: 9px 11px; display: flex; align-items: center; gap: 8px; font-size: 12.5px; background: var(--card); }
+      .tool .ic { width: 18px; height: 18px; border-radius: 999px; display: grid; place-items: center; flex-shrink: 0; }
+      .tool .ic.ok { background: var(--success-soft); color: var(--success); }
+      .tool .ic.run { background: color-mix(in oklch, var(--primary) 15%, transparent); color: var(--primary); }
+      .tool code { font-size: 11.5px; }
+      .plan { border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--card); overflow: hidden; }
+      .plan .ph { padding: 10px 12px; border-bottom: 1px solid var(--border); font-size: 12.5px; font-weight: 600; display: flex; align-items: center; justify-content: space-between; }
+      .plan ol { margin: 0; padding: 10px 12px 10px 28px; font-size: 12.5px; line-height: 1.75; color: var(--muted-foreground); }
+      .plan .pf { padding: 10px 12px; border-top: 1px solid var(--border); display: flex; gap: 8px; }
+      .runcard { border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--card); padding: 11px 12px; display: grid; gap: 9px; }
+      .runcard .rh { display: flex; align-items: center; justify-content: space-between; font-size: 12.5px; font-weight: 500; }
+      .pinlist { display: grid; gap: 8px; }
+      .pincard { border: 1px solid var(--border); border-radius: var(--radius-md); padding: 10px 11px; display: grid; gap: 6px; font-size: 12.5px; background: var(--card); }
+      .pincard .ph { display: flex; align-items: center; gap: 7px; font-weight: 500; }
+      .pinbadge { width: 18px; height: 18px; border-radius: 999px 999px 999px 3px; background: var(--warning); color: #fff; display: grid; place-items: center; font-size: 10px; font-weight: 700; flex-shrink: 0; }
+      .pinbadge.done { background: var(--success); }
+      .pincard p { margin: 0; color: var(--muted-foreground); line-height: 1.55; }
+    </style>
+  </head>
+  <body>
+    <header class="ed-head">
+      <a class="icon-btn" href="deck-editor.html" title="Back" aria-label="Back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m12 19-7-7 7-7M19 12H5" /></svg></a>
+      <span class="t">Designing Effective Assessments</span>
+      <span class="badge badge-primary-soft">AI run · slide 9 of 20</span>
+      <span class="sp"></span>
+      <button class="btn btn-outline btn-sm">Cancel run</button>
+    </header>
+
+    <div class="deck-shell">
+      <aside class="slide-rail" id="rail">
+        <div class="slide-rail-head"><span>Slides</span><span class="tnum" id="ct">8</span></div>
+      </aside>
+
+      <section class="stage">
+        <div class="stage-inner">
+          <div class="stage-bar">
+            <div class="stage-meta"><span>Slide 3 of 8</span><span>·</span><span>Two column</span></div>
+            <div class="segctl">
+              <button class="active" type="button">Comment pins</button>
+              <button type="button" onclick="location.href='deck-editor.html'">Edit</button>
+            </div>
+          </div>
+          <div class="stage-frame" id="stageFrame"></div>
+          <p class="insp-hint" style="margin-top: 10px; text-align: center">
+            Click anywhere on a block to drop a pin and describe the change. Pins collect on the right — the agent applies them to the blocks they address.
+          </p>
+        </div>
+      </section>
+
+      <aside class="ai">
+        <div class="ai-head">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor"><path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M5.6 18.4l2.1-2.1M16.3 7.7l2.1-2.1"/></svg>
+          Assistant
+          <span class="sp" style="flex: 1"></span>
+          <span class="badge badge-muted">Claude</span>
+        </div>
+
+        <div class="ai-body">
+          <div class="msg me">Build a deck from this lesson. Keep it under 20 slides and use our brand theme.</div>
+
+          <div class="msg">I read the lesson and drafted a plan. This is a lot of slides, so it runs as a background job you can cancel or resume — not inline in chat.</div>
+
+          <div class="plan">
+            <div class="ph">Plan <span class="badge badge-muted">20 slides</span></div>
+            <ol>
+              <li>Cover + agenda</li>
+              <li>Part 1 — outcomes before items (4 slides)</li>
+              <li>Part 2 — the four traits (5 slides)</li>
+              <li>Part 3 — rubrics as a contract (4 slides)</li>
+              <li>Evidence from the 2025 cohort (3 slides)</li>
+              <li>Close + assignment (2 slides)</li>
+            </ol>
+            <div class="pf">
+              <button class="btn btn-primary btn-sm" style="flex: 1" disabled>Running…</button>
+              <button class="btn btn-outline btn-sm">Edit plan</button>
+            </div>
+          </div>
+
+          <div class="tool"><span class="ic ok"><svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6 9 17l-5-5"/></svg></span><span><code>create_slide_deck</code> — created “Cohort Kickoff”</span></div>
+          <div class="tool"><span class="ic ok"><svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6 9 17l-5-5"/></svg></span><span><code>apply_deck_theme</code> — Your brand</span></div>
+          <div class="tool"><span class="ic run"><svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="3"><path d="M12 2v4M12 18v4M4.9 4.9l2.9 2.9M16.2 16.2l2.9 2.9M2 12h4M18 12h4"/></svg></span><span><code>add_slides</code> — writing slide 9 of 20</span></div>
+
+          <div class="runcard">
+            <div class="rh"><span>Run progress</span><span class="tnum">9 / 20</span></div>
+            <div class="progress"><span style="width: 45%"></span></div>
+            <div style="display: flex; gap: 8px">
+              <button class="btn btn-outline btn-sm" style="flex: 1">Pause</button>
+              <button class="btn btn-outline btn-sm" style="flex: 1">Cancel</button>
+            </div>
+          </div>
+
+          <hr style="border: 0; border-top: 1px solid var(--border); margin: 4px 0" />
+
+          <div class="ai-head" style="padding: 0; border: 0">Comment pins <span class="badge badge-muted" style="margin-left: auto" id="pinCount">2 open</span></div>
+
+          <div class="pinlist" id="pins">
+            <div class="pincard">
+              <div class="ph"><span class="pinbadge">1</span>Heading · slide 3</div>
+              <p>“Tighten this to six words — it wraps to two lines on the projector.”</p>
+              <div style="display: flex; gap: 6px"><button class="btn btn-primary btn-sm" style="flex: 1" onclick="applyPin(this)">Apply</button><button class="btn btn-ghost btn-sm">Dismiss</button></div>
+            </div>
+            <div class="pincard">
+              <div class="ph"><span class="pinbadge">2</span>Text · slide 3</div>
+              <p>“Cut the second sentence and make the first one the takeaway.”</p>
+              <div style="display: flex; gap: 6px"><button class="btn btn-primary btn-sm" style="flex: 1" onclick="applyPin(this)">Apply</button><button class="btn btn-ghost btn-sm">Dismiss</button></div>
+            </div>
+            <div class="pincard" style="opacity: 0.75">
+              <div class="ph"><span class="pinbadge done"><svg viewBox="0 0 24 24" width="9" height="9" fill="none" stroke="currentColor" stroke-width="4"><path d="M20 6 9 17l-5-5"/></svg></span>Image · slide 3 — applied</div>
+              <p>Swapped for the rubric photo. Recorded in history as <b>agent</b>.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="ai-foot">
+          <textarea class="input" rows="2" placeholder="Ask for a change…" style="resize: none"></textarea>
+          <div style="display: flex; gap: 8px">
+            <button class="btn btn-outline btn-sm" style="flex: 1" onclick="applyAll()">Apply all pins</button>
+            <button class="btn btn-primary btn-sm">Send</button>
+          </div>
+        </div>
+      </aside>
+    </div>
+
+    <script src="deck-data.js"></script>
+    <script>
+      const rail = document.getElementById('rail');
+      DECK.slides.forEach((slide, index) => {
+        const row = document.createElement('div');
+        row.className = 'thumb-row' + (index === 2 ? ' active' : '');
+        row.innerHTML = `<span class="n">${index + 1}</span><div class="thumb${index === 2 ? ' active' : ''}">${renderSlide(slide, { chrome: false })}</div>`;
+        rail.appendChild(row);
+      });
+
+      /* new slides streaming in from the run */
+      let streamed = 8;
+      const streamTimer = setInterval(() => {
+        if (streamed >= 12) return clearInterval(streamTimer);
+
+        streamed += 1;
+        const row = document.createElement('div');
+        row.className = 'thumb-row';
+        row.style.opacity = '0';
+        row.innerHTML = `<span class="n">${streamed}</span><div class="thumb">${renderSlide(DECK.slides[streamed % DECK.slides.length], { theme: 'brand', chrome: false })}</div>`;
+        rail.appendChild(row);
+        requestAnimationFrame(() => { row.style.transition = 'opacity .5s'; row.style.opacity = '1'; });
+        document.getElementById('ct').textContent = streamed;
+      }, 2200);
+
+      /* canvas + pins */
+      const stageFrame = document.getElementById('stageFrame');
+      stageFrame.innerHTML = renderSlide(DECK.slides[2]);
+
+      const PINS = [
+        { n: 1, x: 18, y: 32 },
+        { n: 2, x: 20, y: 58 },
+        { n: 3, x: 74, y: 46, done: true }
+      ];
+      PINS.forEach((pin) => {
+        const el = document.createElement('span');
+        el.className = 'pin' + (pin.done ? ' done' : '');
+        el.style.left = pin.x + '%';
+        el.style.top = pin.y + '%';
+        el.innerHTML = pin.done
+          ? '<svg viewBox="0 0 24 24" width="10" height="10" fill="none" stroke="currentColor" stroke-width="4"><path d="M20 6 9 17l-5-5"/></svg>'
+          : pin.n;
+        stageFrame.appendChild(el);
+      });
+
+      function applyPin(button) {
+        const card = button.closest('.pincard');
+        card.style.opacity = '0.75';
+        card.querySelector('.pinbadge').classList.add('done');
+        card.querySelector('.pinbadge').innerHTML = '<svg viewBox="0 0 24 24" width="9" height="9" fill="none" stroke="currentColor" stroke-width="4"><path d="M20 6 9 17l-5-5"/></svg>';
+        card.querySelector('.ph').lastChild.textContent = card.querySelector('.ph').lastChild.textContent + ' — applied';
+        button.parentElement.remove();
+        recount();
+      }
+
+      function applyAll() {
+        document.querySelectorAll('.pincard button.btn-primary').forEach((b) => applyPin(b));
+      }
+
+      function recount() {
+        const open = document.querySelectorAll('.pincard button.btn-primary').length;
+        document.getElementById('pinCount').textContent = open ? open + ' open' : 'all applied';
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') clearInterval(streamTimer);
+      });
+    </script>
+  </body>
+</html>

--- a/prototypes/slide-builder/deck-data.js
+++ b/prototypes/slide-builder/deck-data.js
@@ -1,0 +1,251 @@
+/*
+ * deck-data.js — the sample deck plus a tiny renderer.
+ *
+ * This is deliberately a direct mirror of the PRD's slide document: a slide is
+ * { layout, blocks[], notes, transition }, and a block is a discriminated union
+ * on a STRING `kind`. Slotted blocks carry `slot`; free blocks carry `box`.
+ * Every prototype renders from THIS data, so the editor, the player, the
+ * presenter view, the themes gallery and the public page cannot drift.
+ */
+
+// Stand-in images: CSS gradients, so the prototypes stay self-contained.
+const IMG = {
+  workshop:
+    'linear-gradient(135deg, oklch(0.546 0.245 262.881), oklch(0.623 0.214 259.815) 55%, oklch(0.809 0.105 251.813))',
+  rubric: 'linear-gradient(140deg, oklch(0.596 0.145 163.225), oklch(0.696 0.17 162.48) 60%, oklch(0.83 0.12 165))',
+  charts: 'linear-gradient(125deg, oklch(0.666 0.179 58.318), oklch(0.769 0.188 70.08) 70%, oklch(0.86 0.14 80))'
+};
+
+const DECK = {
+  id: 'dk_assess',
+  title: 'Designing Effective Assessments',
+  themeId: 'classic',
+  course: 'Instructional Design 201',
+  lesson: 'Designing Effective Assessments',
+  slides: [
+    {
+      layout: 'cover',
+      notes:
+        'Set the frame: we are not talking about grading, we are talking about evidence. Ask who has written a quiz question in the last month.',
+      blocks: [
+        { kind: 'eyebrow', slot: 'main', text: 'Instructional Design 201 · Module 4' },
+        { kind: 'heading', slot: 'main', level: 'hero', text: 'Designing Effective Assessments' },
+        {
+          kind: 'text',
+          slot: 'main',
+          emphasis: 'muted',
+          text: 'How to write items that measure what you actually taught.'
+        }
+      ]
+    },
+    {
+      layout: 'section-break',
+      notes: 'Transition slide. Keep it to ten seconds.',
+      blocks: [{ kind: 'heading', slot: 'main', level: 'section', text: 'Part 1 — Start with the outcome' }]
+    },
+    {
+      layout: 'two-col',
+      notes:
+        'The single most common failure: the question is written first, then an outcome is reverse-engineered to justify it. Walk through the example on screen.',
+      blocks: [
+        { kind: 'eyebrow', slot: 'left', text: 'The core move' },
+        { kind: 'heading', slot: 'left', level: 'page', text: 'Write the outcome before the question' },
+        {
+          kind: 'text',
+          slot: 'left',
+          text: 'An item that cannot name the outcome it measures is decoration. Name the behaviour, then build the evidence for it.'
+        },
+        { kind: 'image', slot: 'media', src: IMG.workshop, alt: 'Workshop participants mapping outcomes to items' }
+      ]
+    },
+    {
+      layout: 'bullets',
+      notes: 'Spend the most time here. Ask for a show of hands on which trait their current quiz fails.',
+      blocks: [
+        { kind: 'heading', slot: 'main', level: 'page', text: 'Four traits of a usable item' },
+        {
+          kind: 'bullets',
+          slot: 'main',
+          items: [
+            'It maps to exactly one stated outcome',
+            'A learner who knows the material answers it correctly',
+            'A learner who does not cannot guess it',
+            'The distractors are all plausible to a novice'
+          ]
+        }
+      ]
+    },
+    {
+      layout: 'image-right',
+      notes: 'The rubric is the contract. Show them the two-column version from the workbook.',
+      blocks: [
+        { kind: 'heading', slot: 'left', level: 'page', text: 'A rubric is a promise you make first' },
+        {
+          kind: 'text',
+          slot: 'left',
+          text: 'Publish it with the task, not with the grade. Learners calibrate to what you measure, so measure the thing you want.'
+        },
+        { kind: 'image', slot: 'media', src: IMG.rubric, alt: 'A two-column analytic rubric' }
+      ]
+    },
+    {
+      layout: 'kpi-row',
+      notes: 'Numbers are from the 2025 cohort study — cite it if asked, do not put the citation on the slide.',
+      blocks: [
+        { kind: 'heading', slot: 'main', level: 'page', text: 'What changed when cohorts published rubrics up front' },
+        {
+          kind: 'kpis',
+          slot: 'main',
+          items: [
+            { value: '+31%', label: 'Items answered on first attempt' },
+            { value: '−48%', label: 'Regrade requests' },
+            { value: '2.4×', label: 'Revision submissions' }
+          ]
+        }
+      ]
+    },
+    {
+      layout: 'quote',
+      notes: 'Pause here. Let it sit before moving on.',
+      blocks: [
+        {
+          kind: 'quote',
+          slot: 'main',
+          text: 'Assessment is the point at which your course finds out whether it worked.',
+          attribution: 'Dylan Wiliam, paraphrased'
+        }
+      ]
+    },
+    {
+      layout: 'title-body',
+      notes: 'Close with the assignment. They build three items and bring them to the next session.',
+      blocks: [
+        { kind: 'eyebrow', slot: 'main', text: 'Before the next session' },
+        { kind: 'heading', slot: 'main', level: 'page', text: 'Bring three items you have written' },
+        {
+          kind: 'text',
+          slot: 'main',
+          text: 'One recall, one applied, one scenario. Name the outcome each one measures. We will workshop them live.'
+        },
+        { kind: 'divider', slot: 'main' },
+        { kind: 'text', slot: 'main', emphasis: 'accent', text: 'Post them to the cohort newsfeed by Thursday.' }
+      ]
+    }
+  ]
+};
+
+/* A deliberately overflowing free-position slide, used to show the guard.
+ * y + h = 760 + 400 = 1160 > 1080, so ZSlide.superRefine rejects it. */
+const FREE_SLIDE = {
+  layout: 'free',
+  notes: 'Free-position example. The pull-quote block is dragged past the bottom edge on purpose.',
+  blocks: [
+    { kind: 'eyebrow', box: { x: 160, y: 150, w: 700, h: 60 }, text: 'Case study' },
+    {
+      kind: 'heading',
+      level: 'section',
+      box: { x: 160, y: 220, w: 980, h: 260 },
+      text: 'One item, rewritten four times'
+    },
+    {
+      kind: 'text',
+      box: { x: 160, y: 520, w: 820, h: 200 },
+      text: 'Each pass removed a guessable distractor and tightened the stem to a single outcome.'
+    },
+    {
+      kind: 'image',
+      box: { x: 1180, y: 220, w: 580, h: 640 },
+      src: IMG.charts,
+      alt: 'Four revisions of the same item'
+    },
+    {
+      kind: 'quote',
+      box: { x: 160, y: 760, w: 820, h: 400 },
+      text: 'The fourth version was half the length.',
+      attribution: 'Cohort 12 review'
+    }
+  ]
+};
+
+/* ---------- renderer: block kind -> markup (mirrors the block registry) ---------- */
+
+function esc(value) {
+  return String(value).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c]);
+}
+
+function renderBlock(block) {
+  const emphasis = block.emphasis ? ` em-${block.emphasis}` : ' em-default';
+
+  switch (block.kind) {
+    case 'eyebrow':
+      return `<div class="b-eyebrow">${esc(block.text)}</div>`;
+    case 'heading':
+      return `<h2 class="b-heading lv-${block.level || 'page'}">${esc(block.text)}</h2>`;
+    case 'text':
+      return `<p class="b-text${emphasis}">${esc(block.text)}</p>`;
+    case 'bullets':
+      return `<ul class="b-bullets">${block.items.map((i) => `<li><span>${esc(i)}</span></li>`).join('')}</ul>`;
+    case 'image':
+      return `<div class="b-image" role="img" aria-label="${esc(block.alt)}" style="background-image:${block.src}"></div>`;
+    case 'quote':
+      return `<div><p class="b-quote">“${esc(block.text)}”</p>${block.attribution ? `<div class="b-attr">— ${esc(block.attribution)}</div>` : ''}</div>`;
+    case 'kpis':
+      return `<div class="b-kpis">${block.items
+        .map((k) => `<div class="b-kpi"><div class="v">${esc(k.value)}</div><div class="l">${esc(k.label)}</div></div>`)
+        .join('')}</div>`;
+    case 'code':
+      return `<pre class="b-code">${esc(block.code)}</pre>`;
+    case 'divider':
+      return '<hr class="b-divider" />';
+    default:
+      return '';
+  }
+}
+
+function renderSlide(slide, options) {
+  const opts = options || {};
+  const theme = opts.theme || DECK.themeId;
+  const chrome = opts.chrome !== false;
+
+  let inner;
+
+  if (slide.layout === 'free') {
+    inner = slide.blocks
+      .map((block, index) => {
+        const box = block.box;
+        const overflow = box.y + box.h > 1080 || box.x + box.w > 1920;
+        return `<div class="fblock${overflow ? ' is-overflow' : ''}" data-block="${index}"
+          style="--x:${box.x};--y:${box.y};--w:${box.w};--h:${box.h}">${renderBlock(block)}</div>`;
+      })
+      .join('');
+    inner = `<div class="lay lay-free">${inner}</div>`;
+  } else {
+    const slots = {};
+    slide.blocks.forEach((block, index) => {
+      const slot = block.slot || 'main';
+      (slots[slot] = slots[slot] || []).push(`<div data-block="${index}" class="blk">${renderBlock(block)}</div>`);
+    });
+    const order = slide.layout === 'image-left' ? ['media', 'left', 'main'] : ['left', 'main', 'media', 'right'];
+    inner = order
+      .filter((slot) => slots[slot])
+      .map((slot) => `<div class="slot${slot === 'media' ? ' slot-media' : ''}">${slots[slot].join('')}</div>`)
+      .join('');
+    inner = `<div class="lay lay-${slide.layout}">${inner}</div>`;
+  }
+
+  const foot =
+    chrome && slide.layout !== 'cover' && slide.layout !== 'section-break'
+      ? `<div class="slide-foot"><span class="logo"><span class="mk">A</span>Acme Academy</span><span>${esc(DECK.title)}</span></div>`
+      : '';
+
+  return `<div class="slide-frame theme-${theme}">${inner}${foot}</div>`;
+}
+
+/** Blocks whose declared box escapes the 1920x1080 canvas. */
+function overflowingBlocks(slide) {
+  if (slide.layout !== 'free') return [];
+
+  return slide.blocks.filter(
+    (block) => block.box && (block.box.y + block.box.h > 1080 || block.box.x + block.box.w > 1920)
+  );
+}

--- a/prototypes/slide-builder/deck-editor-free.html
+++ b/prototypes/slide-builder/deck-editor-free.html
@@ -1,0 +1,296 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Deck editor — free position · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="deck.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      body { overflow: hidden; }
+      .ed-head { height: 56px; border-bottom: 1px solid var(--border); background: var(--background); display: flex; align-items: center; gap: 10px; padding: 0 12px; flex-shrink: 0; }
+      .ed-head .t { font-size: 15px; letter-spacing: -0.01em; }
+      .ed-head .sp { flex: 1; }
+      .fblock { cursor: grab; }
+      .fblock.dragging { cursor: grabbing; }
+      .num { font-variant-numeric: tabular-nums; }
+      .box-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+      .box-field { display: grid; gap: 4px; }
+      .box-field span { font-size: 11px; color: var(--muted-foreground); }
+      .box-field input { width: 100%; font-family: ui-monospace, Menlo, monospace; font-size: 12.5px; }
+    </style>
+  </head>
+  <body>
+    <header class="ed-head">
+      <a class="icon-btn" href="deck-editor.html" title="Back" aria-label="Back">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m12 19-7-7 7-7M19 12H5" /></svg>
+      </a>
+      <span class="t">Designing Effective Assessments</span>
+      <span class="badge badge-muted">Slide 9 · Free position</span>
+      <span class="badge badge-outline" id="dirty" hidden>Unsaved</span>
+      <span class="sp"></span>
+      <button class="btn btn-primary btn-sm" id="save" disabled>Save</button>
+    </header>
+
+    <div class="deck-shell">
+      <aside class="slide-rail">
+        <div class="slide-rail-head"><span>Slides</span><span class="tnum">9</span></div>
+        <div class="thumb" onclick="location.href='deck-editor.html'"><span class="n">7</span><div id="t7"></div></div>
+        <div class="thumb" onclick="location.href='deck-editor.html'"><span class="n">8</span><div id="t8"></div></div>
+        <div class="thumb active"><span class="n">9</span><span class="warn" id="railWarn" title="Content past the canvas edge">!</span><div id="t9"></div></div>
+      </aside>
+
+      <section class="stage">
+        <div class="stage-inner">
+          <div class="stage-bar">
+            <div class="stage-meta"><span>Slide 9 of 9</span><span>·</span><span>Free position</span></div>
+            <div class="segctl" role="group" aria-label="Canvas mode">
+              <button type="button" onclick="location.href='deck-editor.html'">Layout</button>
+              <button class="active" type="button">Free</button>
+            </div>
+          </div>
+
+          <div class="stage-frame" id="stageFrame"></div>
+
+          <div id="overflowNote" class="note-strip" style="margin-top: 12px">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 9v4M12 17h.01" /><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" /></svg>
+            <span>
+              <b id="ovName">Quote</b> extends past the canvas — <span class="num" id="ovMath">760 + 400 = 1160 &gt; 1080</span>.
+              Saving is blocked until it fits. Drag it up, or shrink its height.
+            </span>
+          </div>
+          <p class="insp-hint" style="margin-top: 10px; text-align: center">
+            Drag any block to move it. Snap guides appear at the canvas centre and thirds.
+          </p>
+        </div>
+      </section>
+
+      <aside class="inspector">
+        <div class="insp-tabs">
+          <button class="insp-tab" data-tab="slide" type="button">Slide</button>
+          <button class="insp-tab active" data-tab="block" type="button">Block</button>
+          <button class="insp-tab" data-tab="notes" type="button">Notes</button>
+        </div>
+
+        <div class="insp-body" data-panel="slide" hidden>
+          <div class="insp-group">
+            <span class="insp-label">Layout</span>
+            <div class="insp-row"><span>Free position</span><span class="badge badge-muted">free</span></div>
+            <p class="insp-hint">Every block on this slide carries its own x / y / w / h box. Switch back to a named layout to let slots own geometry again.</p>
+          </div>
+          <div class="insp-group">
+            <span class="insp-label">Canvas</span>
+            <div class="insp-row"><span>Size</span><span class="num">1920 × 1080</span></div>
+            <div class="insp-row"><span>Snap</span><label class="switch"><input type="checkbox" checked id="snap" /><span></span></label></div>
+          </div>
+        </div>
+
+        <div class="insp-body" data-panel="block">
+          <div class="insp-group">
+            <span class="insp-label">Selected block</span>
+            <div class="insp-row"><span id="bKind">Quote</span><span class="badge badge-muted">free</span></div>
+          </div>
+          <div class="insp-group">
+            <span class="insp-label">Box</span>
+            <div class="box-grid">
+              <label class="box-field"><span>X</span><input class="input" id="fx" type="number" step="10" /></label>
+              <label class="box-field"><span>Y</span><input class="input" id="fy" type="number" step="10" /></label>
+              <label class="box-field"><span>W</span><input class="input" id="fw" type="number" step="10" /></label>
+              <label class="box-field"><span>H</span><input class="input" id="fh" type="number" step="10" /></label>
+            </div>
+            <p class="insp-hint" id="boxHint"></p>
+          </div>
+          <div class="insp-group">
+            <span class="insp-label">Text</span>
+            <textarea class="input" id="bText" rows="3" style="resize: vertical"></textarea>
+          </div>
+          <div class="insp-group">
+            <button class="btn btn-outline btn-sm" id="fit" type="button">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" /></svg>
+              Snap back into the canvas
+            </button>
+          </div>
+        </div>
+
+        <div class="insp-body" data-panel="notes" hidden>
+          <div class="insp-group">
+            <span class="insp-label">Presenter notes</span>
+            <textarea class="input" rows="8" style="resize: vertical">Free-position example. The pull-quote block is dragged past the bottom edge on purpose.</textarea>
+          </div>
+        </div>
+      </aside>
+    </div>
+
+    <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme" style="position: fixed; bottom: 18px; right: 320px">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" /></svg>
+    </button>
+
+    <script src="deck-data.js"></script>
+    <script>
+      const slide = FREE_SLIDE;
+      let selected = 4; // the deliberately overflowing quote block
+
+      const stageFrame = document.getElementById('stageFrame');
+      document.getElementById('t7').innerHTML = renderSlide(DECK.slides[6], { chrome: false });
+      document.getElementById('t8').innerHTML = renderSlide(DECK.slides[7], { chrome: false });
+
+      function paint() {
+        stageFrame.innerHTML = renderSlide(slide);
+        document.getElementById('t9').innerHTML = renderSlide(slide, { chrome: false });
+
+        stageFrame.querySelectorAll('.fblock').forEach((el) => {
+          const index = +el.dataset.block;
+          el.onmousedown = (event) => startDrag(event, index, el);
+          el.onclick = () => selectBlock(index);
+          if (index === selected) drawSelection(el);
+        });
+
+        const bad = overflowingBlocks(slide);
+        const note = document.getElementById('overflowNote');
+        note.hidden = bad.length === 0;
+        document.getElementById('railWarn').hidden = bad.length === 0;
+        document.getElementById('save').disabled = bad.length > 0;
+
+        if (bad.length) {
+          const block = bad[0];
+          document.getElementById('ovName').textContent = block.kind;
+          const overY = block.box.y + block.box.h > 1080;
+          document.getElementById('ovMath').textContent = overY
+            ? `${block.box.y} + ${block.box.h} = ${block.box.y + block.box.h} > 1080`
+            : `${block.box.x} + ${block.box.w} = ${block.box.x + block.box.w} > 1920`;
+        }
+
+        syncFields();
+      }
+
+      function drawSelection(el) {
+        const marker = document.createElement('div');
+        marker.className = 'sel-box';
+        marker.dataset.label = slide.blocks[selected].kind;
+        const frame = stageFrame.getBoundingClientRect();
+        const box = el.getBoundingClientRect();
+        marker.style.left = box.left - frame.left + 'px';
+        marker.style.top = box.top - frame.top + 'px';
+        marker.style.width = box.width + 'px';
+        marker.style.height = box.height + 'px';
+        marker.innerHTML = '<span class="handle nw"></span><span class="handle ne"></span><span class="handle sw"></span><span class="handle se"></span>';
+        stageFrame.appendChild(marker);
+      }
+
+      function selectBlock(index) {
+        selected = index;
+        paint();
+      }
+
+      function syncFields() {
+        const block = slide.blocks[selected];
+        document.getElementById('bKind').textContent = block.kind;
+        ['x', 'y', 'w', 'h'].forEach((key) => (document.getElementById('f' + key).value = Math.round(block.box[key])));
+        document.getElementById('bText').value = block.text || '';
+        const bottom = block.box.y + block.box.h;
+        const right = block.box.x + block.box.w;
+        document.getElementById('boxHint').textContent = `Bottom edge ${Math.round(bottom)} / 1080 · right edge ${Math.round(right)} / 1920`;
+      }
+
+      ['x', 'y', 'w', 'h'].forEach((key) => {
+        document.getElementById('f' + key).oninput = (event) => {
+          slide.blocks[selected].box[key] = +event.target.value || 0;
+          markDirty();
+          paint();
+        };
+      });
+
+      document.getElementById('bText').oninput = (event) => {
+        slide.blocks[selected].text = event.target.value;
+        markDirty();
+        paint();
+      };
+
+      document.getElementById('fit').onclick = () => {
+        const box = slide.blocks[selected].box;
+        box.y = Math.min(box.y, 1080 - box.h);
+        box.x = Math.min(box.x, 1920 - box.w);
+        markDirty();
+        paint();
+      };
+
+      /* ---- drag with snap guides ---- */
+      function startDrag(event, index, el) {
+        event.preventDefault();
+        selected = index;
+        el.classList.add('dragging');
+
+        const frame = stageFrame.getBoundingClientRect();
+        const scale = 1920 / frame.width;
+        const box = slide.blocks[index].box;
+        const originX = event.clientX;
+        const originY = event.clientY;
+        const startX = box.x;
+        const startY = box.y;
+
+        function onMove(moveEvent) {
+          box.x = Math.round(startX + (moveEvent.clientX - originX) * scale);
+          box.y = Math.round(startY + (moveEvent.clientY - originY) * scale);
+
+          if (document.getElementById('snap').checked) {
+            [0, 640, 960, 1280, 1920].forEach((line) => {
+              if (Math.abs(box.x - line) < 24) box.x = line;
+              if (Math.abs(box.x + box.w - line) < 24) box.x = line - box.w;
+            });
+            [0, 360, 540, 720, 1080].forEach((line) => {
+              if (Math.abs(box.y - line) < 24) box.y = line;
+              if (Math.abs(box.y + box.h - line) < 24) box.y = line - box.h;
+            });
+          }
+
+          paint();
+          showGuides(box);
+        }
+
+        function onUp() {
+          removeEventListener('mousemove', onMove);
+          removeEventListener('mouseup', onUp);
+          stageFrame.querySelectorAll('.guide').forEach((g) => g.remove());
+          markDirty();
+          paint();
+        }
+
+        addEventListener('mousemove', onMove);
+        addEventListener('mouseup', onUp);
+      }
+
+      function showGuides(box) {
+        stageFrame.querySelectorAll('.guide').forEach((g) => g.remove());
+        const add = (className, style) => {
+          const guide = document.createElement('div');
+          guide.className = 'guide ' + className;
+          Object.assign(guide.style, style);
+          stageFrame.appendChild(guide);
+        };
+        if ([0, 640, 960, 1280, 1920].includes(box.x)) add('v', { left: (box.x / 1920) * 100 + '%' });
+        if ([0, 360, 540, 720, 1080].includes(box.y)) add('h', { top: (box.y / 1080) * 100 + '%' });
+      }
+
+      function markDirty() { document.getElementById('dirty').hidden = false; }
+
+      document.querySelectorAll('.insp-tab').forEach((tab) => {
+        tab.onclick = () => {
+          document.querySelectorAll('.insp-tab').forEach((t) => t.classList.toggle('active', t === tab));
+          document.querySelectorAll('.insp-body').forEach((b) => (b.hidden = b.dataset.panel !== tab.dataset.tab));
+        };
+      });
+
+      paint();
+
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>

--- a/prototypes/slide-builder/deck-editor.html
+++ b/prototypes/slide-builder/deck-editor.html
@@ -1,0 +1,408 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Deck editor · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="deck.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      body { overflow: hidden; }
+      /* Full-screen editor header — mirrors certificate-editor-header.svelte:
+         inline top bar with back, title, badges, discard/save. Not the floating pill. */
+      .ed-head { height: 56px; border-bottom: 1px solid var(--border); background: var(--background); display: flex; align-items: center; gap: 10px; padding: 0 12px; flex-shrink: 0; }
+      .ed-head .t { font-size: 15px; letter-spacing: -0.01em; }
+      .ed-head .badges { display: flex; gap: 6px; align-items: center; }
+      .ed-head .sp { flex: 1; }
+      .blk { position: relative; }
+    </style>
+  </head>
+  <body>
+    <header class="ed-head">
+      <a class="icon-btn" href="lesson-slide-tab.html" title="Back to lesson" aria-label="Back to lesson">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m12 19-7-7 7-7M19 12H5" /></svg>
+      </a>
+      <span class="t">Designing Effective Assessments</span>
+      <div class="badges">
+        <span class="badge badge-muted">Classic</span>
+        <span class="badge badge-outline" id="dirty" hidden>Unsaved</span>
+      </div>
+      <span class="sp"></span>
+      <a class="btn btn-ghost btn-sm" href="deck-ai.html">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M5.6 18.4l2.1-2.1M16.3 7.7l2.1-2.1" /></svg>
+        Ask AI
+      </a>
+      <a class="btn btn-ghost btn-sm" href="deck-export.html">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" /></svg>
+        Export
+      </a>
+      <a class="btn btn-secondary btn-sm" href="presenter.html" target="_blank">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 3h20v12H2zM12 15v6M8 21h8" /></svg>
+        Present
+      </a>
+      <button class="btn btn-primary btn-sm" id="save" disabled>Save</button>
+    </header>
+
+    <div class="deck-shell">
+      <!-- ============ slide rail ============ -->
+      <aside class="slide-rail" id="rail">
+        <div class="slide-rail-head"><span>Slides</span><span id="count" class="tnum">8</span></div>
+        <!-- thumbnails injected -->
+        <button class="slide-rail-add" id="addSlide">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 5v14M5 12h14" /></svg>
+          Add slide
+        </button>
+        <a class="slide-rail-add" href="deck-editor-free.html" style="border-style: solid">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3h7v7H3zM14 14h7v7h-7zM14 3h7v4h-7zM3 14h7v4H3z" /></svg>
+          Free-position slide
+        </a>
+      </aside>
+
+      <!-- ============ stage ============ -->
+      <section class="stage">
+        <div class="stage-inner">
+          <div class="stage-bar">
+            <div class="stage-meta">
+              <span id="pos">Slide 1 of 8</span>
+              <span>·</span>
+              <span id="layoutName">Cover</span>
+            </div>
+            <div class="segctl" role="group" aria-label="Canvas mode">
+              <button class="active" type="button">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3h18v18H3z" /><path d="M3 9h18" /></svg>
+                Layout
+              </button>
+              <button type="button" onclick="location.href='deck-editor-free.html'">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 5h6v6H5zM13 13h6v6h-6z" /></svg>
+                Free
+              </button>
+            </div>
+          </div>
+          <div class="stage-frame" id="stageFrame">
+            <!-- slide injected -->
+          </div>
+          <p class="insp-hint" style="margin-top: 10px; text-align: center">
+            Click a block on the canvas to select it. In layout mode blocks snap to their slot — switch to Free to drag.
+          </p>
+        </div>
+      </section>
+
+      <!-- ============ inspector ============ -->
+      <aside class="inspector">
+        <div class="insp-tabs">
+          <button class="insp-tab active" data-tab="slide" type="button">Slide</button>
+          <button class="insp-tab" data-tab="block" type="button">Block</button>
+          <button class="insp-tab" data-tab="notes" type="button">Notes</button>
+        </div>
+
+        <!-- Slide tab -->
+        <div class="insp-body" data-panel="slide">
+          <div class="insp-group">
+            <span class="insp-label">Layout</span>
+            <div class="layout-grid" id="layoutGrid"></div>
+            <p class="insp-hint">Slots own geometry, so text auto-fits and a slide cannot crop.</p>
+          </div>
+          <div class="insp-group">
+            <span class="insp-label">Background</span>
+            <div class="segctl">
+              <button class="active" type="button">Theme</button>
+              <button type="button">Solid</button>
+              <button type="button">Image</button>
+            </div>
+          </div>
+          <div class="insp-group">
+            <span class="insp-label">Transition</span>
+            <div class="segctl">
+              <button type="button">None</button>
+              <button class="active" type="button">Fade</button>
+              <button type="button">Slide</button>
+            </div>
+          </div>
+          <div class="insp-group">
+            <span class="insp-label">Theme</span>
+            <a class="btn btn-outline btn-sm" href="deck-themes.html" style="justify-content: space-between">
+              Classic
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m9 18 6-6-6-6" /></svg>
+            </a>
+            <p class="insp-hint">Themes carry no content — switching one never changes a word.</p>
+          </div>
+        </div>
+
+        <!-- Block tab -->
+        <div class="insp-body" data-panel="block" hidden>
+          <div id="blockEmpty" class="insp-hint">Select a block on the canvas to edit it.</div>
+          <div id="blockFields" hidden>
+            <div class="insp-group">
+              <span class="insp-label">Kind</span>
+              <div class="insp-row"><span id="bKind">Heading</span><span class="badge badge-muted" id="bSlot">slot: main</span></div>
+            </div>
+            <div class="insp-group">
+              <span class="insp-label">Text</span>
+              <textarea class="input" id="bText" rows="3" style="resize: vertical"></textarea>
+            </div>
+            <div class="insp-group">
+              <span class="insp-label">Level</span>
+              <div class="segctl">
+                <button type="button">Hero</button>
+                <button type="button">Section</button>
+                <button class="active" type="button">Page</button>
+              </div>
+            </div>
+            <div class="insp-group">
+              <span class="insp-label">Align</span>
+              <div class="segctl">
+                <button class="active" type="button">Start</button>
+                <button type="button">Center</button>
+                <button type="button">End</button>
+              </div>
+            </div>
+            <div class="insp-group">
+              <span class="insp-label">Emphasis</span>
+              <div class="segctl">
+                <button class="active" type="button">Default</button>
+                <button type="button">Muted</button>
+                <button type="button">Accent</button>
+              </div>
+            </div>
+            <div class="insp-group">
+              <div class="insp-row">
+                <span>Detach to free position</span>
+                <label class="switch"><input type="checkbox" onchange="if(this.checked) location.href='deck-editor-free.html'" /><span></span></label>
+              </div>
+              <p class="insp-hint">Gives this block an explicit x / y / w / h box on the 1920×1080 canvas.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Notes tab -->
+        <div class="insp-body" data-panel="notes" hidden>
+          <div class="insp-group">
+            <span class="insp-label">Presenter notes</span>
+            <textarea class="input" id="notes" rows="10" style="resize: vertical"></textarea>
+            <p class="insp-hint">Shown only in presenter mode. Never rendered to learners or exports.</p>
+          </div>
+        </div>
+      </aside>
+    </div>
+
+    <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme" style="position: fixed; bottom: 18px; right: 320px">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" /></svg>
+    </button>
+
+    <script src="deck-data.js"></script>
+    <script>
+      const LAYOUTS = ['cover', 'title-body', 'two-col', 'bullets', 'image-left', 'image-right', 'quote', 'code', 'kpi-row', 'section-break'];
+      const LAYOUT_LABEL = {
+        cover: 'Cover', 'title-body': 'Title + body', 'two-col': 'Two column', bullets: 'Bullets',
+        'image-left': 'Image left', 'image-right': 'Image right', quote: 'Quote', code: 'Code',
+        'kpi-row': 'KPI row', 'section-break': 'Section break', free: 'Free position'
+      };
+
+      let current = 0;
+      let selectedBlock = null;
+
+      const rail = document.getElementById('rail');
+      const addBtn = document.getElementById('addSlide');
+      const stageFrame = document.getElementById('stageFrame');
+
+      /* ---- rail ---- */
+      function buildRail() {
+        DECK.slides.forEach((slide, index) => {
+          const row = document.createElement('div');
+          row.className = 'thumb-row' + (index === current ? ' active' : '');
+          row.draggable = true;
+          row.dataset.index = index;
+          row.innerHTML =
+            `<span class="n">${index + 1}</span>` +
+            `<div class="thumb${index === current ? ' active' : ''}">` +
+            renderSlide(slide, { chrome: false }) +
+            '<span class="drag"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor"><circle cx="9" cy="6" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="18" r="1"/><circle cx="15" cy="6" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="18" r="1"/></svg></span></div>';
+          row.onclick = () => select(index);
+          rail.insertBefore(row, addBtn);
+        });
+        wireDrag();
+      }
+
+      /* ---- drag to reorder ---- */
+      function wireDrag() {
+        let dragged = null;
+        rail.querySelectorAll('.thumb-row').forEach((el) => {
+          el.ondragstart = () => { dragged = el; el.style.opacity = '0.4'; };
+          el.ondragend = () => { dragged = null; el.style.opacity = ''; rail.querySelectorAll('.thumb-row').forEach((t) => t.classList.remove('drop-target')); };
+          el.ondragover = (event) => { event.preventDefault(); if (el !== dragged) el.classList.add('drop-target'); };
+          el.ondragleave = () => el.classList.remove('drop-target');
+          el.ondrop = (event) => {
+            event.preventDefault();
+            el.classList.remove('drop-target');
+            if (!dragged || dragged === el) return;
+
+            const from = +dragged.dataset.index;
+            const to = +el.dataset.index;
+            const [moved] = DECK.slides.splice(from, 1);
+            DECK.slides.splice(to, 0, moved);
+            rail.querySelectorAll('.thumb-row').forEach((t) => t.remove());
+            current = to;
+            buildRail();
+            render();
+            markDirty();
+          };
+        });
+      }
+
+      /* ---- stage ---- */
+      function render() {
+        const slide = DECK.slides[current];
+        stageFrame.innerHTML = renderSlide(slide);
+        document.getElementById('pos').textContent = `Slide ${current + 1} of ${DECK.slides.length}`;
+        document.getElementById('layoutName').textContent = LAYOUT_LABEL[slide.layout];
+        document.getElementById('count').textContent = DECK.slides.length;
+        document.getElementById('notes').value = slide.notes || '';
+
+        stageFrame.querySelectorAll('[data-block]').forEach((el) => {
+          el.style.cursor = 'pointer';
+          el.onclick = (event) => { event.stopPropagation(); selectBlock(+el.dataset.block, el); };
+        });
+
+        document.querySelectorAll('#layoutGrid .layout-opt').forEach((opt) => {
+          opt.classList.toggle('active', opt.dataset.layout === slide.layout);
+        });
+      }
+
+      function select(index) {
+        current = index;
+        selectedBlock = null;
+        rail.querySelectorAll('.thumb-row').forEach((t, i) => {
+          t.classList.toggle('active', i === index);
+          t.querySelector('.thumb').classList.toggle('active', i === index);
+        });
+        clearSelection();
+        render();
+      }
+
+      /* ---- block selection ---- */
+      function clearSelection() {
+        stageFrame.querySelectorAll('.sel-box').forEach((b) => b.remove());
+        document.getElementById('blockEmpty').hidden = false;
+        document.getElementById('blockFields').hidden = true;
+      }
+
+      function selectBlock(index, el) {
+        selectedBlock = index;
+        stageFrame.querySelectorAll('.sel-box').forEach((b) => b.remove());
+
+        const block = DECK.slides[current].blocks[index];
+        const frame = stageFrame.getBoundingClientRect();
+        const box = el.getBoundingClientRect();
+        const marker = document.createElement('div');
+        marker.className = 'sel-box';
+        marker.dataset.label = block.kind;
+        marker.style.left = box.left - frame.left - 3 + 'px';
+        marker.style.top = box.top - frame.top - 3 + 'px';
+        marker.style.width = box.width + 6 + 'px';
+        marker.style.height = box.height + 6 + 'px';
+        stageFrame.appendChild(marker);
+
+        showTab('block');
+        document.getElementById('blockEmpty').hidden = true;
+        document.getElementById('blockFields').hidden = false;
+        document.getElementById('bKind').textContent = block.kind;
+        document.getElementById('bSlot').textContent = 'slot: ' + (block.slot || 'main');
+        const field = document.getElementById('bText');
+        field.value = block.text || (block.items ? block.items.join('\n') : '');
+        field.oninput = () => {
+          if (block.items) block.items = field.value.split('\n');
+          else block.text = field.value;
+          render();
+          selectedBlock = null;
+          markDirty();
+        };
+      }
+
+      /* ---- inspector tabs ---- */
+      function showTab(name) {
+        document.querySelectorAll('.insp-tab').forEach((t) => t.classList.toggle('active', t.dataset.tab === name));
+        document.querySelectorAll('.insp-body').forEach((b) => (b.hidden = b.dataset.panel !== name));
+      }
+      document.querySelectorAll('.insp-tab').forEach((t) => (t.onclick = () => showTab(t.dataset.tab)));
+
+      /* ---- layout picker ---- */
+      const grid = document.getElementById('layoutGrid');
+      LAYOUTS.forEach((layout) => {
+        const opt = document.createElement('button');
+        opt.className = 'layout-opt';
+        opt.type = 'button';
+        opt.dataset.layout = layout;
+        opt.title = LAYOUT_LABEL[layout];
+        if (layout === 'two-col' || layout === 'image-left' || layout === 'image-right') {
+          opt.classList.add('split');
+          const bars = '<span><i class="t"></i><i class="l"></i><i class="l" style="width:70%"></i></span>';
+          const fill = '<span class="fill"></span>';
+          opt.innerHTML = layout === 'image-left' ? fill + bars : bars + fill;
+        } else if (layout === 'cover' || layout === 'section-break' || layout === 'quote' || layout === 'kpi-row') {
+          opt.classList.add('mid');
+          opt.innerHTML = '<i class="t" style="width:85%;height:5px"></i><i class="l" style="width:55%"></i>';
+        } else {
+          opt.innerHTML = '<i class="t"></i><i class="l"></i><i class="l" style="width:80%"></i>';
+        }
+        opt.onclick = () => { DECK.slides[current].layout = layout; render(); rebuildThumb(current); markDirty(); };
+        grid.appendChild(opt);
+      });
+
+      function rebuildThumb(index) {
+        const el = rail.querySelectorAll('.thumb-row')[index].querySelector('.thumb');
+        el.innerHTML = renderSlide(DECK.slides[index], { chrome: false });
+      }
+
+      /* ---- notes ---- */
+      document.getElementById('notes').oninput = (event) => { DECK.slides[current].notes = event.target.value; markDirty(); };
+
+      /* ---- add slide ---- */
+      addBtn.onclick = () => {
+        DECK.slides.splice(current + 1, 0, {
+          layout: 'title-body',
+          notes: '',
+          blocks: [
+            { kind: 'heading', slot: 'main', level: 'page', text: 'New slide' },
+            { kind: 'text', slot: 'main', text: 'Add your point here.' }
+          ]
+        });
+        rail.querySelectorAll('.thumb-row').forEach((t) => t.remove());
+        current += 1;
+        buildRail();
+        render();
+        markDirty();
+      };
+
+      /* ---- dirty state ---- */
+      function markDirty() {
+        document.getElementById('dirty').hidden = false;
+        document.getElementById('save').disabled = false;
+      }
+      document.getElementById('save').onclick = () => {
+        document.getElementById('dirty').hidden = true;
+        document.getElementById('save').disabled = true;
+      };
+
+      /* ---- keyboard ---- */
+      addEventListener('keydown', (event) => {
+        if (event.target.tagName === 'TEXTAREA' || event.target.tagName === 'INPUT') return;
+
+        if (event.key === 'ArrowDown' && current < DECK.slides.length - 1) select(current + 1);
+        if (event.key === 'ArrowUp' && current > 0) select(current - 1);
+      });
+
+      buildRail();
+      render();
+
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>

--- a/prototypes/slide-builder/deck-export.html
+++ b/prototypes/slide-builder/deck-export.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Export deck · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="deck.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .scrim { position: fixed; inset: 0; background: rgb(0 0 0 / 0.5); display: grid; place-items: center; z-index: 200; padding: 20px; }
+      .modal { background: var(--background); border: 1px solid var(--border); border-radius: var(--radius-lg); width: min(100%, 560px); padding: 24px; display: grid; gap: 16px; box-shadow: var(--shadow-lg, 0 10px 15px -3px rgb(0 0 0 / 0.1)); }
+      .modal h2 { margin: 0; font-size: 18px; font-weight: 600; }
+      .modal .sub { margin: 0; font-size: 13.5px; color: var(--muted-foreground); }
+      .fmt { display: grid; gap: 10px; }
+      .fopt { border: 1px solid var(--border); border-radius: var(--radius-md); padding: 13px 14px; display: grid; grid-template-columns: 20px 1fr; gap: 12px; cursor: pointer; background: var(--card); }
+      .fopt.on { border-color: var(--primary); box-shadow: 0 0 0 2px color-mix(in oklch, var(--primary) 18%, transparent); }
+      .fopt .radio { width: 18px; height: 18px; border-radius: 999px; border: 1.5px solid var(--border); margin-top: 2px; display: grid; place-items: center; }
+      .fopt.on .radio { border-color: var(--primary); }
+      .fopt.on .radio::after { content: ''; width: 9px; height: 9px; border-radius: 999px; background: var(--primary); }
+      .fopt h4 { margin: 0 0 3px; font-size: 14px; font-weight: 500; display: flex; align-items: center; gap: 8px; }
+      .fopt p { margin: 0; font-size: 12.5px; color: var(--muted-foreground); line-height: 1.55; }
+      .jobrow { display: flex; align-items: center; gap: 12px; border: 1px solid var(--border); border-radius: var(--radius-md); padding: 11px 13px; font-size: 13px; background: var(--card); }
+      .jobrow .g { width: 30px; height: 30px; border-radius: var(--radius-sm); display: grid; place-items: center; background: var(--muted); flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="brand"><div class="brand-mark">C</div><div class="brand-name">ClassroomIO</div></div>
+        <div class="nav-label">Content</div>
+        <a class="nav-item active" href="deck-library.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 3h20v12H2zM12 15v6M8 21h8"/></svg>Decks</a>
+        <div class="sidebar-foot"><div class="avatar">JD</div><div class="who"><div class="nm">Jordan Diallo</div><div class="rl">Admin</div></div></div>
+      </aside>
+
+      <div class="main">
+        <header class="topbar">
+          <div class="crumbs"><a href="deck-library.html">Decks</a><span class="sep">/</span><a href="deck-editor.html">Designing Effective Assessments</a><span class="sep">/</span><span>Export</span></div>
+          <div class="top-actions">
+            <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+          </div>
+        </header>
+
+        <main class="content">
+          <div class="wrap" style="max-width: 800px">
+            <div class="page-head">
+              <div>
+                <h1 class="page-title">Exports</h1>
+                <p class="page-sub">Exports run in the background, so you can close this page and come back to the file.</p>
+              </div>
+              <button class="btn btn-primary" onclick="document.getElementById('scrim').hidden=false">New export</button>
+            </div>
+
+            <div style="display: grid; gap: 10px">
+              <div class="jobrow">
+                <span class="g"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg></span>
+                <div style="flex: 1; min-width: 0">
+                  <div style="font-weight: 500">Designing Effective Assessments.pdf</div>
+                  <div class="hint" style="margin: 0">8 pages · 4.2 MB · finished 3 minutes ago</div>
+                </div>
+                <button class="btn btn-outline btn-sm">Download</button>
+              </div>
+
+              <div class="jobrow">
+                <span class="g"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor"><path d="M2 3h20v12H2zM12 15v6M8 21h8"/></svg></span>
+                <div style="flex: 1; min-width: 0">
+                  <div style="font-weight: 500">Designing Effective Assessments.pptx</div>
+                  <div class="hint" style="margin: 0">Capturing slide 5 of 8…</div>
+                  <div class="progress progress-thin" style="margin-top: 7px"><span style="width: 62%"></span></div>
+                </div>
+                <button class="btn btn-ghost btn-sm">Cancel</button>
+              </div>
+
+              <div class="jobrow" style="opacity: 0.8">
+                <span class="g"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor"><path d="M12 9v4M12 17h.01"/><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg></span>
+                <div style="flex: 1; min-width: 0">
+                  <div style="font-weight: 500">Rubric Clinic.pptx</div>
+                  <div class="hint" style="margin: 0">Failed — a slide image could not be loaded. Retry to run it again.</div>
+                </div>
+                <button class="btn btn-outline btn-sm">Retry</button>
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <!-- export dialog -->
+    <div class="scrim" id="scrim">
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="exTitle">
+        <div>
+          <h2 id="exTitle">Export deck</h2>
+          <p class="sub">Designing Effective Assessments · 8 slides</p>
+        </div>
+
+        <div class="fmt">
+          <label class="fopt on" id="optPdf">
+            <span class="radio"></span>
+            <span>
+              <h4>PDF <span class="badge badge-success-soft">Best fidelity</span></h4>
+              <p>One 1920×1080 page per slide. Text stays selectable and vector where the theme allows, so it prints and zooms cleanly.</p>
+            </span>
+          </label>
+
+          <label class="fopt" id="optPptx">
+            <span class="radio"></span>
+            <span>
+              <h4>PowerPoint (.pptx)</h4>
+              <p>One full-bleed image per slide. Opens anywhere, keeps your theme exactly — but the text is <b>not editable</b> in PowerPoint. Presenter notes are carried across.</p>
+            </span>
+          </label>
+        </div>
+
+        <div class="note-strip" id="longWarn" hidden>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 9v4M12 17h.01"/><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg>
+          <span>PowerPoint export captures each slide separately, so a deck this long takes about <b>40 seconds</b>. It runs in the background — you can leave this page.</span>
+        </div>
+
+        <div style="display: flex; gap: 8px; justify-content: flex-end">
+          <button class="btn btn-outline" onclick="document.getElementById('scrim').hidden=true">Cancel</button>
+          <button class="btn btn-primary" onclick="document.getElementById('scrim').hidden=true">Start export</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      const pdf = document.getElementById('optPdf');
+      const pptx = document.getElementById('optPptx');
+      const warn = document.getElementById('longWarn');
+
+      pdf.onclick = () => { pdf.classList.add('on'); pptx.classList.remove('on'); warn.hidden = true; };
+      pptx.onclick = () => { pptx.classList.add('on'); pdf.classList.remove('on'); warn.hidden = false; };
+
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>

--- a/prototypes/slide-builder/deck-import.html
+++ b/prototypes/slide-builder/deck-import.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Import a deck · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="deck.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .steps { display: flex; align-items: center; gap: 10px; margin-bottom: 20px; font-size: 12.5px; }
+      .stepi { display: flex; align-items: center; gap: 7px; color: var(--muted-foreground); }
+      .stepi .b { width: 20px; height: 20px; border-radius: 999px; border: 1px solid var(--border); display: grid; place-items: center; font-size: 11px; font-weight: 600; }
+      .stepi.on { color: var(--foreground); font-weight: 500; }
+      .stepi.on .b { background: var(--primary); border-color: var(--primary); color: var(--primary-foreground); }
+      .stepi.done .b { background: var(--success-soft); border-color: transparent; color: var(--success); }
+      .steps .dash { flex: 1; height: 1px; background: var(--border); max-width: 42px; }
+      .maphead { display: grid; grid-template-columns: 1fr 150px 1.1fr; gap: 12px; padding: 8px 12px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted-foreground); border-bottom: 1px solid var(--border); }
+      .drop { border: 1px dashed var(--border); border-radius: var(--radius-lg); padding: 44px 24px; text-align: center; display: grid; justify-items: center; gap: 12px; background: var(--muted); }
+      .drop .di { width: 44px; height: 44px; border-radius: var(--radius-md); background: var(--background); display: grid; place-items: center; border: 1px solid var(--border); }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="brand"><div class="brand-mark">C</div><div class="brand-name">ClassroomIO</div></div>
+        <div class="nav-label">Content</div>
+        <a class="nav-item" href="lesson-slide-tab.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Courses</a>
+        <a class="nav-item active" href="deck-library.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 3h20v12H2zM12 15v6M8 21h8"/></svg>Decks</a>
+        <div class="sidebar-foot"><div class="avatar">JD</div><div class="who"><div class="nm">Jordan Diallo</div><div class="rl">Admin</div></div></div>
+      </aside>
+
+      <div class="main">
+        <header class="topbar">
+          <div class="crumbs"><a href="deck-library.html">Decks</a><span class="sep">/</span><span>Import</span></div>
+          <div class="top-actions">
+            <button class="btn btn-outline btn-sm" onclick="setStep(step === 1 ? 2 : 1)">Toggle upload / review</button>
+            <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+          </div>
+        </header>
+
+        <main class="content">
+          <div class="wrap" style="max-width: 980px">
+            <div class="page-head">
+              <div>
+                <h1 class="page-title">Import a PowerPoint deck</h1>
+                <p class="page-sub">Bring the content of an existing deck across as native slides you can edit, theme and export.</p>
+              </div>
+            </div>
+
+            <div class="steps">
+              <span class="stepi done" id="s1"><span class="b">1</span>Upload</span>
+              <span class="dash"></span>
+              <span class="stepi on" id="s2"><span class="b">2</span>Review mapping</span>
+              <span class="dash"></span>
+              <span class="stepi" id="s3"><span class="b">3</span>Create deck</span>
+            </div>
+
+            <!-- STEP 1 -->
+            <section id="step1" hidden>
+              <div class="drop">
+                <span class="di"><svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/></svg></span>
+                <div>
+                  <h3 style="margin: 0 0 4px; font-size: 15px; font-weight: 500">Drop a .pptx here</h3>
+                  <p class="hint" style="margin: 0">Up to 50 MB. We unzip it in your workspace — the file is never sent anywhere else.</p>
+                </div>
+                <button class="btn btn-primary btn-sm" onclick="setStep(2)">Choose a file</button>
+              </div>
+              <div class="note-strip" style="margin-top: 16px">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 9v4M12 17h.01"/><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg>
+                <span><b>What comes across:</b> the text of every slide, and every image in the file. <b>What does not:</b> original positioning, fonts, animations and speaker-view formatting. Slides are rebuilt on ClassroomIO layouts, so they will look like your theme, not like the original.</span>
+              </div>
+            </section>
+
+            <!-- STEP 2 -->
+            <section id="step2">
+              <div class="insp-row" style="margin-bottom: 12px">
+                <div style="display: flex; gap: 8px; align-items: center">
+                  <span class="badge badge-muted">Q3-enablement.pptx</span>
+                  <span class="hint" style="margin: 0">18 slides · 7 images extracted</span>
+                </div>
+                <select class="select" style="width: auto"><option>Theme: Your brand</option><option>Theme: Classic</option></select>
+              </div>
+
+              <div class="card" style="overflow: hidden">
+                <div class="maphead"><span>Source slide text</span><span>Layout</span><span>Result</span></div>
+                <div id="rows"></div>
+              </div>
+
+              <h3 style="font-size: 14px; font-weight: 500; margin: 22px 0 8px">Unplaced images</h3>
+              <p class="hint" style="margin: 0 0 10px">Extracted from <code>ppt/media/</code> and added to your media library. Drag one onto a slide, or leave them — nothing is lost either way.</p>
+              <div class="tray">
+                <div class="tray-items" id="tray"></div>
+              </div>
+
+              <div style="display: flex; gap: 8px; justify-content: flex-end; margin-top: 20px">
+                <a class="btn btn-outline" href="deck-library.html">Cancel</a>
+                <a class="btn btn-primary" href="deck-editor.html">Create deck with 18 slides</a>
+              </div>
+            </section>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <script src="deck-data.js"></script>
+    <script>
+      let step = 2;
+
+      const ROWS = [
+        { src: 'Q3 Enablement\nSales Kickoff 2026', title: 'Q3 Enablement', layout: 'cover', cover: 0 },
+        { src: 'Agenda\n• Where we landed in Q2\n• The three plays\n• What changes for you', title: 'Agenda', layout: 'bullets', cover: 3 },
+        { src: 'Where we landed\n31% attach rate\n48% fewer escalations\n2.4x expansion', title: 'Where we landed', layout: 'kpi-row', cover: 5 },
+        { src: 'The discovery play\nLead with the outcome the buyer already named.', title: 'The discovery play', layout: 'two-col', cover: 2 },
+        { src: '“We stopped pitching features in week one.”\n— Regional lead', title: 'Quote', layout: 'quote', cover: 6 }
+      ];
+
+      const LAYOUTS = ['cover', 'title-body', 'two-col', 'bullets', 'image-left', 'image-right', 'quote', 'kpi-row', 'section-break'];
+
+      document.getElementById('rows').innerHTML = ROWS.map((row, index) => `
+        <div class="map-row">
+          <div class="map-src"><b>Slide ${index + 1}</b>${row.src.replace(/\n/g, '<br />')}</div>
+          <select class="select" data-row="${index}">
+            ${LAYOUTS.map((l) => `<option ${l === row.layout ? 'selected' : ''}>${l}</option>`).join('')}
+          </select>
+          <div style="border:1px solid var(--border);border-radius:var(--radius-sm);overflow:hidden">
+            ${renderSlide(DECK.slides[row.cover], { theme: 'brand', chrome: false })}
+          </div>
+        </div>`).join('');
+
+      const GRADS = [
+        'linear-gradient(135deg,#6366f1,#a5b4fc)', 'linear-gradient(135deg,#10b981,#6ee7b7)',
+        'linear-gradient(135deg,#f59e0b,#fcd34d)', 'linear-gradient(135deg,#ef4444,#fca5a5)',
+        'linear-gradient(135deg,#0ea5e9,#7dd3fc)', 'linear-gradient(135deg,#8b5cf6,#c4b5fd)',
+        'linear-gradient(135deg,#64748b,#cbd5e1)'
+      ];
+      document.getElementById('tray').innerHTML = GRADS.map((g, i) =>
+        `<div class="tray-item" draggable="true" title="image${i + 1}.png" style="background:${g}"></div>`).join('');
+
+      function setStep(next) {
+        step = next;
+        document.getElementById('step1').hidden = next !== 1;
+        document.getElementById('step2').hidden = next !== 2;
+        document.getElementById('s1').className = 'stepi' + (next === 1 ? ' on' : ' done');
+        document.getElementById('s2').className = 'stepi' + (next === 2 ? ' on' : '');
+      }
+
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>

--- a/prototypes/slide-builder/deck-library.html
+++ b/prototypes/slide-builder/deck-library.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Decks · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="deck.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .stats { display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 20px; }
+      .filters { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; justify-content: space-between; margin-bottom: 16px; }
+      .kindtabs { display: grid; grid-auto-flow: column; background: var(--muted); border-radius: var(--radius-md); padding: 3px; gap: 2px; }
+      .kindtabs button { border: 0; background: none; font-family: inherit; font-size: 13px; padding: 5px 12px; border-radius: calc(var(--radius-md) - 2px); color: var(--muted-foreground); cursor: pointer; }
+      .kindtabs button.active { background: var(--background); color: var(--foreground); font-weight: 500; box-shadow: var(--shadow-2xs); }
+      .dgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+      .dcard { border: 1px solid var(--border); border-radius: var(--radius-md); padding: 14px; background: var(--card); display: grid; gap: 10px; align-content: start; position: relative; cursor: pointer; text-decoration: none; color: inherit; }
+      .dcard:hover { border-color: color-mix(in oklch, var(--primary) 45%, var(--border)); }
+      .dcard .well { border: 1px solid var(--border); border-radius: var(--radius-sm); overflow: hidden; background: var(--muted); }
+      .dcard h3 { margin: 0; font-size: 14px; font-weight: 500; line-height: 1.4; }
+      .dcard .bl { display: flex; gap: 6px; flex-wrap: wrap; }
+      .dcard .stats2 { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; font-size: 13px; margin-top: 2px; }
+      .dcard .stats2 .k { font-size: 11px; text-transform: uppercase; color: var(--muted-foreground); letter-spacing: 0.04em; }
+      .dcard .stats2 .v { font-weight: 500; }
+      .dcard .more { position: absolute; top: 12px; right: 12px; opacity: 0; transition: opacity 0.15s; z-index: 3; }
+      .dcard:hover .more { opacity: 1; }
+      .gen { display: grid; place-items: center; gap: 10px; aspect-ratio: 16/9; background: var(--muted); text-align: center; padding: 14px; }
+      .genbar { width: 80%; height: 5px; border-radius: 999px; background: color-mix(in oklch, var(--primary) 20%, transparent); overflow: hidden; }
+      .genbar i { display: block; height: 100%; width: 45%; background: var(--primary); border-radius: 999px; animation: gwork 1.6s ease-in-out infinite; }
+      @keyframes gwork { 0% { transform: translateX(-90%); } 100% { transform: translateX(240%); } }
+      .empty-box { border: 1px dashed var(--border); border-radius: var(--radius-lg); padding: 48px 24px; text-align: center; display: grid; justify-items: center; gap: 14px; }
+      .empty-box .ei { width: 40px; height: 40px; border-radius: var(--radius-md); background: var(--muted); display: grid; place-items: center; }
+      @media (max-width: 1050px) { .dgrid { grid-template-columns: repeat(2, 1fr); } }
+      @media (max-width: 700px) { .dgrid { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="brand"><div class="brand-mark">C</div><div class="brand-name">ClassroomIO</div></div>
+        <div class="nav-label">Content</div>
+        <a class="nav-item" href="lesson-slide-tab.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Courses</a>
+        <a class="nav-item active" href="deck-library.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 3h20v12H2zM12 15v6M8 21h8"/></svg>Decks</a>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg>Media</a>
+        <div class="sidebar-foot"><div class="avatar">JD</div><div class="who"><div class="nm">Jordan Diallo</div><div class="rl">Admin</div></div></div>
+      </aside>
+
+      <div class="main">
+        <header class="topbar">
+          <div class="crumbs"><a href="#">Acme Academy</a><span class="sep">/</span><span>Decks</span></div>
+          <div class="top-actions">
+            <button class="btn btn-outline btn-sm" onclick="toggleEmpty()">Toggle empty state</button>
+            <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+          </div>
+        </header>
+
+        <main class="content">
+          <div class="wrap" style="max-width: 1150px">
+            <div class="page-head">
+              <div>
+                <h1 class="page-title">Decks</h1>
+                <p class="page-sub">Slide decks you own. Attach one to any lesson, or reuse it across courses.</p>
+              </div>
+              <div style="display: flex; gap: 8px">
+                <a class="btn btn-outline" href="deck-import.html">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/></svg>
+                  Import .pptx
+                </a>
+                <a class="btn btn-primary" href="deck-editor.html">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 5v14M5 12h14"/></svg>
+                  New deck
+                </a>
+              </div>
+            </div>
+
+            <div class="stats">
+              <div class="card stat-card"><div class="k"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 3h20v12H2zM12 15v6M8 21h8"/></svg>Decks</div><div class="v tnum">7</div></div>
+              <div class="card stat-card"><div class="k"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3h18v18H3z"/><path d="M3 9h18M9 21V9"/></svg>Slides</div><div class="v tnum">104</div></div>
+              <div class="card stat-card"><div class="k"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7L12 19"/></svg>Attached to lessons</div><div class="v tnum">5</div></div>
+            </div>
+
+            <div class="filters">
+              <div class="kindtabs">
+                <button class="active">All</button><button>Attached</button><button>Unattached</button><button>Draft</button><button>Published</button>
+              </div>
+              <div style="display: flex; gap: 8px; align-items: center">
+                <input class="input" placeholder="Search decks" style="width: 180px" />
+                <select class="select"><option>All courses</option><option>Instructional Design 201</option><option>Assessment Clinic</option></select>
+                <button class="btn btn-primary btn-sm">Apply</button>
+              </div>
+            </div>
+
+            <div class="dgrid" id="grid"></div>
+
+            <div class="empty-box" id="empty" hidden>
+              <span class="ei"><svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor"><path d="M2 3h20v12H2zM12 15v6M8 21h8"/></svg></span>
+              <div>
+                <h3 style="margin: 0 0 6px; font-size: 17px; font-weight: 500">No decks yet</h3>
+                <p class="hint" style="margin: 0; max-width: 420px">Build a deck from scratch, let the assistant draft one from a lesson, or bring the decks you already have.</p>
+              </div>
+              <div style="display: flex; gap: 8px; flex-wrap: wrap; justify-content: center">
+                <a class="btn btn-primary btn-sm" href="deck-editor.html">Start from blank</a>
+                <a class="btn btn-outline btn-sm" href="deck-ai.html">Generate with AI</a>
+                <a class="btn btn-outline btn-sm" href="deck-import.html">Import a .pptx</a>
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <script src="deck-data.js"></script>
+    <script>
+      const DECKS = [
+        { title: 'Designing Effective Assessments', slides: 8, theme: 'Classic', status: 'Published', lesson: 'Instructional Design 201', updated: '2 hours ago', cover: 0, href: 'deck-editor.html' },
+        { title: 'Writing Learning Outcomes', slides: 14, theme: 'Editorial', status: 'Published', lesson: 'Instructional Design 201', updated: 'Yesterday', cover: 2, href: 'deck-editor.html' },
+        { title: 'Rubric Clinic — Worked Examples', slides: 22, theme: 'Brand', status: 'Draft', lesson: 'Unattached', updated: '3 days ago', cover: 4, href: 'deck-editor.html' },
+        { generating: true, title: 'Cohort Kickoff — Autumn 2026', done: 9, total: 20 },
+        { title: 'Feedback That Changes Behaviour', slides: 11, theme: 'Bold', status: 'Published', lesson: 'Assessment Clinic', updated: 'Last week', cover: 5, href: 'deck-editor.html' },
+        { title: 'Question Types, Ranked', slides: 16, theme: 'Mono', status: 'Draft', lesson: 'Unattached', updated: 'Last week', cover: 6, href: 'deck-editor.html' }
+      ];
+
+      const THEME_ID = { Classic: 'classic', Editorial: 'editorial', Bold: 'bold', Mono: 'mono', Brand: 'brand' };
+
+      document.getElementById('grid').innerHTML = DECKS.map((deck) => {
+        if (deck.generating) {
+          return `<div class="dcard" style="cursor:default">
+            <div class="well"><div class="gen">
+              <span class="badge badge-primary-soft">Generating</span>
+              <div class="genbar"><i></i></div>
+              <p class="hint" style="margin:0">Slide ${deck.done} of ${deck.total}</p>
+            </div></div>
+            <h3>${deck.title}</h3>
+            <div class="bl"><span class="badge badge-muted">AI run</span><span class="badge badge-outline">Started 1 min ago</span></div>
+            <div style="display:flex;gap:8px"><button class="btn btn-outline btn-sm" style="flex:1">Cancel run</button><a class="btn btn-ghost btn-sm" href="deck-ai.html">View</a></div>
+          </div>`;
+        }
+
+        return `<a class="dcard" href="${deck.href}">
+          <span class="more"><span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg></span></span>
+          <div class="well">${renderSlide(DECK.slides[deck.cover], { theme: THEME_ID[deck.theme], chrome: false })}</div>
+          <h3>${deck.title}</h3>
+          <div class="bl">
+            <span class="badge badge-outline">${deck.slides} slides</span>
+            <span class="badge badge-outline">${deck.theme}</span>
+            <span class="badge ${deck.status === 'Published' ? 'badge-success-soft' : 'badge-muted'}">${deck.status}</span>
+          </div>
+          <div class="stats2">
+            <div><div class="k">Used in</div><div class="v">${deck.lesson}</div></div>
+            <div><div class="k">Updated</div><div class="v">${deck.updated}</div></div>
+          </div>
+        </a>`;
+      }).join('');
+
+      function toggleEmpty() {
+        const grid = document.getElementById('grid');
+        const empty = document.getElementById('empty');
+        const showEmpty = grid.hidden === false;
+        grid.hidden = showEmpty;
+        empty.hidden = !showEmpty;
+      }
+
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>

--- a/prototypes/slide-builder/deck-themes.html
+++ b/prototypes/slide-builder/deck-themes.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Deck themes · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="deck.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .tgrid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+      .tcard { border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--card); overflow: hidden; cursor: pointer; }
+      .tcard.on { border-color: var(--primary); box-shadow: 0 0 0 2px color-mix(in oklch, var(--primary) 22%, transparent); }
+      .tcard .strip { display: grid; grid-template-columns: 1fr 1fr; }
+      .tcard .bar { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 11px 13px; border-top: 1px solid var(--border); }
+      .tcard .nm { font-size: 14px; font-weight: 500; display: flex; align-items: center; gap: 8px; }
+      .toks { display: flex; gap: 5px; align-items: center; }
+      .tok { width: 15px; height: 15px; border-radius: 4px; border: 1px solid var(--border); }
+      .over { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+      @media (max-width: 950px) { .tgrid, .over { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="brand"><div class="brand-mark">C</div><div class="brand-name">ClassroomIO</div></div>
+        <div class="nav-label">Content</div>
+        <a class="nav-item" href="lesson-slide-tab.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Courses</a>
+        <a class="nav-item active" href="deck-library.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 3h20v12H2zM12 15v6M8 21h8"/></svg>Decks</a>
+        <div class="sidebar-foot"><div class="avatar">JD</div><div class="who"><div class="nm">Jordan Diallo</div><div class="rl">Admin</div></div></div>
+      </aside>
+
+      <div class="main">
+        <header class="topbar">
+          <div class="crumbs"><a href="deck-library.html">Decks</a><span class="sep">/</span><a href="deck-editor.html">Designing Effective Assessments</a><span class="sep">/</span><span>Theme</span></div>
+          <div class="top-actions">
+            <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+          </div>
+        </header>
+
+        <main class="content">
+          <div class="wrap" style="max-width: 1050px">
+            <div class="page-head">
+              <div>
+                <h1 class="page-title">Theme</h1>
+                <p class="page-sub">Every theme is a set of tokens — colour, type scale, fonts, radius. Applying one changes how the deck looks and never changes a word of it.</p>
+              </div>
+              <a class="btn btn-primary" href="deck-editor.html">Done</a>
+            </div>
+
+            <div class="note-strip info" style="margin-bottom: 18px">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01"/></svg>
+              <span>Each theme is previewed on two real slides from this deck, not a colour swatch — you are choosing how <b>your</b> content will look.</span>
+            </div>
+
+            <div class="tgrid" id="grid"></div>
+
+            <h2 style="font-size: 15px; font-weight: 500; margin: 30px 0 6px">Overrides</h2>
+            <p class="hint" style="margin: 0 0 14px">A small set of per-deck adjustments. A full token editor is deliberately out of scope for v1.</p>
+            <div class="card card-pad">
+              <div class="over">
+                <div class="field">
+                  <span class="label">Accent colour</span>
+                  <div class="swatches">
+                    <span class="swatch active" style="background: oklch(0.488 0.243 264.376)"></span>
+                    <span class="swatch" style="background: oklch(0.596 0.145 163.225)"></span>
+                    <span class="swatch" style="background: oklch(0.666 0.179 58.318)"></span>
+                    <span class="swatch" style="background: oklch(0.577 0.245 27.325)"></span>
+                    <span class="swatch" style="background: #7c3aed"></span>
+                    <span class="swatch" style="background: #0f172a"></span>
+                  </div>
+                  <p class="hint">Defaults to your organisation's brand colour.</p>
+                </div>
+                <div class="field">
+                  <label class="label" for="pair">Heading font pairing</label>
+                  <select class="select" id="pair">
+                    <option>Geist / Geist — the app default</option>
+                    <option>Georgia / Geist — editorial</option>
+                    <option>Geist / JetBrains Mono — technical</option>
+                  </select>
+                  <p class="hint">Body text always stays highly legible at projector distance.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <script src="deck-data.js"></script>
+    <script>
+      const THEMES = [
+        { id: 'brand', name: 'Your brand', note: 'Seeded from your logo and brand colour', badge: 'Auto', toks: ['#fff', 'oklch(0.596 0.145 163.225)', '#10201a'] },
+        { id: 'classic', name: 'Classic', note: 'Neutral, high contrast, safe on any projector', badge: 'Current', toks: ['#fff', 'oklch(0.488 0.243 264.376)', '#14161a'] },
+        { id: 'editorial', name: 'Editorial', note: 'Warm paper, serif headings, generous margins', toks: ['#fbf9f4', '#9a3412', '#1b1a17'] },
+        { id: 'bold', name: 'Bold', note: 'Dark ground, tight tracking, big type', toks: ['#0b0d12', 'oklch(0.769 0.188 70.08)', '#f6f7f9'] },
+        { id: 'mono', name: 'Mono', note: 'Monospaced throughout, square corners', toks: ['#101215', 'oklch(0.696 0.17 162.48)', '#d7dbe0'] }
+      ];
+
+      document.getElementById('grid').innerHTML = THEMES.map((theme, index) => `
+        <div class="tcard ${theme.id === 'classic' ? 'on' : ''}" data-id="${theme.id}">
+          <div class="strip">
+            ${renderSlide(DECK.slides[0], { theme: theme.id, chrome: false })}
+            ${renderSlide(DECK.slides[3], { theme: theme.id, chrome: false })}
+          </div>
+          <div class="bar">
+            <span class="nm">${theme.name}${theme.badge ? ` <span class="badge ${theme.badge === 'Auto' ? 'badge-primary-soft' : 'badge-muted'}">${theme.badge}</span>` : ''}</span>
+            <span class="toks">${theme.toks.map((c) => `<span class="tok" style="background:${c}"></span>`).join('')}</span>
+          </div>
+          <div class="bar" style="border-top: 0; padding-top: 0">
+            <span class="hint" style="margin: 0">${theme.note}</span>
+          </div>
+        </div>`).join('');
+
+      document.querySelectorAll('.tcard').forEach((card) => {
+        card.onclick = () => document.querySelectorAll('.tcard').forEach((c) => c.classList.toggle('on', c === card));
+      });
+
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>

--- a/prototypes/slide-builder/deck.css
+++ b/prototypes/slide-builder/deck.css
@@ -1,0 +1,1126 @@
+/*
+ * deck.css — slide-canvas + deck-editor styles for the slide-builder prototypes.
+ *
+ * Companion to app-theme.css (which mirrors packages/ui/src/index.css).
+ * This sheet owns everything inside the 1920x1080 slide canvas plus the
+ * three-pane editor chrome. Slide themes are token sets, exactly like
+ * packages/ui/src/custom/org-landing-page/theme-vars-base.ts.
+ */
+
+/* `hidden` has to beat our own display rules */
+[hidden] {
+  display: none !important;
+}
+
+/* ============ the canvas unit ============
+ * A slide is authored at 1920x1080 and rendered at any width. Container query
+ * units make that pure CSS: 1920 canvas px == 100cqw, so 1 canvas px is
+ * 0.0520833cqw. Every size inside a frame is calc(N * var(--u)).
+ */
+.slide-frame {
+  container-type: inline-size;
+  --u: 0.0520833cqw;
+  position: relative;
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  overflow: hidden;
+  background: var(--slide-bg);
+  color: var(--slide-fg);
+  font-family: var(--slide-font-body);
+  isolation: isolate;
+}
+
+/* ============ slide theme token sets ============ */
+.theme-classic {
+  --slide-bg: #ffffff;
+  --slide-bg-alt: #f4f5f7;
+  --slide-fg: #14161a;
+  --slide-fg-muted: #5d636e;
+  --slide-accent: oklch(0.488 0.243 264.376);
+  --slide-accent-fg: #ffffff;
+  --slide-border: #e3e5e9;
+  --slide-font-head: 'Geist', system-ui, sans-serif;
+  --slide-font-body: 'Geist', system-ui, sans-serif;
+  --slide-font-mono: ui-monospace, 'SFMono-Regular', Menlo, monospace;
+  --slide-head-weight: 620;
+  --slide-head-tracking: -0.022em;
+  --slide-radius: calc(16 * var(--u));
+  --slide-pad: calc(120 * var(--u));
+}
+.theme-editorial {
+  --slide-bg: #fbf9f4;
+  --slide-bg-alt: #f2ede2;
+  --slide-fg: #1b1a17;
+  --slide-fg-muted: #6b6559;
+  --slide-accent: #9a3412;
+  --slide-accent-fg: #fdf6ee;
+  --slide-border: #e0d8c8;
+  --slide-font-head: Georgia, 'Times New Roman', serif;
+  --slide-font-body: 'Geist', system-ui, sans-serif;
+  --slide-font-mono: ui-monospace, Menlo, monospace;
+  --slide-head-weight: 600;
+  --slide-head-tracking: -0.01em;
+  --slide-radius: calc(4 * var(--u));
+  --slide-pad: calc(140 * var(--u));
+}
+.theme-bold {
+  --slide-bg: #0b0d12;
+  --slide-bg-alt: #161a23;
+  --slide-fg: #f6f7f9;
+  --slide-fg-muted: #98a0ae;
+  --slide-accent: oklch(0.769 0.188 70.08);
+  --slide-accent-fg: #14161a;
+  --slide-border: #262c38;
+  --slide-font-head: 'Geist', system-ui, sans-serif;
+  --slide-font-body: 'Geist', system-ui, sans-serif;
+  --slide-font-mono: ui-monospace, Menlo, monospace;
+  --slide-head-weight: 750;
+  --slide-head-tracking: -0.035em;
+  --slide-radius: calc(20 * var(--u));
+  --slide-pad: calc(110 * var(--u));
+}
+.theme-mono {
+  --slide-bg: #101215;
+  --slide-bg-alt: #171a1f;
+  --slide-fg: #d7dbe0;
+  --slide-fg-muted: #7d848f;
+  --slide-accent: oklch(0.696 0.17 162.48);
+  --slide-accent-fg: #0b0d10;
+  --slide-border: #262a31;
+  --slide-font-head: ui-monospace, 'SFMono-Regular', Menlo, monospace;
+  --slide-font-body: ui-monospace, 'SFMono-Regular', Menlo, monospace;
+  --slide-font-mono: ui-monospace, Menlo, monospace;
+  --slide-head-weight: 600;
+  --slide-head-tracking: -0.01em;
+  --slide-radius: 0;
+  --slide-pad: calc(120 * var(--u));
+}
+/* Seeded from organization.theme + organization.avatarUrl */
+.theme-brand {
+  --slide-bg: #ffffff;
+  --slide-bg-alt: #eef6f2;
+  --slide-fg: #10201a;
+  --slide-fg-muted: #4f6a5f;
+  --slide-accent: oklch(0.596 0.145 163.225);
+  --slide-accent-fg: #ffffff;
+  --slide-border: #d8e7e0;
+  --slide-font-head: 'Geist', system-ui, sans-serif;
+  --slide-font-body: 'Geist', system-ui, sans-serif;
+  --slide-font-mono: ui-monospace, Menlo, monospace;
+  --slide-head-weight: 640;
+  --slide-head-tracking: -0.022em;
+  --slide-radius: calc(14 * var(--u));
+  --slide-pad: calc(120 * var(--u));
+}
+
+/* ============ layouts ============ */
+.lay {
+  position: absolute;
+  inset: 0;
+  padding: var(--slide-pad);
+  display: grid;
+  gap: calc(48 * var(--u));
+  align-content: start;
+}
+.lay-cover {
+  align-content: center;
+}
+.lay-section-break {
+  align-content: center;
+  justify-items: center;
+  text-align: center;
+  background: var(--slide-accent);
+  color: var(--slide-accent-fg);
+}
+.lay-two-col,
+.lay-image-left,
+.lay-image-right {
+  grid-template-columns: 1fr 1fr;
+  align-content: center;
+  align-items: center;
+  column-gap: calc(80 * var(--u));
+}
+.lay-image-left > .slot-media {
+  order: -1;
+}
+.lay-kpi-row {
+  align-content: center;
+}
+.lay-quote {
+  align-content: center;
+  justify-items: center;
+  text-align: center;
+}
+.lay-free {
+  padding: 0;
+  display: block;
+}
+
+.slot {
+  min-width: 0;
+  display: grid;
+  gap: calc(32 * var(--u));
+  align-content: start;
+}
+.slot-media {
+  align-self: stretch;
+}
+
+/* free-positioned block: box in canvas px */
+.fblock {
+  position: absolute;
+  left: calc(var(--x) * var(--u));
+  top: calc(var(--y) * var(--u));
+  width: calc(var(--w) * var(--u));
+  height: calc(var(--h) * var(--u));
+  display: grid;
+  align-content: center;
+}
+
+/* ============ blocks ============ */
+.b-heading {
+  font-family: var(--slide-font-head);
+  font-weight: var(--slide-head-weight);
+  letter-spacing: var(--slide-head-tracking);
+  line-height: 1.08;
+  margin: 0;
+  text-wrap: balance;
+}
+.b-heading.lv-hero {
+  font-size: calc(150 * var(--u));
+}
+.b-heading.lv-section {
+  font-size: calc(96 * var(--u));
+}
+.b-heading.lv-page {
+  font-size: calc(68 * var(--u));
+}
+
+.b-text {
+  font-size: calc(38 * var(--u));
+  line-height: 1.55;
+  margin: 0;
+  color: var(--slide-fg-muted);
+  max-width: 34ch;
+}
+.b-text.em-default {
+  color: var(--slide-fg);
+}
+.b-text.em-accent {
+  color: var(--slide-accent);
+}
+
+.b-bullets {
+  display: grid;
+  gap: calc(26 * var(--u));
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.b-bullets li {
+  font-size: calc(38 * var(--u));
+  line-height: 1.4;
+  display: grid;
+  grid-template-columns: calc(34 * var(--u)) 1fr;
+  align-items: start;
+  gap: calc(8 * var(--u));
+}
+.b-bullets li::before {
+  content: '';
+  width: calc(14 * var(--u));
+  height: calc(14 * var(--u));
+  border-radius: 999px;
+  background: var(--slide-accent);
+  margin-top: calc(20 * var(--u));
+}
+
+.b-image {
+  width: 100%;
+  height: 100%;
+  min-height: calc(420 * var(--u));
+  border-radius: var(--slide-radius);
+  background: var(--slide-bg-alt);
+  background-size: cover;
+  background-position: center;
+  display: grid;
+  place-items: center;
+  color: var(--slide-fg-muted);
+  overflow: hidden;
+}
+.b-image svg {
+  width: calc(64 * var(--u));
+  height: calc(64 * var(--u));
+  stroke-width: 1.5;
+  opacity: 0.5;
+}
+
+.b-quote {
+  font-family: var(--slide-font-head);
+  font-size: calc(64 * var(--u));
+  line-height: 1.28;
+  font-weight: var(--slide-head-weight);
+  letter-spacing: var(--slide-head-tracking);
+  margin: 0;
+  max-width: 22ch;
+  text-wrap: balance;
+}
+.b-attr {
+  font-size: calc(30 * var(--u));
+  color: var(--slide-fg-muted);
+  margin-top: calc(36 * var(--u));
+}
+
+.b-code {
+  font-family: var(--slide-font-mono);
+  font-size: calc(30 * var(--u));
+  line-height: 1.6;
+  background: var(--slide-bg-alt);
+  border: calc(2 * var(--u)) solid var(--slide-border);
+  border-radius: var(--slide-radius);
+  padding: calc(40 * var(--u));
+  margin: 0;
+  white-space: pre;
+  overflow: hidden;
+}
+
+.b-kpis {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  gap: calc(56 * var(--u));
+}
+.b-kpi .v {
+  font-family: var(--slide-font-head);
+  font-size: calc(120 * var(--u));
+  font-weight: var(--slide-head-weight);
+  letter-spacing: var(--slide-head-tracking);
+  line-height: 1;
+  color: var(--slide-accent);
+  font-variant-numeric: tabular-nums;
+}
+.b-kpi .l {
+  font-size: calc(28 * var(--u));
+  color: var(--slide-fg-muted);
+  margin-top: calc(18 * var(--u));
+}
+
+.b-divider {
+  height: calc(4 * var(--u));
+  background: var(--slide-border);
+  border: 0;
+  width: calc(160 * var(--u));
+}
+
+.b-eyebrow {
+  font-size: calc(26 * var(--u));
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--slide-accent);
+  font-weight: 600;
+}
+
+.slide-foot {
+  position: absolute;
+  left: var(--slide-pad);
+  right: var(--slide-pad);
+  bottom: calc(56 * var(--u));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: calc(24 * var(--u));
+  color: var(--slide-fg-muted);
+}
+.slide-foot .logo {
+  display: flex;
+  align-items: center;
+  gap: calc(14 * var(--u));
+  font-weight: 600;
+}
+.slide-foot .logo .mk {
+  width: calc(34 * var(--u));
+  height: calc(34 * var(--u));
+  border-radius: calc(8 * var(--u));
+  background: var(--slide-accent);
+  color: var(--slide-accent-fg);
+  display: grid;
+  place-items: center;
+  font-size: calc(20 * var(--u));
+}
+
+/* ============ editor shell: rail | stage | inspector ============ */
+.deck-shell {
+  display: grid;
+  grid-template-columns: 232px 1fr 300px;
+  height: calc(100vh - 56px);
+  min-height: 0;
+}
+.deck-shell.no-inspector {
+  grid-template-columns: 232px 1fr;
+}
+
+.slide-rail {
+  border-right: 1px solid var(--border);
+  background: var(--sidebar);
+  overflow-y: auto;
+  padding: 12px;
+  display: grid;
+  gap: 10px;
+  align-content: start;
+}
+.slide-rail-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+  padding: 2px 2px 4px;
+}
+.thumb-row {
+  display: grid;
+  grid-template-columns: 16px 1fr;
+  gap: 6px;
+  align-items: start;
+}
+.thumb-row > .n {
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted-foreground);
+  text-align: right;
+  padding-top: 5px;
+}
+.thumb-row.active > .n {
+  color: var(--primary);
+  font-weight: 600;
+}
+.thumb {
+  position: relative;
+  border: 2px solid transparent;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  cursor: pointer;
+  background: var(--card);
+  box-shadow: var(--shadow-2xs);
+}
+.thumb.active {
+  border-color: var(--primary);
+}
+.thumb .warn {
+  position: absolute;
+  right: 6px;
+  top: 6px;
+  z-index: 2;
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: var(--warning);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 9px;
+  font-weight: 700;
+}
+.thumb .drag {
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
+  z-index: 2;
+  opacity: 0;
+  color: var(--muted-foreground);
+}
+.thumb:hover .drag {
+  opacity: 1;
+}
+.thumb.drop-target {
+  border-color: var(--primary);
+  border-style: dashed;
+}
+.slide-rail-add {
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 12.5px;
+  color: var(--muted-foreground);
+  background: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+.slide-rail-add:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+.slide-rail-add svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2;
+}
+
+.stage {
+  /* 18px dot grid — verbatim from the certificate editor canvas */
+  background-color: oklch(0.967 0.001 286.375);
+  background-image: radial-gradient(circle, #d4d4d8 1px, transparent 1px);
+  background-size: 18px 18px;
+  overflow: auto;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  position: relative;
+}
+.dark .stage {
+  background-color: oklch(0.145 0 0);
+  background-image: radial-gradient(circle, rgb(113 113 122 / 0.4) 1px, transparent 1px);
+}
+.stage-inner {
+  width: min(100%, 880px);
+}
+.stage-frame {
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  position: relative;
+}
+.stage-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.stage-meta {
+  font-size: 12.5px;
+  color: var(--muted-foreground);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* selection + drag affordances on the stage */
+.sel-box {
+  position: absolute;
+  border: 2px solid var(--primary);
+  border-radius: 3px;
+  pointer-events: none;
+  z-index: 5;
+}
+.sel-box::after {
+  content: attr(data-label);
+  position: absolute;
+  top: -20px;
+  left: -2px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: 10.5px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+.handle {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  background: var(--background);
+  border: 2px solid var(--primary);
+  border-radius: 2px;
+}
+.handle.nw {
+  left: -5px;
+  top: -5px;
+}
+.handle.ne {
+  right: -5px;
+  top: -5px;
+}
+.handle.sw {
+  left: -5px;
+  bottom: -5px;
+}
+.handle.se {
+  right: -5px;
+  bottom: -5px;
+}
+.guide {
+  position: absolute;
+  background: var(--primary);
+  opacity: 0.55;
+  z-index: 4;
+  pointer-events: none;
+}
+.guide.v {
+  width: 1px;
+  top: 0;
+  bottom: 0;
+}
+.guide.h {
+  height: 1px;
+  left: 0;
+  right: 0;
+}
+
+.pin {
+  position: absolute;
+  z-index: 6;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px 999px 999px 3px;
+  background: var(--warning);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  font-weight: 700;
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+}
+.pin.done {
+  background: var(--success);
+}
+
+.inspector {
+  border-left: 1px solid var(--border);
+  background: var(--background);
+  overflow-y: auto;
+}
+.insp-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 8px 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+.insp-tab {
+  flex: 1;
+  text-align: center;
+  font-size: 12.5px;
+  padding: 7px 8px;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  border: 0;
+  background: none;
+  font-family: inherit;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+.insp-tab.active {
+  color: var(--foreground);
+  font-weight: 500;
+  border-bottom-color: var(--primary);
+}
+.insp-body {
+  padding: 14px;
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+.insp-group {
+  display: grid;
+  gap: 8px;
+}
+.insp-label {
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+.insp-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 13px;
+}
+.insp-hint {
+  font-size: 11.5px;
+  color: var(--muted-foreground);
+  line-height: 1.5;
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+}
+.layout-opt {
+  aspect-ratio: 16/9;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--card);
+  cursor: pointer;
+  padding: 5px;
+  display: grid;
+  gap: 2px;
+  align-content: start;
+}
+.layout-opt.split {
+  grid-template-columns: 1fr 1fr;
+  column-gap: 3px;
+  align-content: stretch;
+}
+.layout-opt.split .fill {
+  background: var(--muted-foreground);
+  opacity: 0.22;
+  border-radius: 1px;
+}
+.layout-opt.mid {
+  align-content: center;
+}
+.layout-opt.active {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--primary) 20%, transparent);
+}
+.layout-opt i {
+  background: var(--muted-foreground);
+  opacity: 0.4;
+  border-radius: 1px;
+  display: block;
+}
+.layout-opt .t {
+  height: 4px;
+  width: 70%;
+}
+.layout-opt .l {
+  height: 3px;
+  width: 100%;
+}
+.layout-opt.two i {
+  opacity: 0.35;
+}
+
+.segctl {
+  display: inline-flex;
+  background: var(--muted);
+  border-radius: var(--radius-md);
+  padding: 2px;
+  gap: 2px;
+}
+.segctl button {
+  border: 0;
+  background: none;
+  font-family: inherit;
+  font-size: 12.5px;
+  padding: 5px 11px;
+  border-radius: calc(var(--radius-md) - 2px);
+  color: var(--muted-foreground);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.segctl button.active {
+  background: var(--background);
+  color: var(--foreground);
+  font-weight: 500;
+  box-shadow: var(--shadow-2xs);
+}
+.segctl button svg {
+  width: 13px;
+  height: 13px;
+  stroke-width: 2;
+}
+
+.range {
+  width: 100%;
+  accent-color: var(--primary);
+}
+.swatches {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  border: 2px solid var(--border);
+  cursor: pointer;
+}
+.swatch.active {
+  border-color: var(--foreground);
+}
+
+/* ============ overview grid / player ============ */
+.overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 14px;
+}
+.ov-item {
+  border: 2px solid transparent;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  cursor: pointer;
+  position: relative;
+  box-shadow: var(--shadow-2xs);
+}
+.ov-item.current {
+  border-color: var(--primary);
+}
+.ov-item .n {
+  position: absolute;
+  left: 6px;
+  bottom: 6px;
+  font-size: 10.5px;
+  background: color-mix(in oklch, var(--background) 82%, transparent);
+  border-radius: 5px;
+  padding: 1px 5px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.player {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--card);
+}
+.player-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--border);
+  background: var(--background);
+  font-size: 12.5px;
+  color: var(--muted-foreground);
+}
+.player-bar .pos {
+  font-variant-numeric: tabular-nums;
+  margin-left: auto;
+}
+.pdots {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+}
+.pdot {
+  height: 4px;
+  flex: 1;
+  border-radius: 999px;
+  background: var(--border);
+}
+.pdot.seen {
+  background: var(--primary);
+}
+.pdot.current {
+  background: var(--primary);
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--primary) 25%, transparent);
+}
+
+.kbd {
+  display: inline-grid;
+  place-items: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 5px;
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 5px;
+  background: var(--muted);
+  font-size: 11px;
+  font-family: ui-monospace, Menlo, monospace;
+  color: var(--muted-foreground);
+}
+
+/* ============ presenter ============ */
+.presenter {
+  display: grid;
+  grid-template-columns: 1.55fr 1fr;
+  gap: 18px;
+  padding: 18px;
+  height: 100vh;
+  background: #0b0d12;
+  color: #e9ecf1;
+}
+.presenter .pcol {
+  display: grid;
+  gap: 14px;
+  align-content: start;
+  min-height: 0;
+}
+.presenter .plabel {
+  font-size: 11.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #7f8794;
+  font-weight: 600;
+}
+.presenter .pframe {
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 10px 40px rgb(0 0 0 / 0.5);
+}
+.presenter .notes {
+  background: #141821;
+  border: 1px solid #232936;
+  border-radius: 10px;
+  padding: 16px;
+  font-size: 15px;
+  line-height: 1.65;
+  color: #c6ccd6;
+  overflow-y: auto;
+}
+.presenter .notes b {
+  color: #fff;
+}
+.presenter .ptimer {
+  font-size: 44px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+.presenter .pmeta {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  justify-content: space-between;
+}
+.presenter .pkeys {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.presenter .pkeys .kbd {
+  background: #1a1f2a;
+  border-color: #2a3140;
+  color: #97a0af;
+}
+
+/* ============ misc ============ */
+.tray {
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-lg);
+  padding: 12px;
+  background: var(--muted);
+}
+.tray-items {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+.tray-item {
+  width: 84px;
+  height: 56px;
+  border-radius: var(--radius-sm);
+  background: var(--card);
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  cursor: grab;
+  color: var(--muted-foreground);
+  position: relative;
+  overflow: hidden;
+}
+.tray-item svg {
+  width: 18px;
+  height: 18px;
+  stroke-width: 1.5;
+}
+
+.map-row {
+  display: grid;
+  grid-template-columns: 1fr 150px 1.1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+}
+.map-row:last-child {
+  border-bottom: 0;
+}
+.map-src {
+  font-size: 12.5px;
+  color: var(--muted-foreground);
+  line-height: 1.6;
+  max-height: 130px;
+  overflow: hidden;
+}
+.map-src b {
+  color: var(--foreground);
+  font-weight: 500;
+  display: block;
+  font-size: 13px;
+  margin-bottom: 2px;
+}
+
+.note-strip {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  background: var(--warning-soft);
+  color: var(--foreground);
+  font-size: 12.5px;
+  line-height: 1.55;
+}
+.note-strip.info {
+  background: color-mix(in oklch, var(--primary) 9%, transparent);
+}
+.note-strip svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: var(--warning);
+}
+.note-strip.info svg {
+  color: var(--primary);
+}
+
+@media (max-width: 1100px) {
+  .deck-shell {
+    grid-template-columns: 180px 1fr;
+  }
+  .inspector {
+    display: none;
+  }
+  .presenter {
+    grid-template-columns: 1fr;
+    height: auto;
+  }
+}
+
+/* ============ underline tabs (mirrors @cio/ui custom/underline-tabs) ============
+ * The lesson materials tab bar. Bottom border on the list, 2px primary bar on
+ * the active trigger at -1px, chip badge after the label.
+ */
+.utabs {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  height: 36px;
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.utabs::-webkit-scrollbar {
+  display: none;
+}
+.utab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: calc(100% - 3px);
+  padding: 4px 12px;
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--foreground);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  white-space: nowrap;
+  text-decoration: none;
+}
+.utab:hover {
+  color: var(--primary);
+}
+.utab svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+}
+.utab.active::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -3px;
+  height: 2px;
+  background: var(--primary);
+}
+.utab .chip {
+  margin-left: 4px;
+  display: inline-grid;
+  place-items: center;
+  height: 20px;
+  min-width: 20px;
+  padding: 0 4px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 11px;
+  font-family: ui-monospace, Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+  color: var(--foreground);
+}
+
+/* mode chooser on an empty Slide tab */
+.mode-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.mode-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  background: var(--card);
+  display: grid;
+  gap: 10px;
+  align-content: start;
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color 0.12s,
+    box-shadow 0.12s;
+}
+.mode-card:hover {
+  border-color: var(--primary);
+  box-shadow: var(--shadow-sm);
+}
+.mode-card .ic {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-md);
+  background: var(--muted);
+  display: grid;
+  place-items: center;
+  color: var(--foreground);
+}
+.mode-card .ic svg {
+  width: 18px;
+  height: 18px;
+  stroke-width: 1.8;
+}
+.mode-card h4 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+}
+.mode-card p {
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--muted-foreground);
+  line-height: 1.55;
+}
+.mode-card .pick {
+  font-size: 12.5px;
+  color: var(--primary);
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+@media (max-width: 760px) {
+  .mode-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* a free block whose declared box escapes the canvas */
+.fblock.is-overflow {
+  outline: calc(3 * var(--u)) dashed var(--warning);
+  outline-offset: calc(4 * var(--u));
+}

--- a/prototypes/slide-builder/index.html
+++ b/prototypes/slide-builder/index.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Slide Builder — prototypes · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="deck.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .page { max-width: 1040px; margin: 0 auto; padding: 56px 28px 96px; }
+      .eyebrow { font-size: 11.5px; text-transform: uppercase; letter-spacing: 0.09em; color: var(--muted-foreground); font-weight: 600; }
+      h1 { font-size: 34px; letter-spacing: -0.025em; margin: 10px 0 12px; font-weight: 500; }
+      .lead { font-size: 15px; line-height: 1.7; color: var(--muted-foreground); max-width: 660px; margin: 0; }
+      .lead code { font-size: 13px; }
+      .sec { position: relative; font-size: 12.5px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted-foreground); margin: 44px 0 16px; display: flex; align-items: center; gap: 12px; }
+      .sec::after { content: ''; flex: 1; height: 1px; background: var(--border); }
+      .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+      .shot { display: block; text-decoration: none; color: inherit; overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--card); transition: border-color 0.14s, transform 0.14s; }
+      .shot:hover { border-color: color-mix(in oklch, var(--primary) 50%, var(--border)); transform: translateY(-2px); }
+      .cover { aspect-ratio: 16/9; display: grid; place-items: center; color: #fff; }
+      .cover svg { width: 26px; height: 26px; stroke-width: 1.6; }
+      .b { padding: 13px 14px; display: grid; gap: 3px; }
+      .n { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted-foreground); font-weight: 600; }
+      .t { font-size: 14px; font-weight: 500; }
+      .d { font-size: 12.5px; color: var(--muted-foreground); line-height: 1.55; }
+      .foot { margin-top: 52px; border-top: 1px solid var(--border); padding-top: 20px; font-size: 13px; line-height: 1.9; color: var(--muted-foreground); }
+      .foot b { color: var(--foreground); }
+      @media (max-width: 900px) { .grid { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="eyebrow">ClassroomIO · Prototype + PRD handoff</div>
+      <h1>Slide Builder</h1>
+      <p class="lead">
+        A native slide deck teachers author, theme, present and export inside ClassroomIO — no round trip to Google Slides or Canva.
+        Slides are structured data, so the assistant and MCP can write them, and the platform can measure them.
+        The engineering PRD lives at <code>prd/slide-builder/README.md</code>.
+      </p>
+
+      <div class="sec">1 · Teacher — authoring</div>
+      <div class="grid">
+        <a class="shot" href="deck-library.html">
+          <div class="cover" style="background: linear-gradient(135deg, oklch(0.488 0.243 264.376), oklch(0.623 0.214 259.815))">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+          </div>
+          <div class="b"><span class="n">Org · Decks</span><span class="t">Deck library</span><span class="d">Every deck you own, reusable across lessons. Try the empty-state toggle in the header.</span></div>
+        </a>
+
+        <a class="shot" href="lesson-slide-tab.html">
+          <div class="cover" style="background: linear-gradient(135deg, oklch(0.546 0.245 262.881), oklch(0.809 0.105 251.813))">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 3h20v12H2zM12 15v6M8 21h8"/></svg>
+          </div>
+          <div class="b"><span class="n">Lesson · Slide tab</span><span class="t">Embed or build</span><span class="d">The two modes on one tab. Switch between them — neither destroys the other's data.</span></div>
+        </a>
+
+        <a class="shot" href="deck-editor.html">
+          <div class="cover" style="background: linear-gradient(135deg, oklch(0.424 0.199 265.638), oklch(0.546 0.245 262.881))">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3h18v18H3z"/><path d="M3 9h18M9 21V9"/></svg>
+          </div>
+          <div class="b"><span class="n">Editor · Layout mode</span><span class="t">Deck editor</span><span class="d">Rail, canvas, inspector. Drag thumbnails to reorder, click a block to edit, change the layout.</span></div>
+        </a>
+
+        <a class="shot" href="deck-editor-free.html">
+          <div class="cover" style="background: linear-gradient(135deg, oklch(0.666 0.179 58.318), oklch(0.769 0.188 70.08))">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 5h6v6H5zM13 13h6v6h-6z"/></svg>
+          </div>
+          <div class="b"><span class="n">Editor · Free position</span><span class="t">Free canvas + the overflow guard</span><span class="d">Drag blocks anywhere. One block is deliberately past the edge — Save stays blocked until it fits.</span></div>
+        </a>
+
+        <a class="shot" href="deck-themes.html">
+          <div class="cover" style="background: linear-gradient(135deg, oklch(0.596 0.145 163.225), oklch(0.696 0.17 162.48))">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="13.5" cy="6.5" r="2.5"/><circle cx="17.5" cy="14" r="2.5"/><circle cx="6.5" cy="12.5" r="2.5"/><path d="M12 2a10 10 0 1 0 0 20 2 2 0 0 0 0-4 2 2 0 0 1 0-4h2a6 6 0 0 0 0-12z"/></svg>
+          </div>
+          <div class="b"><span class="n">Editor · Theme</span><span class="t">Themes</span><span class="d">Five token sets previewed on real slides, with your brand seeded first.</span></div>
+        </a>
+
+        <a class="shot" href="presenter.html">
+          <div class="cover" style="background: linear-gradient(135deg, #0b0d12, #2a3140)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 3h20v12H2zM12 15v6M8 21h8"/></svg>
+          </div>
+          <div class="b"><span class="n">Teacher · Live</span><span class="t">Presenter mode</span><span class="d">Next slide, notes and a timer. Arrows to advance, O for overview, B to black out.</span></div>
+        </a>
+      </div>
+
+      <div class="sec">2 · Teacher — AI, import, export</div>
+      <div class="grid">
+        <a class="shot" href="deck-ai.html">
+          <div class="cover" style="background: linear-gradient(135deg, #7c3aed, #a78bfa)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M5.6 18.4l2.1-2.1M16.3 7.7l2.1-2.1"/></svg>
+          </div>
+          <div class="b"><span class="n">Assistant</span><span class="t">AI authoring + comment pins</span><span class="d">Plan → durable run, slides streaming into the rail, and pins the agent applies. Try “Apply all pins”.</span></div>
+        </a>
+
+        <a class="shot" href="deck-import.html">
+          <div class="cover" style="background: linear-gradient(135deg, #d24726, #f2a08a)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/></svg>
+          </div>
+          <div class="b"><span class="n">Migration</span><span class="t">PowerPoint import</span><span class="d">Per-slide mapping review and an unplaced-images tray. Toggle back to the upload step in the header.</span></div>
+        </a>
+
+        <a class="shot" href="deck-export.html">
+          <div class="cover" style="background: linear-gradient(135deg, oklch(0.556 0 0), oklch(0.708 0 0))">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
+          </div>
+          <div class="b"><span class="n">Output</span><span class="t">Export to PDF / PPTX</span><span class="d">The dialog states what each format actually produces. Running, finished and failed jobs all shown.</span></div>
+        </a>
+      </div>
+
+      <div class="sec">3 · Learner and public visitor</div>
+      <div class="grid">
+        <a class="shot" href="lesson-deck-player.html">
+          <div class="cover" style="background: linear-gradient(135deg, oklch(0.596 0.145 163.225), oklch(0.83 0.12 165))">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 3l14 9-14 9V3z"/></svg>
+          </div>
+          <div class="b"><span class="n">LMS · Lesson</span><span class="t">Learner deck player</span><span class="d">Keyboard nav, overview grid, and progress gating completion. Toggle the locked state in the header.</span></div>
+        </a>
+
+        <a class="shot" href="public-course-lesson.html">
+          <div class="cover" style="background: linear-gradient(135deg, #0ea5e9, #7dd3fc)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a15 15 0 0 1 0 18 15 15 0 0 1 0-18z"/></svg>
+          </div>
+          <div class="b"><span class="n">Org site · Public</span><span class="t">Public course page</span><span class="d">A deck rendered for anonymous visitors — something the public path cannot do at all today.</span></div>
+        </a>
+      </div>
+
+      <div class="foot">
+        <b>Key product decisions baked into these prototypes:</b><br />
+        · The Slide tab has <b>two modes</b> — embed an external deck, or build a native one. Both persist; <code>slideMode</code> decides what renders.<br />
+        · Decks are an <b>org-level library</b> with a nullable lesson link, so one deck can serve many lessons.<br />
+        · A slide is <b>layout slots plus a free-position escape hatch</b>. Slots own geometry; free blocks declare an explicit box.<br />
+        · <b>Overflow is arithmetic</b>, rejected at the API boundary — neither a teacher nor an agent can save a cropped slide.<br />
+        · Themes are <b>token sets</b> carrying no content, with one seeded from the organisation's brand.<br />
+        · <b>Heavy AI tools run as durable jobs</b>, not inline in chat — cancellable, resumable, with progress.<br />
+        · Deck content is <b>structured jsonb rendered by components</b>, never HTML through the lesson sanitizer.<br />
+        · Exports are <b>PDF and PPTX</b> in v1, and the dialog is honest that PPTX slides arrive as images.
+      </div>
+    </div>
+
+    <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme" style="position: fixed; bottom: 18px; right: 18px">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" /></svg>
+    </button>
+
+    <script>
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>

--- a/prototypes/slide-builder/lesson-deck-player.html
+++ b/prototypes/slide-builder/lesson-deck-player.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Lesson — deck player · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="deck.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .lockwrap { position: relative; border-radius: var(--radius-lg); overflow: hidden; border: 1px solid var(--border); }
+      .lockwrap .veil { position: absolute; inset: 0; backdrop-filter: blur(9px); background: color-mix(in oklch, var(--background) 55%, transparent); display: grid; place-items: center; text-align: center; padding: 20px; }
+      .lockwrap .veil .box { display: grid; justify-items: center; gap: 8px; }
+      .lockwrap .veil .li { width: 36px; height: 36px; border-radius: 999px; background: var(--muted); display: grid; place-items: center; border: 1px solid var(--border); }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="brand"><div class="brand-mark">C</div><div class="brand-name">ClassroomIO</div></div>
+        <div class="nav-label">Learning</div>
+        <a class="nav-item active" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>My courses</a>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="8" r="6"/><path d="M15.5 13.5 17 22l-5-3-5 3 1.5-8.5"/></svg>Certificates</a>
+        <div class="sidebar-foot"><div class="avatar">MR</div><div class="who"><div class="nm">Maya Ruiz</div><div class="rl">Learner</div></div></div>
+      </aside>
+
+      <div class="main">
+        <header class="topbar">
+          <div class="crumbs"><a href="#">Instructional Design 201</a><span class="sep">/</span><span>Designing Effective Assessments</span></div>
+          <div class="top-actions">
+            <button class="btn btn-outline btn-sm" onclick="toggleLock()">Toggle locked state</button>
+            <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+          </div>
+        </header>
+
+        <main class="content">
+          <!-- learner view uses the reading column, max-w-3xl -->
+          <div class="wrap-narrow">
+            <div class="page-head">
+              <div>
+                <p class="page-sub" style="text-transform: uppercase; letter-spacing: 0.06em; font-size: 11.5px; margin-bottom: 4px">Module 4</p>
+                <h1 class="page-title">Designing Effective Assessments</h1>
+              </div>
+            </div>
+
+            <!-- unlocked -->
+            <section id="open">
+              <div class="player">
+                <div id="frame"></div>
+                <div class="player-bar">
+                  <button class="icon-btn" id="prev" aria-label="Previous slide"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m15 18-6-6 6-6"/></svg></button>
+                  <button class="icon-btn" id="next" aria-label="Next slide"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m9 18 6-6-6-6"/></svg></button>
+                  <div class="pdots" id="dots"></div>
+                  <span class="pos tnum" id="pos">1 / 8</span>
+                  <button class="icon-btn" id="ovBtn" aria-label="Overview"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg></button>
+                  <button class="icon-btn" aria-label="Fullscreen" onclick="document.getElementById('frame').requestFullscreen?.()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M8 21H5a2 2 0 0 1-2-2v-3M16 21h3a2 2 0 0 0 2-2v-3"/></svg></button>
+                </div>
+              </div>
+
+              <div id="ov" hidden style="margin-top: 14px">
+                <div class="overview" id="ovGrid"></div>
+              </div>
+
+              <div class="item item-outline" style="margin-top: 16px">
+                <span class="item-media-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>
+                <div class="item-content">
+                  <div class="item-title">Reach the last slide to complete this lesson</div>
+                  <div class="item-desc" id="progressCopy">You've viewed 1 of 8 slides.</div>
+                </div>
+                <div class="item-actions"><button class="btn btn-primary btn-sm" id="complete" disabled>Mark complete</button></div>
+              </div>
+
+              <p class="hint" style="margin-top: 12px">
+                Navigate with <span class="kbd">←</span> <span class="kbd">→</span>, open the grid with <span class="kbd">O</span>. Your position is saved as you go.
+              </p>
+            </section>
+
+            <!-- locked -->
+            <section id="locked" hidden>
+              <div class="lockwrap">
+                <div id="lockedFrame"></div>
+                <div class="veil">
+                  <div class="box">
+                    <span class="li"><svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg></span>
+                    <h3 style="margin: 0; font-size: 15px; font-weight: 500">Finish the previous lesson first</h3>
+                    <p class="hint" style="margin: 0; max-width: 340px">This deck unlocks once you complete <b>Writing Learning Outcomes</b>.</p>
+                  </div>
+                </div>
+              </div>
+              <p class="hint" style="margin-top: 12px">A locked deck is never sent to the browser — the blurred frame is a placeholder, not the real content.</p>
+            </section>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <script src="deck-data.js"></script>
+    <script>
+      let index = 0;
+      let furthest = 0;
+
+      const frame = document.getElementById('frame');
+      document.getElementById('lockedFrame').innerHTML = renderSlide(DECK.slides[0], { chrome: false });
+
+      document.getElementById('dots').innerHTML = DECK.slides.map(() => '<span class="pdot"></span>').join('');
+      document.getElementById('ovGrid').innerHTML = DECK.slides
+        .map((slide, i) => `<div class="ov-item" data-i="${i}">${renderSlide(slide, { chrome: false })}<span class="n">${i + 1}</span></div>`)
+        .join('');
+      document.querySelectorAll('#ovGrid .ov-item').forEach((el) => {
+        el.onclick = () => { index = +el.dataset.i; document.getElementById('ov').hidden = true; paint(); };
+      });
+
+      function paint() {
+        furthest = Math.max(furthest, index);
+        frame.innerHTML = renderSlide(DECK.slides[index]);
+        document.getElementById('pos').textContent = `${index + 1} / ${DECK.slides.length}`;
+
+        document.querySelectorAll('.pdot').forEach((dot, i) => {
+          dot.classList.toggle('seen', i <= furthest);
+          dot.classList.toggle('current', i === index);
+        });
+        document.querySelectorAll('#ovGrid .ov-item').forEach((el, i) => el.classList.toggle('current', i === index));
+
+        const seen = furthest + 1;
+        document.getElementById('progressCopy').textContent =
+          seen === DECK.slides.length ? 'You reached the last slide — this lesson can be completed.' : `You've viewed ${seen} of ${DECK.slides.length} slides.`;
+        document.getElementById('complete').disabled = seen < DECK.slides.length;
+      }
+
+      const go = (delta) => { index = Math.min(DECK.slides.length - 1, Math.max(0, index + delta)); paint(); };
+      document.getElementById('prev').onclick = () => go(-1);
+      document.getElementById('next').onclick = () => go(1);
+      document.getElementById('ovBtn').onclick = () => {
+        const ov = document.getElementById('ov');
+        ov.hidden = !ov.hidden;
+      };
+      frame.onclick = () => go(1);
+
+      addEventListener('keydown', (event) => {
+        if (event.key === 'ArrowRight') go(1);
+        if (event.key === 'ArrowLeft') go(-1);
+        if (event.key.toLowerCase() === 'o') document.getElementById('ovBtn').onclick();
+      });
+
+      function toggleLock() {
+        const open = document.getElementById('open');
+        const locked = document.getElementById('locked');
+        const showLocked = locked.hidden;
+        locked.hidden = !showLocked;
+        open.hidden = showLocked;
+      }
+
+      paint();
+
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>

--- a/prototypes/slide-builder/lesson-slide-tab.html
+++ b/prototypes/slide-builder/lesson-slide-tab.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Lesson — Slide tab · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="deck.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .deck-summary { display: grid; grid-template-columns: 260px 1fr; gap: 18px; border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 16px; background: var(--card); }
+      .deck-summary .meta { display: grid; gap: 10px; align-content: start; }
+      .deck-summary h3 { margin: 0; font-size: 16px; font-weight: 500; }
+      .meta-row { display: flex; gap: 16px; flex-wrap: wrap; font-size: 13px; color: var(--muted-foreground); }
+      .meta-row b { color: var(--foreground); font-weight: 500; }
+      .plat-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; }
+      .plat { border: 1px solid var(--border); border-radius: var(--radius-md); padding: 10px 6px; display: grid; gap: 6px; justify-items: center; font-size: 11.5px; cursor: pointer; background: var(--card); text-align: center; }
+      .plat:hover, .plat.on { border-color: var(--primary); }
+      .plat .g { width: 26px; height: 26px; border-radius: 7px; display: grid; place-items: center; color: #fff; font-size: 11px; font-weight: 700; }
+      @media (max-width: 900px) { .deck-summary { grid-template-columns: 1fr; } .plat-grid { grid-template-columns: repeat(3, 1fr); } }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="brand"><div class="brand-mark">C</div><div class="brand-name">ClassroomIO</div></div>
+        <div class="nav-label">Content</div>
+        <a class="nav-item active" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Courses</a>
+        <a class="nav-item" href="deck-library.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 3h20v12H2zM12 15v6M8 21h8"/></svg>Decks</a>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg>Media</a>
+        <div class="sidebar-foot"><div class="avatar">JD</div><div class="who"><div class="nm">Jordan Diallo</div><div class="rl">Admin</div></div></div>
+      </aside>
+
+      <div class="main">
+        <header class="topbar">
+          <div class="crumbs">
+            <a href="#">Courses</a><span class="sep">/</span><a href="#">Instructional Design 201</a><span class="sep">/</span><span>Designing Effective Assessments</span>
+          </div>
+          <div class="top-actions">
+            <span class="badge badge-muted">Edit mode</span>
+            <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+          </div>
+        </header>
+
+        <main class="content">
+          <!-- Edit mode uses the wide column (lg:w-full xl:w-11/12), not the reading column -->
+          <div style="max-width: 1100px; margin: 0 auto">
+            <div class="page-head">
+              <div>
+                <h1 class="page-title">Designing Effective Assessments</h1>
+                <p class="page-sub">Module 4 · Instructional Design 201</p>
+              </div>
+            </div>
+
+            <!-- materials tab bar — mirrors UnderlineTabs -->
+            <div class="utabs" role="tablist">
+              <button class="utab" role="tab"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m22 8-6 4 6 4V8z"/><rect x="2" y="6" width="14" height="12" rx="2"/></svg>Video<span class="chip">2</span></button>
+              <button class="utab" role="tab"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2zM22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>Note<span class="chip">1</span></button>
+              <button class="utab active" role="tab" aria-selected="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 3h20v12H2zM12 15v6M8 21h8"/></svg>Slide<span class="chip" id="tabChip">8</span></button>
+              <button class="utab" role="tab"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>Document<span class="chip">1</span></button>
+              <button class="utab" role="tab"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="3"/><path d="M12 3v2M12 19v2M3 12h2M19 12h2"/></svg>Settings</button>
+            </div>
+
+            <div style="padding-top: 20px">
+              <!-- STATE A: nothing chosen yet -->
+              <section id="chooser" hidden>
+                <p class="hint" style="margin: 0 0 12px">This lesson has no deck yet. Pick how you want to add one.</p>
+                <div class="mode-grid">
+                  <a class="mode-card" href="#" onclick="setState('embed');return false">
+                    <span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7L12 19"/></svg></span>
+                    <h4>Embed an existing deck</h4>
+                    <p>Paste a link from Google Slides, Canva, PowerPoint, Figma Slides and six more. The deck stays where it lives.</p>
+                    <span class="pick">Choose a platform <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor"><path d="m9 18 6-6-6-6"/></svg></span>
+                  </a>
+                  <a class="mode-card" href="#" onclick="setState('deck');return false">
+                    <span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M2 3h20v12H2zM12 15v6M8 21h8"/></svg></span>
+                    <h4>Build a deck here</h4>
+                    <p>Author slides in ClassroomIO. Themed to your brand, exportable, editable by AI, and progress is tracked for every learner.</p>
+                    <span class="pick">Start a deck <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor"><path d="m9 18 6-6-6-6"/></svg></span>
+                  </a>
+                </div>
+              </section>
+
+              <!-- STATE B: embed mode (the slide-embed-picker, folded in as one mode) -->
+              <section id="embed" hidden>
+                <div class="insp-row" style="margin-bottom: 12px">
+                  <span class="badge badge-muted">Embed mode</span>
+                  <button class="btn btn-ghost btn-sm" onclick="setState('deck')">Switch to a native deck</button>
+                </div>
+                <div class="plat-grid">
+                  <div class="plat on"><span class="g" style="background:#f9ab00">GS</span>Google Slides</div>
+                  <div class="plat"><span class="g" style="background:#00c4cc">Cv</span>Canva</div>
+                  <div class="plat"><span class="g" style="background:#d24726">PP</span>PowerPoint</div>
+                  <div class="plat"><span class="g" style="background:#111">Fg</span>Figma Slides</div>
+                  <div class="plat"><span class="g" style="background:#3181ff">Pz</span>Prezi</div>
+                </div>
+                <div class="field" style="margin-top: 14px">
+                  <label class="label" for="url">Published link or embed code</label>
+                  <input class="input" id="url" value="https://docs.google.com/presentation/d/e/2PACX-1v.../pub?start=false" />
+                  <p class="hint">File → Share → <b>Publish to web</b> → Embed. We rewrite <code>/pub</code>, <code>/edit</code> and <code>/present</code> to <code>/embed</code>.</p>
+                </div>
+                <div class="note-strip info" style="margin-top: 12px">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg>
+                  <span>Embed ready — resolved to <code>…/embed?start=false&amp;loop=false</code>. Only the resolved URL is stored, never the pasted markup.</span>
+                </div>
+                <div style="border:1px solid var(--border);border-radius:var(--radius-lg);aspect-ratio:16/9;margin-top:14px;display:grid;place-items:center;background:var(--muted);color:var(--muted-foreground);font-size:13px">
+                  Live preview of the embedded deck
+                </div>
+              </section>
+
+              <!-- STATE C: native deck attached -->
+              <section id="deck">
+                <div class="insp-row" style="margin-bottom: 12px">
+                  <span class="badge badge-success-soft">Native deck</span>
+                  <button class="btn btn-ghost btn-sm" onclick="setState('embed')">Switch to an embedded deck</button>
+                </div>
+                <div class="deck-summary">
+                  <div id="cover"></div>
+                  <div class="meta">
+                    <h3>Designing Effective Assessments</h3>
+                    <div class="meta-row">
+                      <span><b>8</b> slides</span>
+                      <span>Theme <b>Classic</b></span>
+                      <span>Edited <b>2 hours ago</b> by Jordan</span>
+                    </div>
+                    <div class="meta-row"><span>Also used in <b>Assessment Clinic</b> — this deck lives in your org library.</span></div>
+                    <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-top: 4px">
+                      <a class="btn btn-primary btn-sm" href="deck-editor.html">Open editor</a>
+                      <a class="btn btn-outline btn-sm" href="presenter.html" target="_blank">Present</a>
+                      <a class="btn btn-outline btn-sm" href="deck-export.html">Export</a>
+                      <a class="btn btn-outline btn-sm" href="deck-library.html">Replace from library</a>
+                    </div>
+                  </div>
+                </div>
+                <div class="note-strip info" style="margin-top: 14px">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01"/></svg>
+                  <span>Switching modes never deletes the other one. The embedded link and the deck both stay on the lesson — <code>slideMode</code> decides which renders.</span>
+                </div>
+              </section>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <script src="deck-data.js"></script>
+    <script>
+      document.getElementById('cover').innerHTML = renderSlide(DECK.slides[0], { chrome: false });
+
+      function setState(which) {
+        ['chooser', 'embed', 'deck'].forEach((id) => (document.getElementById(id).hidden = id !== which));
+        document.getElementById('tabChip').textContent = which === 'deck' ? '8' : which === 'embed' ? '1' : '0';
+      }
+
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>

--- a/prototypes/slide-builder/presenter.html
+++ b/prototypes/slide-builder/presenter.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Presenter view · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="deck.css" />
+    <style>
+      body { background: #0b0d12; margin: 0; }
+      .pbtn { border: 1px solid #2a3140; background: #161a23; color: #d6dbe3; font-family: inherit; font-size: 13px; padding: 7px 12px; border-radius: 8px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
+      .pbtn:hover { background: #1e2431; }
+      .pbtn svg { width: 14px; height: 14px; stroke-width: 2; }
+      .pnext { opacity: 0.55; }
+      .blackout { position: fixed; inset: 0; background: #000; z-index: 500; display: grid; place-items: center; color: #3a4150; font-size: 14px; }
+    </style>
+  </head>
+  <body>
+    <div class="presenter">
+      <!-- current slide + controls -->
+      <div class="pcol">
+        <div class="pmeta">
+          <span class="plabel">Now presenting</span>
+          <span class="plabel" id="posLabel">3 / 8</span>
+        </div>
+        <div class="pframe" id="cur"></div>
+        <div class="pmeta">
+          <div style="display: flex; gap: 8px">
+            <button class="pbtn" id="prev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m15 18-6-6 6-6" /></svg>Prev</button>
+            <button class="pbtn" id="next">Next<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m9 18 6-6-6-6" /></svg></button>
+            <button class="pbtn" id="ovBtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" /><rect x="3" y="14" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" /></svg>Overview</button>
+            <button class="pbtn" id="blackBtn">Blackout</button>
+          </div>
+          <div class="pkeys">
+            <span class="kbd">←</span><span class="kbd">→</span><span class="kbd">O</span><span class="kbd">B</span><span class="kbd">F</span><span class="kbd">Esc</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- next slide + notes + timer -->
+      <div class="pcol">
+        <div class="pmeta">
+          <span class="plabel">Up next</span>
+          <span class="ptimer" id="timer">00:00</span>
+        </div>
+        <div class="pframe pnext" id="nextFrame"></div>
+        <span class="plabel">Presenter notes</span>
+        <div class="notes" id="notes" style="min-height: 180px"></div>
+        <div class="pmeta">
+          <button class="pbtn" id="reset">Reset timer</button>
+          <a class="pbtn" href="deck-editor.html">Exit presenter</a>
+        </div>
+      </div>
+    </div>
+
+    <!-- overview grid -->
+    <div class="blackout" id="overview" hidden style="background: #0b0d12; align-items: start; padding: 30px; overflow: auto">
+      <div style="width: 100%">
+        <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px">
+          <span class="plabel" style="color: #7f8794">Overview — press O or Esc to close</span>
+        </div>
+        <div class="overview" id="ovGrid"></div>
+      </div>
+    </div>
+
+    <div class="blackout" id="black" hidden>Screen blacked out — press B to resume</div>
+
+    <script src="deck-data.js"></script>
+    <script>
+      let index = 2;
+      let seconds = 0;
+
+      const cur = document.getElementById('cur');
+      const nextFrame = document.getElementById('nextFrame');
+      const notes = document.getElementById('notes');
+
+      function paint() {
+        const slide = DECK.slides[index];
+        cur.innerHTML = renderSlide(slide);
+        nextFrame.innerHTML = DECK.slides[index + 1]
+          ? renderSlide(DECK.slides[index + 1])
+          : '<div class="slide-frame theme-classic" style="display:grid;place-items:center;color:var(--slide-fg-muted);font-size:calc(36 * var(--u))">End of deck</div>';
+        notes.innerHTML = slide.notes ? slide.notes : '<i style="color:#6b7280">No notes on this slide.</i>';
+        document.getElementById('posLabel').textContent = `${index + 1} / ${DECK.slides.length}`;
+        document.querySelectorAll('#ovGrid .ov-item').forEach((el, i) => el.classList.toggle('current', i === index));
+      }
+
+      document.getElementById('ovGrid').innerHTML = DECK.slides
+        .map((slide, i) => `<div class="ov-item" data-i="${i}">${renderSlide(slide, { chrome: false })}<span class="n">${i + 1}</span></div>`)
+        .join('');
+
+      document.querySelectorAll('#ovGrid .ov-item').forEach((el) => {
+        el.onclick = () => {
+          index = +el.dataset.i;
+          document.getElementById('overview').hidden = true;
+          paint();
+        };
+      });
+
+      const go = (delta) => {
+        index = Math.min(DECK.slides.length - 1, Math.max(0, index + delta));
+        paint();
+      };
+
+      document.getElementById('prev').onclick = () => go(-1);
+      document.getElementById('next').onclick = () => go(1);
+      document.getElementById('ovBtn').onclick = () => toggle('overview');
+      document.getElementById('blackBtn').onclick = () => toggle('black');
+      document.getElementById('reset').onclick = () => { seconds = 0; tick(); };
+
+      function toggle(id) {
+        const el = document.getElementById(id);
+        el.hidden = !el.hidden;
+      }
+
+      addEventListener('keydown', (event) => {
+        const key = event.key.toLowerCase();
+        if (event.key === 'ArrowRight' || event.key === ' ') { event.preventDefault(); go(1); }
+        if (event.key === 'ArrowLeft') go(-1);
+        if (key === 'o') toggle('overview');
+        if (key === 'b') toggle('black');
+        if (key === 'f') document.documentElement.requestFullscreen?.();
+        if (event.key === 'Escape') {
+          document.getElementById('overview').hidden = true;
+          document.getElementById('black').hidden = true;
+        }
+      });
+
+      function tick() {
+        const mm = String(Math.floor(seconds / 60)).padStart(2, '0');
+        const ss = String(seconds % 60).padStart(2, '0');
+        document.getElementById('timer').textContent = `${mm}:${ss}`;
+      }
+      setInterval(() => { seconds += 1; tick(); }, 1000);
+
+      paint();
+      tick();
+    </script>
+  </body>
+</html>

--- a/prototypes/slide-builder/public-course-lesson.html
+++ b/prototypes/slide-builder/public-course-lesson.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Designing Effective Assessments · Acme Academy</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="deck.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      /* PublicCourseShell: sticky 3rem header, w-72 outline sidebar, max-w-3xl column */
+      body { background: var(--background); }
+      .pc-head { position: sticky; top: 0; z-index: 30; height: 48px; border-bottom: 1px solid var(--border); background: color-mix(in oklch, var(--background) 90%, transparent); backdrop-filter: blur(8px); display: flex; align-items: center; gap: 12px; padding: 0 24px; }
+      .pc-head .org { display: flex; align-items: center; gap: 8px; text-decoration: none; color: inherit; }
+      .pc-head .org .av { width: 24px; height: 24px; border-radius: 6px; background: color-mix(in oklch, var(--primary) 12%, transparent); color: var(--primary); display: grid; place-items: center; font-size: 11px; font-weight: 600; }
+      .pc-head .org .nm { font-size: 14px; font-weight: 500; }
+      .pc-head .ct { font-size: 14px; color: var(--muted-foreground); flex: 1; min-width: 0; }
+      .pc-body { display: flex; min-height: calc(100dvh - 48px); }
+      .pc-side { position: sticky; top: 48px; width: 288px; flex-shrink: 0; height: calc(100dvh - 48px); overflow-y: auto; border-right: 1px solid var(--border); background: var(--sidebar); padding: 24px 8px; }
+      .pc-sec { margin-bottom: 24px; }
+      .pc-sec h2 { margin: 0 0 8px; padding: 0 12px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted-foreground); font-weight: 500; }
+      .pc-row { display: flex; align-items: center; gap: 6px; padding: 4px 16px 4px 12px; border-radius: 6px; text-decoration: none; font-size: 13px; line-height: 1.35; color: color-mix(in oklch, var(--foreground) 70%, transparent); }
+      .pc-row:hover { color: var(--primary); }
+      .pc-row.on { color: var(--primary); }
+      .nb { width: 28px; height: 28px; border-radius: 6px; display: grid; place-items: center; font-size: 12px; font-variant-numeric: tabular-nums; border: 1px solid var(--border); background: var(--muted); color: var(--muted-foreground); flex-shrink: 0; }
+      .pc-row.on .nb { background: var(--primary); color: var(--primary-foreground); border-color: transparent; }
+      .pc-row.lk { color: var(--muted-foreground); }
+      .pc-main { flex: 1; min-width: 0; padding-bottom: 48px; }
+      .pc-col { max-width: 768px; margin: 0 auto; padding: 32px 24px 40px; }
+      .pc-col h1 { font-size: 30px; letter-spacing: -0.02em; margin: 8px 0 0; font-weight: 500; }
+      .pc-eyebrow { font-size: 11.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted-foreground); font-weight: 500; }
+      .prose p { font-size: 15.5px; line-height: 1.75; color: var(--foreground); }
+      .cta { border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 18px; display: flex; align-items: center; gap: 16px; background: var(--card); margin-top: 28px; }
+      @media (max-width: 1024px) { .pc-side { display: none; } }
+    </style>
+  </head>
+  <body>
+    <header class="pc-head">
+      <a class="org" href="#"><span class="av">A</span><span class="nm">Acme Academy</span></a>
+      <span aria-hidden="true" style="color: var(--muted-foreground); opacity: 0.6">|</span>
+      <span class="ct">Instructional Design 201</span>
+      <a class="btn btn-secondary btn-sm" href="#">Explore courses</a>
+      <a class="btn btn-primary btn-sm" href="#">Sign in</a>
+      <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+    </header>
+
+    <div class="pc-body">
+      <aside class="pc-side" aria-label="Course outline">
+        <div class="pc-sec">
+          <h2>Foundations</h2>
+          <a class="pc-row" href="#"><span class="nb">1</span><span>What instructional design is for</span></a>
+          <a class="pc-row" href="#"><span class="nb">2</span><span>Writing learning outcomes</span></a>
+        </div>
+        <div class="pc-sec">
+          <h2>Assessment</h2>
+          <a class="pc-row on" href="#"><span class="nb">1</span><span>Designing effective assessments</span></a>
+          <a class="pc-row lk" href="#"><span class="nb"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg></span><span>Rubrics in practice</span></a>
+          <a class="pc-row lk" href="#"><span class="nb"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg></span><span>Feedback that changes behaviour</span></a>
+        </div>
+      </aside>
+
+      <main class="pc-main">
+        <div class="pc-col">
+          <div class="pc-eyebrow">Assessment</div>
+          <h1>Designing Effective Assessments</h1>
+
+          <div class="note-strip info" style="margin-top: 20px">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01"/></svg>
+            <span>Slides never reach this page today — <code>public-course.ts</code> does not even select them. A native deck is what makes a public course page able to show one.</span>
+          </div>
+
+          <div class="player" style="margin-top: 20px">
+            <div id="frame"></div>
+            <div class="player-bar">
+              <button class="icon-btn" id="prev" aria-label="Previous slide"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m15 18-6-6 6-6"/></svg></button>
+              <button class="icon-btn" id="next" aria-label="Next slide"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m9 18 6-6-6-6"/></svg></button>
+              <div class="pdots" id="dots"></div>
+              <span class="pos tnum" id="pos">1 / 8</span>
+              <button class="icon-btn" id="ovBtn" aria-label="Overview"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg></button>
+            </div>
+          </div>
+
+          <div id="ov" hidden style="margin-top: 14px"><div class="overview" id="ovGrid"></div></div>
+
+          <div class="prose" style="margin-top: 28px">
+            <p>
+              An assessment item that cannot name the outcome it measures is decoration. This lesson walks through the four traits
+              of a usable item, why a rubric belongs with the task rather than the grade, and what changed for cohorts that
+              published theirs up front.
+            </p>
+          </div>
+
+          <div class="cta">
+            <div style="flex: 1">
+              <div style="font-size: 14.5px; font-weight: 500">Enrol to track your progress</div>
+              <div class="hint" style="margin: 2px 0 0">Anonymous visitors can read and browse the deck. Progress and completion need an account.</div>
+            </div>
+            <a class="btn btn-primary btn-sm" href="#">Enrol free</a>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <script src="deck-data.js"></script>
+    <script>
+      let index = 0;
+      const frame = document.getElementById('frame');
+
+      document.getElementById('dots').innerHTML = DECK.slides.map(() => '<span class="pdot"></span>').join('');
+      document.getElementById('ovGrid').innerHTML = DECK.slides
+        .map((slide, i) => `<div class="ov-item" data-i="${i}">${renderSlide(slide, { chrome: false })}<span class="n">${i + 1}</span></div>`)
+        .join('');
+      document.querySelectorAll('#ovGrid .ov-item').forEach((el) => {
+        el.onclick = () => { index = +el.dataset.i; document.getElementById('ov').hidden = true; paint(); };
+      });
+
+      function paint() {
+        frame.innerHTML = renderSlide(DECK.slides[index]);
+        document.getElementById('pos').textContent = `${index + 1} / ${DECK.slides.length}`;
+        document.querySelectorAll('.pdot').forEach((dot, i) => dot.classList.toggle('current', i === index));
+        document.querySelectorAll('#ovGrid .ov-item').forEach((el, i) => el.classList.toggle('current', i === index));
+      }
+
+      const go = (delta) => { index = Math.min(DECK.slides.length - 1, Math.max(0, index + delta)); paint(); };
+      document.getElementById('prev').onclick = () => go(-1);
+      document.getElementById('next').onclick = () => go(1);
+      document.getElementById('ovBtn').onclick = () => { const ov = document.getElementById('ov'); ov.hidden = !ov.hidden; };
+      frame.onclick = () => go(1);
+      addEventListener('keydown', (event) => {
+        if (event.key === 'ArrowRight') go(1);
+        if (event.key === 'ArrowLeft') go(-1);
+      });
+
+      paint();
+
+      document.getElementById('theme').onclick = () => {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What does this PR do?

Specs an **AI-native slide deck builder** so teachers can CRUD slides inside ClassroomIO instead of round-tripping to Google Slides or Canva — themed, exportable, and editable by the AI assistant and MCP.

Docs and prototypes only. No app code, no schema, no migration in this PR.

The reference experience is [open-slide](https://open-slide.dev/) (MIT, React). Its core primitive is arbitrary React code per slide, which cannot ship here — tenant-authored code in a multi-tenant Svelte app is remote code execution. So the PRD keeps the parts that make it good (fixed 1920×1080 canvas, token-driven themes, agent-first authoring) and swaps the primitive for a **typed, validated slide document**. That single change is what makes AI and MCP editing safe, diffable, and surgical.

### What's here

- `prd/slide-builder/README.md` — the spec, following the house structure (`prd/learning-paths`).
- `prototypes/slide-builder/` — 12 clickable screens across the teacher, learner, and public-visitor journeys. They share `deck-data.js`, so every screen renders from one slide document and cannot drift from each other or from the schema in the PRD.
- `PRD-TRACKER.md` — one row added.

### Decisions worth reviewing

- **The lesson Slide tab gains two modes** — embed an external deck (existing `slideUrl`, untouched) or build a native one. `slideMode` decides what renders; switching never destroys the other mode's data. This absorbs the earlier `prototypes/slide-embed-picker` exploration as the `embed` mode, so the tab is designed once instead of refactored later.
- **Decks are an org-level library** with a nullable `lessonId`, so one deck can serve many lessons and be addressed by id from AI and MCP.
- **One row per slide**, not one jsonb document per deck. `CHAT_VS_RUN.md:75` records that `update_lesson_content` can emit 5–20k tokens in a single call; a per-slide row makes `update_slide` a few hundred.
- **Canvas overflow is arithmetic**, rejected by `ZSlide.superRefine` at the API boundary — neither a teacher nor an agent can persist a cropped slide. This is the problem open-slide's `slide-authoring` skill spends most of its length teaching an agent to solve by hand.
- **Deck content never travels as HTML** through `lesson_language.content`. The server sanitizer strips `iframe`/`object`/`embed` (`packages/utils/src/functions/sanitize.ts:1-15`), which is why the editor's existing IFrame extension silently loses data today. Blocks are structured jsonb rendered by components — the `lesson.videos` pattern.
- **Heavy generation tools are gated to durable run mode.** This implements the API-layer gate `CHAT_VS_RUN.md:87` recommends and that `RUN_ONLY_TOOL_NAMES` (`chat-tools.ts:1066`) currently leaves as an empty set.
- **Public course pages get decks.** `public-course.ts:358-368` does not select `slideUrl` at all today, so a public course page shows no deck whatsoever. This is net-new capability, not a port.

### Product calls made without an explicit answer — flagged for veto

1. **PPTX import extracts images, not just text.** The existing extractor (`document.ts:227-256`) is text-only, but JSZip is already loaded, so pulling `ppt/media/*` into an unplaced-assets tray is incremental. Original positioning is still not reconstructed, and the import banner says so before upload.
2. **Four built-in themes** (Classic, Editorial, Bold, Mono) plus the org brand seed.
3. **`slideMode` is a stored column, not derived** from which field is populated, so a lesson holding both a legacy `slideUrl` and a deck has one unambiguous answer.

Also worth a maintainer decision: this is a product, not a feature — realistically a quarter of work. Phases 1–4 deliver a usable authoring product before AI, MCP, export, and public rendering land.

## Demo

No video — there is no running code to record. The prototypes are the demo:

```bash
open prototypes/slide-builder/index.html
```

`index.html` maps all three journeys and every page cross-links, so each flow clicks through end to end. Each page has a light/dark toggle.

Worth clicking specifically:

- `deck-editor.html` — drag rail thumbnails to reorder, click a block on the canvas to select and edit it, change the layout.
- `deck-editor-free.html` — one block sits deliberately past the canvas edge, so **Save is disabled** and the warning shows the arithmetic (`760 + 400 = 1160 > 1080`). This is the overflow guard made visible.
- `deck-library.html` and `lesson-deck-player.html` — header buttons toggle the empty and locked states.
- `deck-ai.html` — slides stream into the rail from a durable run; "Apply all pins" walks the comment-pin flow.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

Documentation-only. The PRD *proposes* a migration; this PR does not contain one.

## How should this be tested?

This is a spec review, not a code review. Suggested passes:

- **Read the PRD** at `prd/slide-builder/README.md`, especially **Confirmed Decisions** (the contract) and **Risks and Mitigations**.
- **Click every prototype** from `prototypes/slide-builder/index.html` and check the interaction model, states, and copy. Per house process, when the PRD and a prototype disagree on a UI detail, **the prototype wins** — so flag any disagreement you spot.
- **Sanity-check the code references.** Every file:line citation in the Current-State Audit was verified against `main` at time of writing; call out anything that has since moved.
- **Verify nothing else changed:** `git diff --stat origin/main...HEAD` should show only `PRD-TRACKER.md`, `prd/slide-builder/`, and `prototypes/slide-builder/`.

Per `AGENTS.md`, `prototypes/` is excluded from production review standards (`.coderabbit.yaml`, `.greptile/config.json`) — these are design mocks, not production code.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` — **not applicable**: no app or package source changed. Ran the gates that do apply: `pnpm format:check` passes, and lefthook's `pre-commit` passed (`ui-prefix` skipped, no staged `packages/ui/src/**` files).
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch — branched directly off freshly fetched `origin/main`
- [x] My changes don't cause any responsiveness issues — every prototype collapses at its breakpoints; the editor drops the inspector under 1100px
- [x] If I am a first-time or external contributor, I signed the ClassroomIO CLA — n/a, maintainer
- [x] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out — it changes none of them

### Appreciated

- [ ] If a UI change was made: added a screen recording or screenshots — no shipped UI changed; the prototypes are self-serve above
- [x] Updated the ClassroomIO Docs if changes were necessary — none necessary yet. The PRD notes that shipping MCP tools will require updating both `packages/mcp/README.md` and `apps/docs/content/docs/mcp.mdx`, since the tool list is duplicated across them.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR documents an AI-native slide-builder product and adds it to the PRD tracker.
- Specifies deck, slide, history, and learner-progress persistence.
- Defines teacher authoring, AI/MCP, import/export, learner, presenter, and public-course flows.
- Provides a phased implementation plan and acceptance criteria.

<h3>Confidence Score: 3/5</h3>

The specification should not be approved until deck attachment ownership and slide-progress cleanup semantics are made unambiguous.

The proposed schema has two conflicting sources of attachment truth for reusable decks and leaves completion-affecting slide progress outside established referential cleanup and course-reset behavior.

**Files Needing Attention:** prd/slide-builder/README.md

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| prd/slide-builder/README.md | Adds the complete slide-builder specification, but the proposed attachment relationship is contradictory and learner-progress cleanup is incomplete. |
| PRD-TRACKER.md | Adds the new draft slide-builder PRD to the pending tracker. |


<h3>Entity Relationship Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
erDiagram
  ORGANIZATION ||--o{ SLIDE_DECK : owns
  SLIDE_DECK ||--|{ SLIDE : contains
  SLIDE_DECK ||--o{ SLIDE_DECK_VERSION : snapshots
  LESSON }o--o| SLIDE_DECK : selects
  SLIDE_DECK ||--o{ SLIDE_PROGRESS : records
  LESSON ||--o{ SLIDE_PROGRESS : scopes
  PROFILE ||--o{ SLIDE_PROGRESS : earns
```

<sub>Reviews (1): Last reviewed commit: ["docs: add slide builder PRD and prototyp..."](https://github.com/classroomio/classroomio/commit/f940361b373c650b90b8fdb94efe2d757a2c1b7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57424466)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive product specification for a native Slide Builder.
  - Describes creating, editing, organizing, theming, importing, and exporting structured slide decks.
  - Documents presenter mode, learner progress tracking, reusable slide libraries, AI-assisted generation, and version history.
  - Defines support for both native slide decks and existing embedded presentations.
  - Added the Slide Builder to the list of pending product requirements as a draft proposal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->