### PR TITLE
fix(analytics): synchronize dashboard cache invalidation

### DIFF
--- a/apps/api/src/__tests__/analytics-rollup-cache-invalidation.test.ts
+++ b/apps/api/src/__tests__/analytics-rollup-cache-invalidation.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@cio/db/queries/analytics', () => ({
+  selectCountryDailyAggregates: vi.fn(),
+  selectCourseDailyAggregates: vi.fn(),
+  selectOrgDailyAggregates: vi.fn(),
+  upsertCountryDailyRows: vi.fn(),
+  upsertCourseDailyRows: vi.fn(),
+  upsertOrgDailyRows: vi.fn()
+}));
+
+vi.mock('@cio/core/utils/redis/org-stats-cache', () => ({
+  invalidateOrgStatsForIds: vi.fn()
+}));
+
+import {
+  selectCountryDailyAggregates,
+  selectCourseDailyAggregates,
+  selectOrgDailyAggregates,
+  upsertCountryDailyRows,
+  upsertCourseDailyRows,
+  upsertOrgDailyRows
+} from '@cio/db/queries/analytics';
+import { invalidateOrgStatsForIds } from '@cio/core/utils/redis/org-stats-cache';
+import { runAnalyticsRollupDaily } from '@cio/analytics';
+
+describe('analytics rollup cache invalidation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(selectOrgDailyAggregates).mockResolvedValue([
+      {
+        orgId: 'org-1',
+        date: '2026-08-26',
+        landingViews: 2,
+        uniqueVisitors: 2,
+        coursePageViews: 1,
+        enrollments: 1,
+        completions: 0
+      }
+    ]);
+    vi.mocked(selectCourseDailyAggregates).mockResolvedValue([
+      {
+        courseId: 'course-1',
+        orgId: 'org-1',
+        date: '2026-08-26',
+        views: 1,
+        uniqueVisitors: 1,
+        enrollments: 1,
+        completions: 0
+      }
+    ]);
+    vi.mocked(selectCountryDailyAggregates).mockResolvedValue([
+      {
+        orgId: 'org-2',
+        date: '2026-08-26',
+        country: 'NG',
+        views: 1,
+        enrollments: 0
+      }
+    ]);
+    vi.mocked(upsertOrgDailyRows).mockResolvedValue(1);
+    vi.mocked(upsertCourseDailyRows).mockResolvedValue(1);
+    vi.mocked(upsertCountryDailyRows).mockResolvedValue(1);
+  });
+
+  it('invalidates each affected organization after writing rollups', async () => {
+    await runAnalyticsRollupDaily({ daysAgo: 1 });
+
+    expect(invalidateOrgStatsForIds).toHaveBeenCalledWith(['org-1', 'org-2']);
+  });
+});

