### PR TITLE
fix: let students create their own organization from the LMS menu

### DIFF
--- a/apps/dashboard/src/lib/features/ui/sidebar/footer/menu.svelte
+++ b/apps/dashboard/src/lib/features/ui/sidebar/footer/menu.svelte
@@ -8,6 +8,7 @@
   import BadgeHelpIcon from '@lucide/svelte/icons/badge-help';
   import LogOutIcon from '@lucide/svelte/icons/log-out';
   import MessageSquarePlusIcon from '@lucide/svelte/icons/message-square-plus';
+  import PlusIcon from '@lucide/svelte/icons/plus';
   import * as Sidebar from '@cio/ui/base/sidebar';
   import { UserAvatar } from '@cio/ui/custom/user-avatar';
   import { useSidebar } from '@cio/ui/base/sidebar';
@@ -16,9 +17,21 @@
 
   import { t } from '$lib/utils/functions/translations';
   import { profile } from '$lib/utils/store/user';
-  import { currentOrg } from '$lib/utils/store/org';
+  import { currentOrg, getAppOrigin } from '$lib/utils/store/org';
   import { showUserJotWidget } from '$lib/utils/services/userjot';
   import { ROLE } from '@cio/utils/constants';
+  import { PUBLIC_IS_SELFHOSTED } from '$env/static/public';
+
+  const isSelfHosted = PUBLIC_IS_SELFHOSTED === 'true';
+
+  function createOwnOrganization() {
+    if ($globalStore.isOrgSite) {
+      window.location.href = `${getAppOrigin()}/onboarding`;
+      return;
+    }
+
+    goto(resolve('/onboarding', {}));
+  }
 
   const SUPPORT_EMAIL = 'help@classroomio.com';
   const DOCS_URL = 'https://classroomio.com/docs';
@@ -142,7 +155,16 @@
               </div>
             {/if}
 
-            <DropdownMenu.Separator />
+            {#if !isSelfHosted}
+              <DropdownMenu.Item class="m-0" onclick={createOwnOrganization}>
+                <span class="flex w-full items-center gap-2">
+                  <PlusIcon size={16} />
+                  <p class="text-sm">{$t('add_org.create_org')}</p>
+                </span>
+              </DropdownMenu.Item>
+
+              <DropdownMenu.Separator />
+            {/if}
 
             <DropdownMenu.Item onclick={() => goto(resolve(`/logout`, {}))}>
               <span class="flex items-center gap-2">


### PR DESCRIPTION
Fixes #872.

The onboarding flow already lets a student create their own organization: `routeUserToNextPage` in `apps/dashboard/src/lib/features/app/init.svelte.ts` has a case that keeps a student with existing org memberships on `/onboarding` instead of bouncing them back to their org's LMS, and `createOrganizationWithOwner` (`apps/api/src/services/onboarding.ts`) has no per-user block on cloud, only a self-hosted single-org check. Nothing in the UI ever links to `/onboarding` for a logged-in user, though. It's only ever reached as an automatic redirect for someone with zero orgs, so a student who's already a member of another org gets sent straight into that org's LMS on login with no way to find the create-org flow.

The org switcher dropdown does have an "Add Organization" entry, but it's a disabled stub with no click handler, and that dropdown only renders in the org-admin layout, which a student who isn't also an admin somewhere never visits.

Added a "Create Organization" item to the account menu used by both the LMS and org-admin sidebars, shown in cloud mode only (self-hosted is single-org by design). It navigates to `/onboarding` on the admin host, or does a cross-origin redirect there when the user is currently on their org's tenant subdomain, matching how `handlePendingInviteAccepted` already handles cross-origin navigation in the same file.

No test added: the menu component and the redirect logic it depends on aren't covered by existing tests, and a test harness for a one-item dropdown addition felt disproportionate. Traced the full onboarding request chain manually to confirm nothing blocks a user with existing org memberships from creating a new one.

Verified `pnpm --filter @cio/dashboard build` and `pnpm format:check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Create organization” option to the sidebar menu.
  * Selecting the option opens the organization onboarding flow.
  * The option is shown only in supported deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a cloud-only Create Organization action to the shared LMS and organization-admin account menu. It routes users to onboarding, using a full redirect from organization-site hosts.
- Imports and displays a Create Organization menu item with a Lucide plus icon.
- Hides the action in single-organization self-hosted deployments.
- Selects SPA navigation on the app host and cross-origin navigation from tenant or custom-domain sites.

<h3>Confidence Score: 4/5</h3>

The cross-origin organization-creation path should be fixed before merging because authenticated tenant-site learners are redirected to the admin-host login page.

The new tenant-site branch crosses to app.classroomio.com while authentication cookies are host-only, so the target onboarding request is treated as unauthenticated.

**Files Needing Attention:** apps/dashboard/src/lib/features/ui/sidebar/footer/menu.svelte

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/ui/sidebar/footer/menu.svelte | Adds the intended menu entry, but tenant/custom-domain users lose their host-scoped session when redirected to the admin host. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): let students reach org c..."](https://github.com/classroomio/classroomio/commit/9337beb33870378930f301b1cdab41357fdc44d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57723605)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Administration dashboard](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/administration-dashboard.md)

<!-- /greptile_comment -->