### PR TITLE
feat(dashboard): upgrade UserJot widget to v3

### DIFF
--- a/apps/dashboard/src/lib/utils/csp-domains.js
+++ b/apps/dashboard/src/lib/utils/csp-domains.js
@@ -33,6 +33,7 @@ const saasDefaults = {
     'wss://*.classroomio.com',
     'https://assets.cdn.clsrio.com',
     'https://cdn.plyr.io',
+    'https://widget.userjot.com',
     'https://*.posthog.com',
     'https://umami.hz.oncws.com',
     'https://*.r2.cloudflarestorage.com',
@@ -49,7 +50,8 @@ const saasDefaults = {
     'https://www.google.com',
     'https://google.com',
     'https://drive.google.com',
-    'https://docs.google.com'
+    'https://docs.google.com',
+    'https://widget.userjot.com'
   ],
   fontSrc: ['https://fonts.gstatic.com', 'https://cdn.plyr.io'],
   mediaSrc: ['https:']

--- a/apps/dashboard/src/lib/utils/services/userjot/index.ts
+++ b/apps/dashboard/src/lib/utils/services/userjot/index.ts
@@ -3,7 +3,7 @@ import { PUBLIC_IS_SELFHOSTED } from '$env/static/public';
 import { get } from 'svelte/store';
 import { globalStore } from '$lib/utils/store/app';
 
-const USERJOT_APP_ID = 'cm4a6vcmp00jpmdb5n66rmkzz';
+const USERJOT_PROJECT_ID = 'cm4a6vcmp00jpmdb5n66rmkzz';
 
 let isInitialized = false;
 
@@ -22,16 +22,18 @@ function ensureSdkLoaded(): void {
   window.uj =
     window.uj ||
     (new Proxy({} as Window['uj'], {
-      get:
-        (_, prop) =>
-        (...args: unknown[]) =>
-          window.$ujq.push([prop, ...args])
+      get: (_, prop) =>
+        prop === 'then'
+          ? undefined
+          : (...args: unknown[]) => {
+              window.$ujq.push([prop, ...args]);
+            }
     }) as Window['uj']);
 
   const script = document.createElement('script');
   script.type = 'module';
   script.async = true;
-  script.src = 'https://cdn.userjot.com/sdk/v2/uj.js';
+  script.src = 'https://cdn.userjot.com/sdk/v3/uj.js';
   // Browsers hide the nonce attribute in the DOM; read via the IDL property.
   const nonceSource = document.querySelector('script[nonce]') as HTMLScriptElement | null;
   const nonce = nonceSource?.nonce || nonceSource?.getAttribute('nonce');
@@ -45,10 +47,12 @@ export function initUserJot(): void {
 
   ensureSdkLoaded();
 
-  window.uj.init(USERJOT_APP_ID, {
-    trigger: 'custom',
-    position: 'right',
-    theme: 'auto'
+  window.uj.init(USERJOT_PROJECT_ID, {
+    widget: {
+      launcher: false,
+      position: 'right',
+      theme: 'auto'
+    }
   });
 
   isInitialized = true;
@@ -70,11 +74,13 @@ export function identifyUserJotUser({ id, email, fullname, avatarUrl }: UserJotI
   const lastName = rest.join(' ');
 
   window.uj.identify({
-    id,
-    email,
-    firstName: firstName || undefined,
-    lastName: lastName || undefined,
-    avatar: avatarUrl ?? undefined
+    user: {
+      id,
+      email,
+      firstName: firstName || undefined,
+      lastName: lastName || undefined,
+      avatar: avatarUrl ?? undefined
+    }
   });
 }
 
@@ -83,7 +89,7 @@ export function clearUserJotUser(): void {
 
   ensureSdkLoaded();
 
-  window.uj.identify(null);
+  window.uj.logout();
 }
 
 export type UserJotWidgetSection = 'feedback' | 'roadmap' | 'updates';
@@ -93,5 +99,5 @@ export function showUserJotWidget(section: UserJotWidgetSection): void {
 
   ensureSdkLoaded();
 
-  window.uj.showWidget({ section });
+  window.uj.open({ to: section });
 }

--- a/apps/dashboard/src/lib/utils/services/userjot/types.d.ts
+++ b/apps/dashboard/src/lib/utils/services/userjot/types.d.ts
@@ -3,17 +3,24 @@ declare global {
     $ujq: unknown[];
     uj: {
       init: (
-        appId: string,
+        projectId: string,
         options?: {
-          widget?: boolean;
-          position?: 'left' | 'right';
-          theme?: 'auto' | 'light' | 'dark';
+          widget?:
+            | boolean
+            | {
+                launcher?: boolean;
+                position?: 'left' | 'right';
+                theme?: 'auto' | 'light' | 'dark';
+                whispers?: boolean;
+              };
+          locale?: string;
         }
       ) => void;
-      identify: (
-        user: { id: string; email?: string; firstName?: string; lastName?: string; avatar?: string } | null
-      ) => void;
-      showWidget: (options: { section: 'feedback' | 'roadmap' | 'updates' }) => void;
+      identify: (payload: {
+        user: { id: string; email?: string; firstName?: string; lastName?: string; avatar?: string };
+      }) => void;
+      logout: () => void;
+      open: (options?: { to: 'home' | 'feedback' | 'roadmap' | 'updates' | 'messages' | 'notifications' }) => void;
       [method: string]: (...args: unknown[]) => void;
     };
   }


### PR DESCRIPTION
## What does this PR do?

Upgrades the existing UserJot dashboard integration from widget SDK v2 to v3.

- loads the v3 SDK with its promise-safe queued proxy
- uses the v3 nested widget configuration while retaining the custom ClassroomIO sidebar launcher
- migrates identification, logout, and section navigation to the v3 APIs
- allows the v3 widget service and iframe origins in the SaaS CSP

## Demo

No visual layout changes. The existing Feedback and Updates sidebar actions now open the v3 widget.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Sign in to the production SaaS dashboard and choose Feedback from the profile/sidebar menu; confirm the v3 feedback section opens.
- Choose Updates and confirm the v3 updates section opens.
- Sign out and confirm the UserJot session is cleared.
- Verify with Node 20: `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`.

## Checklist

### Required

- [x] Filled out the How to test section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran the dashboard and dependency production builds
- [ ] Checked for warnings, there are none (the build reports existing unrelated Svelte warnings)
- [x] Removed all console.logs
- [x] Branch is based on the latest `origin/main` at creation time
- [x] My changes do not cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the ClassroomIO Contributor License Agreement
- [x] No changes to `pnpm-lock.yaml`, `.github/workflows/**`, or publish config

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] ClassroomIO Docs do not require changes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Upgrades the dashboard’s UserJot integration from SDK v2 to v3.
- Adds the v3 widget origin to the SaaS connection and frame CSP directives.
- Updates SDK loading with a promise-safe queued proxy.
- Migrates initialization, identification, logout, and section navigation to the v3 API shapes.
- Updates the global TypeScript declarations for the v3 interface.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete actionable defects identified.

The changed CSP entries, queued SDK bootstrap, v3 lifecycle calls, and corresponding declarations remain internally consistent across the reviewed dashboard integration.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/utils/csp-domains.js | Allows the v3 UserJot widget origin for SaaS network connections and iframe embedding. |
| apps/dashboard/src/lib/utils/services/userjot/index.ts | Migrates the browser integration, lifecycle calls, and custom-launcher navigation to UserJot SDK v3. |
| apps/dashboard/src/lib/utils/services/userjot/types.d.ts | Aligns the global UserJot declarations with the v3 configuration and method surface. |

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): upgrade UserJot widget ..."](https://github.com/classroomio/classroomio/commit/8a8197f70eccee38bd6c8060791beb5069278b33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57880190)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the feedback widget integration to the latest UserJot experience.
  * Added support for opening additional widget sections, including messages and notifications.
  * Added widget configuration options for launcher visibility, theme, position, and whispers.
  * Added locale support.

* **Bug Fixes**
  * Enabled the dashboard’s security settings to load and display the updated feedback widget correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->