--- a/apps/api/src/__tests__/dash-analytics-cache.test.ts
+++ b/apps/api/src/__tests__/dash-analytics-cache.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redisMocks = vi.hoisted(() => ({
+  mGet: vi.fn(),
+  setEx: vi.fn()
+}));
+
+vi.mock('@cio/core/config/env', () => ({
+  env: { REDIS_URL: 'redis://localhost:6379' }
+}));
+
+vi.mock('@cio/core/utils/redis/redis', () => ({
+  redis: redisMocks,
+  logRedisUnavailableOnce: vi.fn()
+}));
+
+vi.mock('@cio/db/queries/analytics', () => ({
+  selectCountryBreakdown: vi.fn(),
+  selectCourseDailyRange: vi.fn(),
+  selectOrgDailyRange: vi.fn(),
+  selectPopularCourseTypes: vi.fn()
+}));
+
+import { selectOrgDailyRange } from '@cio/db/queries/analytics';
+import { getLandingStats } from '@api/services/analytics/reads';
+
+const cachedLandingStats = {
+  totals: {
+    landingViews: 5,
+    coursePageViews: 4,
+    uniqueVisitors: 3,
+    enrollments: 2,
+    completions: 1
+  },
+  sparkline: [{ date: '2026-08-27', views: 9, enrollments: 2 }]
+};
+
+describe('dashboard analytics cache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisMocks.mGet.mockResolvedValue([null, null]);
+    vi.mocked(selectOrgDailyRange).mockResolvedValue([
+      {
+        date: '2026-08-27',
+        landingViews: 5,
+        coursePageViews: 4,
+        uniqueVisitors: 3,
+        enrollments: 2,
+        completions: 1
+      }
+    ]);
+  });
+
+  it('writes cache entries with the current organization cache version', async () => {
+    redisMocks.mGet.mockResolvedValue(['4', null]);
+
+    const result = await getLandingStats('org-1', 30);
+
+    expect(result).toEqual(cachedLandingStats);
+    expect(redisMocks.setEx).toHaveBeenCalledWith(
+      'dash:analytics:landing:org-1:30',
+      600,
+      JSON.stringify({ version: '4', data: cachedLandingStats })
+    );
+  });
+
+  it('returns cached analytics when the organization cache version matches', async () => {
+    redisMocks.mGet.mockResolvedValue(['4', JSON.stringify({ version: '4', data: cachedLandingStats })]);
+
+    const result = await getLandingStats('org-1', 30);
+
+    expect(result).toEqual(cachedLandingStats);
+    expect(selectOrgDailyRange).not.toHaveBeenCalled();
+    expect(redisMocks.setEx).not.toHaveBeenCalled();
+  });
+
+  it('recomputes analytics when an organization mutation changed the cache version', async () => {
+    redisMocks.mGet.mockResolvedValue(['5', JSON.stringify({ version: '4', data: cachedLandingStats })]);
+
+    await getLandingStats('org-1', 30);
+
+    expect(selectOrgDailyRange).toHaveBeenCalledTimes(1);
+    expect(redisMocks.setEx).toHaveBeenCalledWith(
+      'dash:analytics:landing:org-1:30',
+      600,
+      JSON.stringify({ version: '5', data: cachedLandingStats })
+    );
+  });
+
+  it('bypasses matching cached data when refresh requests a cache bust', async () => {
+    redisMocks.mGet.mockResolvedValue(['4', JSON.stringify({ version: '4', data: cachedLandingStats })]);
+
+    await getLandingStats('org-1', 30, true);
+
+    expect(selectOrgDailyRange).toHaveBeenCalledTimes(1);
+    expect(redisMocks.setEx).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/__tests__/dash-org-stats-cache.test.ts
+++ b/apps/api/src/__tests__/dash-org-stats-cache.test.ts
@@ -32,10 +32,12 @@ vi.mock('@cio/db/queries', () => ({
 import {
   getCourseStats,
   getDashOrgStats,
+  getOrgStudentLoginsByDayOfWeek,
   getRecentCertifications,
   getTotalCertificatesIssued
 } from '@cio/db/queries/dash';
-import { getOrganisationAnalytics } from '@api/services/dash';
+import { getOrganisationAnalytics, getStudentLoginActivity } from '@api/services/dash';
+import { invalidateOrgStats } from '@cio/core/utils/redis/org-stats-cache';
 
 const sampleAnalytics = {
   totalCertificates: 2,
@@ -129,5 +131,31 @@ describe('getOrganisationAnalytics cache', () => {
 
     expect(result.numberOfCourses).toBe(8);
     expect(getDashOrgStats).toHaveBeenCalledTimes(1);
+  });
+
+  it('increments the version shared by dashboard and engagement analytics caches', async () => {
+    await invalidateOrgStats('org-1');
+
+    expect(redisMocks.incr).toHaveBeenCalledWith('dash:stats:ver:org-1');
+    expect(redisMocks.del).toHaveBeenCalledWith('dash:stats:v1:org-1');
+  });
+});
+
+describe('getStudentLoginActivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reads fresh login activity on every request', async () => {
+    vi.mocked(getOrgStudentLoginsByDayOfWeek)
+      .mockResolvedValueOnce([{ dayOfWeek: 1, count: 2 }])
+      .mockResolvedValueOnce([{ dayOfWeek: 1, count: 3 }]);
+
+    const firstResult = await getStudentLoginActivity('org-1', 30);
+    const secondResult = await getStudentLoginActivity('org-1', 30);
+
+    expect(firstResult[1]).toEqual({ day: 'Mon', count: 2 });
+    expect(secondResult[1]).toEqual({ day: 'Mon', count: 3 });
+    expect(getOrgStudentLoginsByDayOfWeek).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/api/src/routes/dash/stats.ts
+++ b/apps/api/src/routes/dash/stats.ts
@@ -73,8 +73,7 @@ export const dashAnalyticsRouter = new Hono()
   })
   .get('/landing-stats', authMiddleware, orgMemberMiddleware, zValidator('query', ZDashAnalyticsRange), async (c) => {
     try {
-      const { orgId, days } = c.req.valid('query');
-      const bust = c.req.query('bust') === '1';
+      const { orgId, days, bust } = c.req.valid('query');
       const result = await getLandingStats(orgId, days, bust);
 
       return c.json({ success: true, data: result }, 200);
@@ -89,8 +88,7 @@ export const dashAnalyticsRouter = new Hono()
     zValidator('query', ZDashAnalyticsRange),
     async (c) => {
       try {
-        const { orgId, days } = c.req.valid('query');
-        const bust = c.req.query('bust') === '1';
+        const { orgId, days, bust } = c.req.valid('query');
         const result = await getCountryBreakdown(orgId, days, bust);
 
         return c.json({ success: true, data: result }, 200);
@@ -101,8 +99,7 @@ export const dashAnalyticsRouter = new Hono()
   )
   .get('/course-funnel', authMiddleware, orgMemberMiddleware, zValidator('query', ZDashCourseFunnel), async (c) => {
     try {
-      const { orgId, days, courseId } = c.req.valid('query');
-      const bust = c.req.query('bust') === '1';
+      const { orgId, days, courseId, bust } = c.req.valid('query');
       const result = await getCourseFunnel(orgId, days, courseId, bust);
 
       return c.json({ success: true, data: result }, 200);
@@ -112,8 +109,7 @@ export const dashAnalyticsRouter = new Hono()
   })
   .get('/popular-types', authMiddleware, orgMemberMiddleware, zValidator('query', ZDashAnalyticsRange), async (c) => {
     try {
-      const { orgId, days } = c.req.valid('query');
-      const bust = c.req.query('bust') === '1';
+      const { orgId, days, bust } = c.req.valid('query');
       const result = await getPopularTypes(orgId, days, bust);
 
       return c.json({ success: true, data: result }, 200);

--- a/apps/api/src/services/analytics/reads.ts
+++ b/apps/api/src/services/analytics/reads.ts
@@ -5,8 +5,7 @@ import {
   selectPopularCourseTypes
 } from '@cio/db/queries/analytics';
 import { DASH_ANALYTICS_TTL_SECONDS, dashAnalyticsKey } from '@api/utils/redis/key-generators';
-import { env } from '@cio/core/config/env';
-import { logRedisUnavailableOnce, redis } from '@cio/core/utils/redis/redis';
+import { readVersionedOrgCache, writeVersionedOrgCache } from '@cio/core/utils/redis/org-stats-cache';
 
 export type LandingStats = {
   totals: {
@@ -48,33 +47,21 @@ function computeRange(days: number): { fromDate: string; toDate: string } {
   return { fromDate: toDateString(from), toDate: toDateString(today) };
 }
 
-async function readCache<T>(key: string): Promise<T | null> {
-  if (!env.REDIS_URL) return null;
-  try {
-    const raw = await redis.get(key);
-    if (!raw) return null;
-    return JSON.parse(raw) as T;
-  } catch (error) {
-    logRedisUnavailableOnce('Redis get failed for analytics cache, using database', error);
-    return null;
-  }
+async function readCache<T>(orgId: string, key: string, bustCache: boolean) {
+  const cachedResult = await readVersionedOrgCache<T>(orgId, key);
+  const cached = bustCache ? null : cachedResult.data;
+
+  return { version: cachedResult.version, cached };
 }
 
-async function writeCache(key: string, value: unknown): Promise<void> {
-  if (!env.REDIS_URL) return;
-  try {
-    await redis.setEx(key, DASH_ANALYTICS_TTL_SECONDS, JSON.stringify(value));
-  } catch (error) {
-    logRedisUnavailableOnce('Redis set failed for analytics cache, continuing', error);
-  }
+function writeCache(key: string, version: string, value: unknown): Promise<void> {
+  return writeVersionedOrgCache(key, DASH_ANALYTICS_TTL_SECONDS, version, value);
 }
 
 export async function getLandingStats(orgId: string, days: number, bustCache = false): Promise<LandingStats> {
   const key = dashAnalyticsKey('landing', orgId, days);
-  if (!bustCache) {
-    const cached = await readCache<LandingStats>(key);
-    if (cached) return cached;
-  }
+  const { version, cached } = await readCache<LandingStats>(orgId, key, bustCache);
+  if (cached) return cached;
 
   const { fromDate, toDate } = computeRange(days);
   const rows = await selectOrgDailyRange(orgId, fromDate, toDate);
@@ -97,16 +84,14 @@ export async function getLandingStats(orgId: string, days: number, bustCache = f
   }));
 
   const result: LandingStats = { totals, sparkline };
-  await writeCache(key, result);
+  await writeCache(key, version, result);
   return result;
 }
 
 export async function getCountryBreakdown(orgId: string, days: number, bustCache = false): Promise<CountryBreakdown> {
   const key = dashAnalyticsKey('country', orgId, days);
-  if (!bustCache) {
-    const cached = await readCache<CountryBreakdown>(key);
-    if (cached) return cached;
-  }
+  const { version, cached } = await readCache<CountryBreakdown>(orgId, key, bustCache);
+  if (cached) return cached;
 
   const { fromDate, toDate } = computeRange(days);
   const rows = await selectCountryBreakdown(orgId, fromDate, toDate);
@@ -115,7 +100,7 @@ export async function getCountryBreakdown(orgId: string, days: number, bustCache
     views: row.views,
     enrollments: row.enrollments
   }));
-  await writeCache(key, result);
+  await writeCache(key, version, result);
   return result;
 }
 
@@ -126,10 +111,8 @@ export async function getCourseFunnel(
   bustCache = false
 ): Promise<CourseFunnel> {
   const key = dashAnalyticsKey('funnel', orgId, days, courseId);
-  if (!bustCache) {
-    const cached = await readCache<CourseFunnel>(key);
-    if (cached) return cached;
-  }
+  const { version, cached } = await readCache<CourseFunnel>(orgId, key, bustCache);
+  if (cached) return cached;
 
   const { fromDate, toDate } = computeRange(days);
 
@@ -167,16 +150,14 @@ export async function getCourseFunnel(
     });
 
   const result: CourseFunnel = { steps };
-  await writeCache(key, result);
+  await writeCache(key, version, result);
   return result;
 }
 
 export async function getPopularTypes(orgId: string, days: number, bustCache = false): Promise<PopularTypes> {
   const key = dashAnalyticsKey('popular-types', orgId, days);
-  if (!bustCache) {
-    const cached = await readCache<PopularTypes>(key);
-    if (cached) return cached;
-  }
+  const { version, cached } = await readCache<PopularTypes>(orgId, key, bustCache);
+  if (cached) return cached;
 
   const { fromDate, toDate } = computeRange(days);
   const rows = await selectPopularCourseTypes(orgId, fromDate, toDate);
@@ -189,6 +170,6 @@ export async function getPopularTypes(orgId: string, days: number, bustCache = f
       completions: row.completions,
       courseCount: row.courseCount
     }));
-  await writeCache(key, result);
+  await writeCache(key, version, result);
   return result;
 }

--- a/apps/api/src/services/dash.ts
+++ b/apps/api/src/services/dash.ts
@@ -1,5 +1,4 @@
 import { AppError, ErrorCodes } from '@api/utils/errors';
-import { env } from '@cio/core/config/env';
 import {
   getCourseStats,
   getDashOrgStats,
@@ -8,8 +7,6 @@ import {
   getRecentCertifications,
   getTotalCertificatesIssued
 } from '@cio/db/queries/dash';
-import { dashLoginActivityKey } from '@api/utils/redis/key-generators';
-import { logRedisUnavailableOnce, redis } from '@cio/core/utils/redis/redis';
 import {
   invalidateOrgStats,
   readOrgStatsVersionAndCache,
@@ -97,85 +94,17 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
 
 type StudentLoginActivityRow = { day: string; count: number };
 
-/** Redis TTL for login-activity chart payload (1 day). */
-const LOGIN_ACTIVITY_CACHE_TTL_SECONDS = 86_400;
-
-function parseLoginActivityCache(raw: string): StudentLoginActivityRow[] | null {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw) as unknown;
-  } catch {
-    return null;
-  }
-
-  if (!Array.isArray(parsed) || parsed.length !== 7) {
-    return null;
-  }
-
-  const out: StudentLoginActivityRow[] = [];
-  for (const item of parsed) {
-    if (
-      typeof item !== 'object' ||
-      item === null ||
-      !('day' in item) ||
-      !('count' in item) ||
-      typeof (item as { day: unknown }).day !== 'string' ||
-      typeof (item as { count: unknown }).count !== 'number' ||
-      !Number.isInteger((item as { count: number }).count) ||
-      (item as { count: number }).count < 0
-    ) {
-      return null;
-    }
-
-    out.push({ day: (item as { day: string }).day, count: (item as { count: number }).count });
-  }
-
-  for (const label of DAY_LABELS) {
-    if (!out.some((r) => r.day === label)) {
-      return null;
-    }
-  }
-
-  return out;
-}
-
-/** Day-of-week login chart; results cached in Redis (24h TTL) when `REDIS_URL` is set. */
+/** Day-of-week login chart. This stays uncached because login writes happen in the auth database hook. */
 export async function getStudentLoginActivity(orgId: string, days: number): Promise<StudentLoginActivityRow[]> {
-  const cacheKey = dashLoginActivityKey(orgId, days);
-
-  if (env.REDIS_URL) {
-    try {
-      const cached = await redis.get(cacheKey);
-      if (cached) {
-        const rows = parseLoginActivityCache(cached);
-        if (rows) {
-          return rows;
-        }
-      }
-    } catch (error) {
-      logRedisUnavailableOnce('Redis get failed for login activity cache, using database', error);
-    }
-  }
-
   try {
     const rows = await getOrgStudentLoginsByDayOfWeek(orgId, days);
 
     const countByDow = new Map(rows.map((r) => [r.dayOfWeek, r.count]));
 
-    const result = DAY_LABELS.map((label, index) => ({
+    return DAY_LABELS.map((label, index) => ({
       day: label,
       count: countByDow.get(index) ?? 0
     }));
-
-    if (env.REDIS_URL) {
-      try {
-        await redis.setEx(cacheKey, LOGIN_ACTIVITY_CACHE_TTL_SECONDS, JSON.stringify(result));
-      } catch (error) {
-        logRedisUnavailableOnce('Redis set failed for login activity cache, continuing', error);
-      }
-    }
-
-    return result;
   } catch (error) {
     console.error('getStudentLoginActivity error:', error);
     throw new AppError('Failed to load login activity', ErrorCodes.ORG_ANALYTICS_FETCH_FAILED, 500);

--- a/apps/api/src/utils/redis/key-generators.ts
+++ b/apps/api/src/utils/redis/key-generators.ts
@@ -132,14 +132,6 @@ export const agentChatKeyGenerator = (c: Context): string => {
 // ─── Dashboard / analytics cache ─────────────────────────────────────────────
 
 /**
- * Redis key for `getStudentLoginActivity` (day-of-week chart per org and window).
- * Value: JSON array `{ day, count }[]`. TTL: 24h.
- */
-export function dashLoginActivityKey(orgId: string, days: number): string {
-  return `dash:login-activity:${orgId}:${days}`;
-}
-
-/**
  * Rate limit key for agent upload endpoint (per-user).
  */
 export const agentUploadKeyGenerator = (c: Context): string => {

--- a/apps/dashboard/src/lib/features/analytics/api/analytics.svelte.ts
+++ b/apps/dashboard/src/lib/features/analytics/api/analytics.svelte.ts
@@ -23,8 +23,6 @@ class AnalyticsApi extends BaseApi {
   loadingPopularTypes = $state(false);
 
   range = $state<7 | 30 | 90>(30);
-  lastFetchedOrgId = $state<string | null>(null);
-  lastFetchedRange = $state<7 | 30 | 90 | null>(null);
 
   get loading() {
     return this.loadingLanding || this.loadingCountry || this.loadingFunnel || this.loadingPopularTypes;
@@ -86,24 +84,12 @@ class AnalyticsApi extends BaseApi {
   fetchAll(orgId: string, bust = false) {
     if (!orgId) return Promise.resolve();
 
-    this.lastFetchedOrgId = orgId;
-    this.lastFetchedRange = this.range;
     return Promise.all([
       this.fetchLanding(orgId, bust),
       this.fetchCountry(orgId, bust),
       this.fetchFunnel(orgId, bust),
       this.fetchPopularTypes(orgId, bust)
     ]);
-  }
-
-  /**
-   * Fetch only if data for this (orgId, range) wasn't fetched in this session.
-   * Singleton state means navigating away and back reuses prior data.
-   */
-  ensureFetched(orgId: string) {
-    if (this.lastFetchedOrgId === orgId && this.lastFetchedRange === this.range) return;
-
-    this.fetchAll(orgId);
   }
 
   setRange(days: 7 | 30 | 90, orgId: string) {

--- a/apps/dashboard/src/lib/features/compliance/api/compliance.svelte.ts
+++ b/apps/dashboard/src/lib/features/compliance/api/compliance.svelte.ts
@@ -5,13 +5,11 @@ import type { ComplianceOverviewData, ComplianceOverviewRequest } from '../utils
 class ComplianceApi extends BaseApi {
   overview = $state<ComplianceOverviewData | null>(null);
   loading = $state(false);
-  lastFetchedOrgId = $state<string | null>(null);
 
   async fetchOverview(orgId: string) {
     if (!orgId) return;
 
     this.loading = true;
-    this.lastFetchedOrgId = orgId;
     await this.execute<ComplianceOverviewRequest>({
       requestFn: () => classroomio.dash['compliance-overview'].$get({ query: { orgId } }),
       logContext: 'fetching org compliance overview',
@@ -20,12 +18,6 @@ class ComplianceApi extends BaseApi {
       }
     });
     this.loading = false;
-  }
-
-  ensureFetched(orgId: string) {
-    if (this.lastFetchedOrgId === orgId) return;
-
-    this.fetchOverview(orgId);
   }
 }
 

--- a/apps/dashboard/src/routes/(app)/org/[slug]/analytics/+page.svelte
+++ b/apps/dashboard/src/routes/(app)/org/[slug]/analytics/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { t } from '$lib/utils/functions/translations';
   import { currentOrg } from '$lib/utils/store/org';
+  import { untrack } from 'svelte';
   import * as Page from '@cio/ui/base/page';
   import * as Tabs from '@cio/ui/custom/underline-tabs';
   import {
@@ -15,7 +16,8 @@
   } from '$features/analytics';
 
   $effect(() => {
-    analyticsApi.ensureFetched($currentOrg.id);
+    const orgId = $currentOrg.id;
+    void untrack(() => analyticsApi.fetchAll(orgId));
   });
 
   function handleRangeChange(days: 7 | 30 | 90) {

--- a/apps/dashboard/src/routes/(app)/org/[slug]/compliance/+page.svelte
+++ b/apps/dashboard/src/routes/(app)/org/[slug]/compliance/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { t } from '$lib/utils/functions/translations';
   import { currentOrg } from '$lib/utils/store/org';
+  import { untrack } from 'svelte';
   import * as Page from '@cio/ui/base/page';
   import * as Tabs from '@cio/ui/custom/underline-tabs';
   import { Button } from '@cio/ui/base/button';
@@ -10,7 +11,8 @@
   import type { ComplianceLearnerRow } from '$features/compliance/utils/types';
 
   $effect(() => {
-    complianceApi.ensureFetched($currentOrg.id);
+    const orgId = $currentOrg.id;
+    void untrack(() => complianceApi.fetchOverview(orgId));
   });
 
   function handleRefresh() {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -23,6 +23,7 @@
     }
   },
   "dependencies": {
+    "@cio/core": "workspace:*",
     "@cio/db": "workspace:*",
     "@cio/tsconfig": "workspace:*",
     "@cio/utils": "workspace:*"

--- a/packages/analytics/src/jobs/rollup-daily.ts
+++ b/packages/analytics/src/jobs/rollup-daily.ts
@@ -6,6 +6,7 @@ import {
   upsertCourseDailyRows,
   upsertOrgDailyRows
 } from '@cio/db/queries/analytics';
+import { invalidateOrgStatsForIds } from '@cio/core/utils/redis/org-stats-cache';
 
 type RollupResult = {
   windowStart: string;
@@ -83,6 +84,14 @@ export async function runAnalyticsRollupDaily(opts: { daysAgo?: number } = {}): 
     upsertCourseDailyRows(courseRows),
     upsertCountryDailyRows(countryRows)
   ]);
+  const updatedOrgIds = [
+    ...new Set([
+      ...orgRows.map((row) => row.orgId),
+      ...courseRows.map((row) => row.orgId),
+      ...countryRows.map((row) => row.orgId)
+    ])
+  ];
+  await invalidateOrgStatsForIds(updatedOrgIds);
 
   return {
     windowStart: startIso,

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -16,6 +16,8 @@
     "typeRoots": ["../../node_modules/@types", "./node_modules/@types"],
     "types": ["node"],
     "paths": {
+      "@cio/core": ["./node_modules/@cio/core/dist/index.d.ts"],
+      "@cio/core/*": ["./node_modules/@cio/core/dist/*"],
       "@cio/db": ["./node_modules/@cio/db/dist/index.d.ts"],
       "@cio/db/*": ["./node_modules/@cio/db/dist/*"],
       "@cio/utils": ["./node_modules/@cio/utils/dist/index.d.ts"],
@@ -24,7 +26,7 @@
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tsconfig.tsbuildinfo"],
-  "references": [{ "path": "../db" }, { "path": "../utils" }],
+  "references": [{ "path": "../core" }, { "path": "../db" }, { "path": "../utils" }],
   "tsc-alias": {
     "resolveFullPaths": true,
     "verbose": false

--- a/packages/core/src/utils/redis/org-stats-cache.ts
+++ b/packages/core/src/utils/redis/org-stats-cache.ts
@@ -13,12 +13,12 @@ export function orgStatsVersionKey(orgId: string): string {
   return `dash:stats:ver:${orgId}`;
 }
 
-type CachedOrgStatsPayload<T> = {
+type VersionedOrgCachePayload<T> = {
   version: string;
   data: T;
 };
 
-function parseCachedOrgStatsPayload<T>(raw: string): CachedOrgStatsPayload<T> | null {
+function parseVersionedOrgCachePayload<T>(raw: string): VersionedOrgCachePayload<T> | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw) as unknown;
@@ -38,17 +38,24 @@ function parseCachedOrgStatsPayload<T>(raw: string): CachedOrgStatsPayload<T> | 
     return null;
   }
 
-  return parsed as CachedOrgStatsPayload<T>;
+  return parsed as VersionedOrgCachePayload<T>;
 }
 
-export async function readOrgStatsVersionAndCache<T>(orgId: string): Promise<{ version: string; data: T | null }> {
+/**
+ * Reads any organization analytics payload against the same generation used
+ * by the dashboard stats cache. A mutation can therefore invalidate every
+ * analytics surface atomically by incrementing one version key.
+ */
+export async function readVersionedOrgCache<T>(
+  orgId: string,
+  payloadKey: string
+): Promise<{ version: string; data: T | null }> {
   if (!env.REDIS_URL) {
     return { version: '0', data: null };
   }
 
   try {
     const versionKey = orgStatsVersionKey(orgId);
-    const payloadKey = orgStatsKey(orgId);
     const [versionRaw, payloadRaw] = await redis.mGet([versionKey, payloadKey]);
     const version = versionRaw ?? '0';
 
@@ -56,31 +63,45 @@ export async function readOrgStatsVersionAndCache<T>(orgId: string): Promise<{ v
       return { version, data: null };
     }
 
-    const payload = parseCachedOrgStatsPayload<T>(payloadRaw);
+    const payload = parseVersionedOrgCachePayload<T>(payloadRaw);
     if (!payload || payload.version !== version) {
       return { version, data: null };
     }
 
     return { version, data: payload.data };
   } catch (error) {
-    logRedisUnavailableOnce('Redis get failed for org stats cache, using database', error);
+    logRedisUnavailableOnce('Redis get failed for versioned org cache, using database', error);
     return { version: '0', data: null };
   }
 }
 
-export async function writeOrgStatsCache<T>(orgId: string, version: string, value: T): Promise<void> {
+export async function writeVersionedOrgCache<T>(
+  payloadKey: string,
+  ttlSeconds: number,
+  version: string,
+  value: T
+): Promise<void> {
   if (!env.REDIS_URL) {
     return;
   }
 
   try {
-    const payload: CachedOrgStatsPayload<T> = { version, data: value };
-    await redis.setEx(orgStatsKey(orgId), ORG_STATS_CACHE_TTL_SECONDS, JSON.stringify(payload));
+    const payload: VersionedOrgCachePayload<T> = { version, data: value };
+    await redis.setEx(payloadKey, ttlSeconds, JSON.stringify(payload));
   } catch (error) {
-    logRedisUnavailableOnce('Redis set failed for org stats cache, continuing', error);
+    logRedisUnavailableOnce('Redis set failed for versioned org cache, continuing', error);
   }
 }
 
+export function readOrgStatsVersionAndCache<T>(orgId: string): Promise<{ version: string; data: T | null }> {
+  return readVersionedOrgCache<T>(orgId, orgStatsKey(orgId));
+}
+
+export function writeOrgStatsCache<T>(orgId: string, version: string, value: T): Promise<void> {
+  return writeVersionedOrgCache(orgStatsKey(orgId), ORG_STATS_CACHE_TTL_SECONDS, version, value);
+}
+
+/** Invalidates the generation shared by org dashboard and analytics payloads. */
 export async function invalidateOrgStats(orgId: string | null | undefined): Promise<void> {
   if (!orgId || !env.REDIS_URL) {
     return;

--- a/packages/utils/src/validation/dash/analytics.ts
+++ b/packages/utils/src/validation/dash/analytics.ts
@@ -1,14 +1,21 @@
 import * as z from 'zod';
 
+const ZBustCache = z
+  .enum(['0', '1'])
+  .optional()
+  .transform((value) => value === '1');
+
 export const ZDashAnalyticsRange = z.object({
   orgId: z.string().uuid(),
-  days: z.coerce.number().int().min(1).max(365).default(30)
+  days: z.coerce.number().int().min(1).max(365).default(30),
+  bust: ZBustCache
 });
 
 export const ZDashCourseFunnel = z.object({
   orgId: z.string().uuid(),
   days: z.coerce.number().int().min(1).max(365).default(30),
-  courseId: z.string().uuid().optional()
+  courseId: z.string().uuid().optional(),
+  bust: ZBustCache
 });
 
 export const ZDashComplianceOverview = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -883,6 +883,9 @@ importers:
 
   packages/analytics:
     dependencies:
+      '@cio/core':
+        specifier: workspace:*
+        version: link:../core
       '@cio/db':
         specifier: workspace:*
         version: link:../db


### PR DESCRIPTION
## Summary

- Apply version-stamped organization cache invalidation to all dashboard analytics payloads.
- Invalidate affected analytics cache generations after daily rollups and reuse the existing mutation invalidation coverage.
- Refetch organization analytics and compliance data whenever pages are entered.
- Remove the separate 24-hour login activity cache and validate analytics cache-bust query parameters.

## Verification

- `pnpm --filter @cio/api exec vitest run src/__tests__/analytics-rollup-cache-invalidation.test.ts src/__tests__/dash-analytics-cache.test.ts src/__tests__/dash-org-stats-cache.test.ts`
- `pnpm --filter @cio/api build`
- `pnpm --filter @cio/dashboard^... build`
- `pnpm --filter @cio/dashboard build`
- `pnpm format:check`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves dashboard analytics payloads onto a shared organization cache generation, invalidates that generation after daily rollups, removes the separate login-activity cache, and refetches analytics and compliance data on page entry.
- Adds reusable versioned organization-cache reads and writes for analytics payloads.
- Invalidates affected organizations after daily organization, course, and country rollups.
- Validates cache-bust query parameters through the shared Zod schemas.
- Refetches analytics and compliance pages on entry, but overlapping responses can overwrite current singleton state.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until analytics and compliance responses are prevented from overwriting state after the user has moved to another organization or range.

The cache-generation changes correctly reject stale payload versions, but the new unconditional page-entry fetches use persistent singleton state without cancellation or request-context checks, allowing out-of-order responses to display data for the wrong organization or range.

**Files Needing Attention:** apps/dashboard/src/routes/(app)/org/[slug]/analytics/+page.svelte, apps/dashboard/src/routes/(app)/org/[slug]/compliance/+page.svelte, and their feature API singletons

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/utils/redis/org-stats-cache.ts | Generalizes the organization dashboard cache into reusable generation-stamped payload helpers and preserves stale-payload rejection. |
| packages/analytics/src/jobs/rollup-daily.ts | Collects every organization represented by written rollup rows and invalidates their shared cache generations after successful upserts. |
| apps/api/src/services/analytics/reads.ts | Migrates all four engagement analytics reads to the shared versioned cache while retaining cache-bust behavior. |
| packages/utils/src/validation/dash/analytics.ts | Validates optional cache-bust values and transforms the accepted query representation into a boolean. |
| apps/dashboard/src/routes/(app)/org/[slug]/analytics/+page.svelte | Refetches on page entry and organization changes, but does not prevent older overlapping responses from overwriting current singleton state. |
| apps/dashboard/src/routes/(app)/org/[slug]/compliance/+page.svelte | Applies the same unconditional page-entry refetch pattern and shares the resulting response-ordering defect. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant U as Dashboard user
  participant P as Analytics page
  participant A as Analytics API singleton
  participant B as Backend
  participant R as Redis
  participant D as Daily rollup
  U->>P: Enter analytics page
  P->>A: fetchAll(orgId)
  A->>B: Request analytics payloads
  B->>R: Read org generation and payload
  alt Matching generation
    R-->>B: Cached payload
  else Miss or cache bust
    B->>B: Read daily summaries
    B->>R: Write versioned payload
  end
  B-->>A: Analytics response
  D->>D: Upsert daily summaries
  D->>R: Increment affected org generations
```

<sub>Reviews (1): Last reviewed commit: ["fix(analytics): synchronize dashboard ca..."](https://github.com/classroomio/classroomio/commit/9ab18e0e07497d20473fb25b02172aa7ab0e53e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57872090)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Analytics and certificates](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/analytics-and-certificates.md)
- Knowledge Base — [Administration dashboard](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/administration-dashboard.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version-aware caching for dashboard analytics, including support for explicitly refreshing cached results.
  * Analytics rollups now refresh affected organization statistics automatically.
  * Dashboard login activity now reflects the latest available data on each request.

* **Bug Fixes**
  * Improved cache invalidation after organization data changes.
  * Ensured analytics and compliance pages fetch current data when switching organizations.

* **Tests**
  * Added coverage for cache reads, refresh behavior, version changes, invalidation, and analytics rollups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->