### PR TITLE
fix(auth): skip password min-length check on login

### DIFF
--- a/apps/dashboard/src/lib/utils/functions/validator.ts
+++ b/apps/dashboard/src/lib/utils/functions/validator.ts
@@ -67,12 +67,12 @@ export const processErrors = (error, mapToId?: boolean) => {
   return errors;
 };
 
-export const authValidation = (fields = {}) => {
+export const authValidation = (fields = {}, { skipPassword = false }: { skipPassword?: boolean } = {}) => {
   const schema = z.object({
     email: z.string().email({
       message: 'validations.auth.email.invalid_email'
     }),
-    password: ZPassword
+    ...(skipPassword ? {} : { password: ZPassword })
   });
 
   const { error } = schema.safeParse(fields);

--- a/apps/dashboard/src/routes/(auth)/login/+page.svelte
+++ b/apps/dashboard/src/routes/(auth)/login/+page.svelte
@@ -78,7 +78,7 @@
       return;
     }
 
-    const validationRes = authValidation(fields);
+    const validationRes = authValidation(fields, { skipPassword: true });
     console.log('validationRes', validationRes);
 
     if (Object.keys(validationRes).length) {


### PR DESCRIPTION
## Summary
- Login no longer runs the 8-character password rule that signup uses.
- Short or older passwords can be submitted. The server still rejects bad credentials.
- Signup and reset still require 8+ characters.

## Test plan
- [ ] On login, enter a password shorter than 8 characters and confirm you get an auth error from the server, not a min-length validation message
- [ ] On login, enter an invalid email and still see the email validation error
- [ ] On signup, a password under 8 characters is still rejected
- [ ] A normal login with a valid password still works


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved login form submission by preventing unnecessary password validation during login.
  - Preserved password validation for other authentication flows where it is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes shared authentication validation so login accepts passwords shorter than the signup minimum while signup and reset retain their existing constraints.
- Adds an optional login-oriented password-validation bypass to `authValidation`.
- Enables that option in the login submission flow.
- The bypass currently removes required-password validation along with the minimum-length check.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking validation issue where empty login passwords now reach the server.

Short passwords correctly bypass the signup-specific length rule, but omitting the complete password schema also drops local required-password validation.

**Files Needing Attention:** apps/dashboard/src/lib/utils/functions/validator.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/utils/functions/validator.ts | Adds conditional password-schema omission, but this also allows empty passwords through client validation. |
| apps/dashboard/src/routes/(auth)/login/+page.svelte | Enables relaxed password validation for login while preserving email validation and the existing authentication request. |

<sub>Reviews (1): Last reviewed commit: ["fix(auth): skip password min-length chec..."](https://github.com/classroomio/classroomio/commit/1776e3967f097a21a9e07e14d1c6785be408cb05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57583715)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->