### PR TITLE
refactor(storybook): align theme class prefixes across stories

### DIFF
--- a/packages/storybook/README.md
+++ b/packages/storybook/README.md
@@ -283,37 +283,26 @@ Composite components:
 
 ### CSS Class Conventions
 
-#### UI Prefix
+#### UI Prefix & Scoping Rules
 
-Use the `ui:` prefix for utility classes to scope them properly:
+Storybook combines two CSS layers:
 
-```svelte
-<!-- ✅ Correct -->
-<div class="ui:flex ui:flex-col ui:gap-6">
-<Button class="ui:w-full">
-
-<!-- ❌ Incorrect -->
-<div class="flex flex-col gap-6">
-<Button class="w-full">
-```
-
-#### When to Use UI Prefix
-
-- **Always use** for utility classes (flex, grid, gap, padding, margin, etc.)
-- **Don't use** for component-specific classes or data attributes
-- **Don't use** for Tailwind classes that are part of component styling
+1. **Unprefixed Tailwind** (`packages/storybook/src/index.css`): All layout, sizing, grid, flex, and spacing utilities stay **unprefixed** (`flex`, `grid`, `gap-4`, `w-96`, `w-full`, `p-4`, `size-12`, etc.).
+2. **`@cio/ui` Precompiled Tokens** (`@cio/ui/output.css`): Theme color classes (`ui:text-muted-foreground`, `ui:text-primary`, `ui:border-border`, `ui:bg-muted`, `ui:ring-background`, etc.) use the **`ui:` prefix** everywhere.
 
 #### Examples
 
 ```svelte
-<!-- Utility classes - use ui: prefix -->
-<div class="ui:flex ui:items-center ui:gap-2">
-<div class="ui:space-y-2">
-<div class="ui:text-muted-foreground ui:text-sm">
-
-<!-- Component classes - no prefix needed -->
+<!-- Layout, sizing & spacing - unprefixed -->
+<div class="flex flex-col gap-6 w-96 p-6">
+<ul class="grid grid-cols-1 gap-4 md:grid-cols-2">
 <Card.Root class="w-full max-w-sm">
-<HoverCard.Content class="w-80">
+<Button class="w-full">
+
+<!-- UI theme colors - use ui: prefix -->
+<span class="ui:text-muted-foreground text-sm">Active students</span>
+<div class="ui:border-border border">
+<Avatar.Root class="ui:ring-background ring-2">
 ```
 
 ### LMS Content Guidelines
@@ -496,7 +485,7 @@ When creating a new story, ensure:
 - [ ] Title follows `'Category/ComponentName'` format
 - [ ] Component reference is correct (Root for multi-part, direct for single)
 - [ ] `tags: ['autodocs']` is included
-- [ ] All utility classes use `ui:` prefix
+- [ ] All theme color utilities use `ui:` prefix; story layout wrappers use standard Tailwind classes
 - [ ] Content is LMS-related (courses, students, instructors, etc.)
 - [ ] Multiple stories showcase different use cases
 - [ ] `fields.ts` is created if controls are needed
@@ -507,7 +496,7 @@ When creating a new story, ensure:
 
 - **State Management**: Use Svelte 5 runes (`$state()`, `$derived()`) for reactive state
 - **Layout**: Most stories use `layout: 'centered'` in parameters
-- **Styling**: Prefer Tailwind utility classes with `ui:` prefix
+- **Styling**: Use standard Tailwind utilities for story wrappers, and `ui:` prefix for UI theme tokens
 - **Accessibility**: Include proper ARIA labels and semantic HTML
 - **Documentation**: Story names should be descriptive and reflect the use case
 

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -17,6 +17,7 @@
     "@cio/email": "workspace:*",
     "@cio/ui": "workspace:*",
     "@cio/utils": "workspace:*",
+    "@lucide/svelte": "^0.562.0",
     "svelte-inview": "^4.0.4",
     "svelte-motion": "^0.12.2"
   },

--- a/packages/storybook/src/atoms/item/item.stories.svelte
+++ b/packages/storybook/src/atoms/item/item.stories.svelte
@@ -223,18 +223,16 @@
       </Item.Root>
       <Item.Root variant="outline">
         <Item.Media>
-          <div
-            class="ui:*:data-[slot=avatar]:ring-background flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:grayscale"
-          >
-            <Avatar.Root class="hidden sm:flex">
+          <div class="flex -space-x-2">
+            <Avatar.Root class="ui:ring-background hidden ring-2 grayscale sm:flex">
               <Avatar.Image src="https://github.com/shadcn.png" alt="@shadcn" />
               <Avatar.Fallback>CN</Avatar.Fallback>
             </Avatar.Root>
-            <Avatar.Root class="hidden sm:flex">
+            <Avatar.Root class="ui:ring-background hidden ring-2 grayscale sm:flex">
               <Avatar.Image src="https://github.com/maxleiter.png" alt="@maxleiter" />
               <Avatar.Fallback>LR</Avatar.Fallback>
             </Avatar.Root>
-            <Avatar.Root>
+            <Avatar.Root class="ui:ring-background ring-2 grayscale">
               <Avatar.Image src="https://github.com/evilrabbit.png" alt="@evilrabbit" />
               <Avatar.Fallback>ER</Avatar.Fallback>
             </Avatar.Root>

--- a/packages/storybook/src/atoms/item/item.stories.svelte
+++ b/packages/storybook/src/atoms/item/item.stories.svelte
@@ -224,7 +224,7 @@
       <Item.Root variant="outline">
         <Item.Media>
           <div
-            class="*:data-[slot=avatar]:ring-background flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:grayscale"
+            class="ui:*:data-[slot=avatar]:ring-background flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:grayscale"
           >
             <Avatar.Root class="hidden sm:flex">
               <Avatar.Image src="https://github.com/shadcn.png" alt="@shadcn" />
@@ -271,7 +271,7 @@
                 </Item.Media>
                 <Item.Content>
                   <Item.Title class="line-clamp-1">
-                    {song.title} - <span class="text-muted-foreground">{song.album}</span>
+                    {song.title} - <span class="ui:text-muted-foreground">{song.album}</span>
                   </Item.Title>
                   <Item.Description>{song.artist}</Item.Description>
                 </Item.Content>

--- a/packages/storybook/src/atoms/mode-switcher/mode-switcher.stories.svelte
+++ b/packages/storybook/src/atoms/mode-switcher/mode-switcher.stories.svelte
@@ -15,7 +15,7 @@
 <Story name="Default">
   {#snippet template()}
     <div class="flex flex-col items-center gap-4">
-      <p class="text-muted-foreground text-sm">Click to toggle dark/light mode</p>
+      <p class="ui:text-muted-foreground text-sm">Click to toggle dark/light mode</p>
       <ModeSwitcher />
     </div>
   {/snippet}

--- a/packages/storybook/src/atoms/number-badge/number-badge.stories.svelte
+++ b/packages/storybook/src/atoms/number-badge/number-badge.stories.svelte
@@ -34,7 +34,7 @@
   {#snippet template()}
     <button
       type="button"
-      class="group hover:border-border flex cursor-pointer items-center gap-2 rounded-md border border-transparent px-2 py-1.5"
+      class="group ui:hover:border-border flex cursor-pointer items-center gap-2 rounded-md border border-transparent px-2 py-1.5"
     >
       <NumberBadge number={2} />
       <span class="text-sm">Hover the row to see badge emphasis</span>

--- a/packages/storybook/src/atoms/popover/popover.stories.svelte
+++ b/packages/storybook/src/atoms/popover/popover.stories.svelte
@@ -22,7 +22,7 @@
         <div class="grid gap-4">
           <div class="space-y-2">
             <h4 class="leading-none font-medium">Dimensions</h4>
-            <p class="text-muted-foreground text-sm">Set the dimensions for the layer.</p>
+            <p class="ui:text-muted-foreground text-sm">Set the dimensions for the layer.</p>
           </div>
           <div class="grid gap-2">
             <div class="grid grid-cols-3 items-center gap-4">
@@ -71,7 +71,7 @@
         <div class="grid gap-4">
           <div class="space-y-2">
             <h4 class="leading-none font-medium">Settings</h4>
-            <p class="text-muted-foreground text-sm">Manage your account settings.</p>
+            <p class="ui:text-muted-foreground text-sm">Manage your account settings.</p>
           </div>
           <div class="grid gap-2">
             <div class="grid gap-1">
@@ -99,7 +99,7 @@
       <Popover.Content class="w-56">
         <div class="space-y-2">
           <h4 class="font-medium">About this feature</h4>
-          <p class="text-muted-foreground text-sm">
+          <p class="ui:text-muted-foreground text-sm">
             This feature allows you to quickly access important information without leaving the current page.
           </p>
         </div>

--- a/packages/storybook/src/atoms/radio-group/radio-group.stories.svelte
+++ b/packages/storybook/src/atoms/radio-group/radio-group.stories.svelte
@@ -43,21 +43,21 @@
         <RadioGroup.Item value="default" id="r1" class="mt-1" />
         <div>
           <Label for="r1" class="font-medium">Default</Label>
-          <p class="text-muted-foreground text-sm">The standard spacing for your app</p>
+          <p class="ui:text-muted-foreground text-sm">The standard spacing for your app</p>
         </div>
       </div>
       <div class="flex items-start space-x-2">
         <RadioGroup.Item value="comfortable" id="r2" class="mt-1" />
         <div>
           <Label for="r2" class="font-medium">Comfortable</Label>
-          <p class="text-muted-foreground text-sm">More space for easier interaction</p>
+          <p class="ui:text-muted-foreground text-sm">More space for easier interaction</p>
         </div>
       </div>
       <div class="flex items-start space-x-2">
         <RadioGroup.Item value="compact" id="r3" class="mt-1" />
         <div>
           <Label for="r3" class="font-medium">Compact</Label>
-          <p class="text-muted-foreground text-sm">Less space, more content</p>
+          <p class="ui:text-muted-foreground text-sm">Less space, more content</p>
         </div>
       </div>
     </RadioGroup.Root>

--- a/packages/storybook/src/atoms/separator/separator.stories.svelte
+++ b/packages/storybook/src/atoms/separator/separator.stories.svelte
@@ -21,12 +21,12 @@
     <div class="w-96 space-y-4">
       <div>
         <h4 class="text-sm font-medium">Section 1</h4>
-        <p class="text-muted-foreground text-sm">Content for the first section</p>
+        <p class="ui:text-muted-foreground text-sm">Content for the first section</p>
       </div>
       <Separator />
       <div>
         <h4 class="text-sm font-medium">Section 2</h4>
-        <p class="text-muted-foreground text-sm">Content for the second section</p>
+        <p class="ui:text-muted-foreground text-sm">Content for the second section</p>
       </div>
     </div>
   {/snippet}

--- a/packages/storybook/src/atoms/tabs/tabs.stories.svelte
+++ b/packages/storybook/src/atoms/tabs/tabs.stories.svelte
@@ -26,17 +26,17 @@
       </Tabs.List>
       <Tabs.Content value="overview">
         <div class="space-y-4 pt-4">
-          <p class="text-muted-foreground text-sm">View your overview dashboard with key metrics and insights.</p>
+          <p class="ui:text-muted-foreground text-sm">View your overview dashboard with key metrics and insights.</p>
         </div>
       </Tabs.Content>
       <Tabs.Content value="analytics">
         <div class="space-y-4 pt-4">
-          <p class="text-muted-foreground text-sm">Deep dive into your analytics and user behavior patterns.</p>
+          <p class="ui:text-muted-foreground text-sm">Deep dive into your analytics and user behavior patterns.</p>
         </div>
       </Tabs.Content>
       <Tabs.Content value="reports">
         <div class="space-y-4 pt-4">
-          <p class="text-muted-foreground text-sm">Generate and download detailed reports for your records.</p>
+          <p class="ui:text-muted-foreground text-sm">Generate and download detailed reports for your records.</p>
         </div>
       </Tabs.Content>
     </Tabs.Root>

--- a/packages/storybook/src/atoms/underline-tabs/underline-tabs.stories.svelte
+++ b/packages/storybook/src/atoms/underline-tabs/underline-tabs.stories.svelte
@@ -51,23 +51,23 @@
           <UnderlineTabs.Trigger value="video">Video</UnderlineTabs.Trigger>
         </UnderlineTabs.List>
         <UnderlineTabs.Content value="note">
-          <div class="ui:py-4">
-            <h3 class="ui:mb-2 ui:text-lg ui:font-semibold">Note Content</h3>
-            <p class="ui:text-muted-foreground ui:text-sm">
+          <div class="py-4">
+            <h3 class="mb-2 text-lg font-semibold">Note Content</h3>
+            <p class="ui:text-muted-foreground text-sm">
               Welcome to the note tab. This is where your note content lives.
             </p>
           </div>
         </UnderlineTabs.Content>
         <UnderlineTabs.Content value="slides">
-          <div class="ui:py-4">
-            <h3 class="ui:mb-2 ui:text-lg ui:font-semibold">Slides Content</h3>
-            <p class="ui:text-muted-foreground ui:text-sm">Manage your slides content and personal information here.</p>
+          <div class="py-4">
+            <h3 class="mb-2 text-lg font-semibold">Slides Content</h3>
+            <p class="ui:text-muted-foreground text-sm">Manage your slides content and personal information here.</p>
           </div>
         </UnderlineTabs.Content>
         <UnderlineTabs.Content value="video">
-          <div class="ui:py-4">
-            <h3 class="ui:mb-2 ui:text-lg ui:font-semibold">Video Content</h3>
-            <p class="ui:text-muted-foreground ui:text-sm">Configure your video content and preferences.</p>
+          <div class="py-4">
+            <h3 class="mb-2 text-lg font-semibold">Video Content</h3>
+            <p class="ui:text-muted-foreground text-sm">Configure your video content and preferences.</p>
           </div>
         </UnderlineTabs.Content>
       </UnderlineTabs.Root>
@@ -86,17 +86,17 @@
         </UnderlineTabs.List>
         <UnderlineTabs.Content value="home">
           <div class="py-4">
-            <p class="text-muted-foreground text-sm">Home content is shown here.</p>
+            <p class="ui:text-muted-foreground text-sm">Home content is shown here.</p>
           </div>
         </UnderlineTabs.Content>
         <UnderlineTabs.Content value="profile">
           <div class="py-4">
-            <p class="text-muted-foreground text-sm">Profile content is shown here.</p>
+            <p class="ui:text-muted-foreground text-sm">Profile content is shown here.</p>
           </div>
         </UnderlineTabs.Content>
         <UnderlineTabs.Content value="settings">
           <div class="py-4">
-            <p class="text-muted-foreground text-sm">Settings content (disabled).</p>
+            <p class="ui:text-muted-foreground text-sm">Settings content (disabled).</p>
           </div>
         </UnderlineTabs.Content>
       </UnderlineTabs.Root>

--- a/packages/storybook/src/molecules/animation/animation.stories.svelte
+++ b/packages/storybook/src/molecules/animation/animation.stories.svelte
@@ -31,29 +31,25 @@
 
 <Story name="BorderBeam">
   {#snippet template()}
-    <div
-      class="ui:relative ui:mx-auto ui:flex ui:h-48 ui:w-80 ui:items-center ui:justify-center ui:rounded-xl ui:border ui:bg-muted"
-    >
+    <div class="ui:bg-muted relative mx-auto flex h-48 w-80 items-center justify-center rounded-xl border">
       <BorderBeam />
-      <span class="ui:relative ui:z-10 ui:text-sm ui:font-medium">Border beam</span>
+      <span class="relative z-10 text-sm font-medium">Border beam</span>
     </div>
   {/snippet}
 </Story>
 
 <Story name="DotPattern">
   {#snippet template()}
-    <div class="ui:relative ui:mx-auto ui:h-48 ui:w-80 ui:overflow-hidden ui:rounded-xl ui:border ui:bg-background">
+    <div class="ui:bg-background relative mx-auto h-48 w-80 overflow-hidden rounded-xl border">
       <DotPattern />
-      <div class="ui:relative ui:z-10 ui:flex ui:h-full ui:items-center ui:justify-center ui:text-sm">Dot pattern</div>
+      <div class="relative z-10 flex h-full items-center justify-center text-sm">Dot pattern</div>
     </div>
   {/snippet}
 </Story>
 
 <Story name="DotField">
   {#snippet template()}
-    <div
-      class="ui:relative ui:mx-auto ui:h-[500px] ui:w-full ui:max-w-3xl ui:overflow-hidden ui:rounded-xl ui:border ui:bg-background"
-    >
+    <div class="ui:bg-background relative mx-auto h-[500px] w-full max-w-3xl overflow-hidden rounded-xl border">
       <DotField
         dotRadius={1.5}
         dotSpacing={14}
@@ -64,22 +60,18 @@
         glowRadius={160}
         sparkle={false}
         waveAmplitude={0}
-        class="ui:absolute ui:inset-0 ui:h-full ui:w-full"
+        class="absolute inset-0 h-full w-full"
       />
-      <div class="ui:relative ui:z-10 ui:flex ui:h-full ui:items-center ui:justify-center ui:text-sm">
-        Move the cursor over this area
-      </div>
+      <div class="relative z-10 flex h-full items-center justify-center text-sm">Move the cursor over this area</div>
     </div>
   {/snippet}
 </Story>
 
 <Story name="Waves">
   {#snippet template()}
-    <div
-      class="ui:relative ui:mx-auto ui:h-[500px] ui:w-full ui:max-w-3xl ui:overflow-hidden ui:rounded-xl ui:border ui:bg-background"
-    >
-      <Waves class="ui:absolute ui:inset-0 ui:h-full ui:w-full" />
-      <div class="ui:relative ui:z-10 ui:flex ui:h-full ui:items-center ui:justify-center ui:text-sm">
+    <div class="ui:bg-background relative mx-auto h-[500px] w-full max-w-3xl overflow-hidden rounded-xl border">
+      <Waves class="absolute inset-0 h-full w-full" />
+      <div class="relative z-10 flex h-full items-center justify-center text-sm">
         Move the cursor — animated waves use the theme primary stroke
       </div>
     </div>
@@ -88,11 +80,11 @@
 
 <Story name="CardContainer">
   {#snippet template()}
-    <CardContainer className="ui:max-w-lg">
+    <CardContainer className="max-w-lg">
       {#snippet children()}
         <CardBody>
           {#snippet children()}
-            <p class="ui:text-center ui:text-sm">Card container with body</p>
+            <p class="text-center text-sm">Card container with body</p>
           {/snippet}
         </CardBody>
       {/snippet}
@@ -102,10 +94,10 @@
 
 <Story name="BlurFade">
   {#snippet template()}
-    <div class="ui:p-8">
+    <div class="p-8">
       <BlurFade>
         {#snippet children()}
-          <p class="ui:text-lg">Scroll into view (blur fade)</p>
+          <p class="text-lg">Scroll into view (blur fade)</p>
         {/snippet}
       </BlurFade>
     </div>
@@ -114,7 +106,7 @@
 
 <Story name="BlurIn">
   {#snippet template()}
-    <div class="ui:p-8 ui:text-center">
+    <div class="p-8 text-center">
       <BlurIn>
         {#snippet children()}
           Blur in heading
@@ -126,20 +118,16 @@
 
 <Story name="Meteors">
   {#snippet template()}
-    <div
-      class="ui:relative ui:mx-auto ui:min-h-64 ui:w-full ui:max-w-xl ui:overflow-visible ui:rounded-xl ui:border ui:bg-slate-950 ui:p-4"
-    >
+    <div class="relative mx-auto min-h-64 w-full max-w-xl overflow-visible rounded-xl border bg-slate-950 p-4">
       <Meteors number={12} />
-      <p class="ui:relative ui:z-10 ui:p-6 ui:text-center ui:text-sm ui:text-slate-300">
-        Meteors (absolute layer behind this copy)
-      </p>
+      <p class="relative z-10 p-6 text-center text-sm text-slate-300">Meteors (absolute layer behind this copy)</p>
     </div>
   {/snippet}
 </Story>
 
 <Story name="ShimmerButton">
   {#snippet template()}
-    <div class="ui:flex ui:justify-center ui:bg-neutral-950 ui:p-8">
+    <div class="flex justify-center bg-neutral-950 p-8">
       <ShimmerButton href="https://example.com" target="_blank" rel="noreferrer">
         {#snippet children()}
           Shimmer CTA
@@ -151,7 +139,7 @@
 
 <Story name="Sparkle">
   {#snippet template()}
-    <div class="ui:flex ui:justify-center ui:bg-background ui:p-12">
+    <div class="ui:bg-background flex justify-center p-12">
       <Sparkle text="Sparkle text" sparklesCount={6} />
     </div>
   {/snippet}
@@ -159,7 +147,7 @@
 
 <Story name="HeroVideoDialog">
   {#snippet template()}
-    <div class="ui:mx-auto ui:max-w-2xl ui:p-8">
+    <div class="mx-auto max-w-2xl p-8">
       <HeroVideoDialog
         thumbnailSrc="https://images.unsplash.com/photo-1492691527719-9d1e07e534b4?w=1200&q=80"
         videoSrc="https://www.youtube.com/embed/dQw4w9WgXcQ"
@@ -171,7 +159,7 @@
 
 <Story name="ShinnyText">
   {#snippet template()}
-    <div class="ui:flex ui:justify-center ui:bg-background ui:p-12">
+    <div class="ui:bg-background flex justify-center p-12">
       <ShinnyText shimmerWidth={120}>
         {#snippet children()}
           Shiny marketing copy
@@ -183,10 +171,10 @@
 
 <Story name="MagicCard">
   {#snippet template()}
-    <div class="ui:mx-auto ui:h-40 ui:max-w-sm ui:p-4">
+    <div class="mx-auto h-40 max-w-sm p-4">
       <MagicCard>
         {#snippet children()}
-          <p class="ui:text-center ui:text-sm">Hover for gradient</p>
+          <p class="text-center text-sm">Hover for gradient</p>
         {/snippet}
       </MagicCard>
     </div>
@@ -195,7 +183,7 @@
 
 <Story name="GradualSpacing">
   {#snippet template()}
-    <div class="ui:bg-background ui:p-12">
+    <div class="ui:bg-background p-12">
       <GradualSpacing words="Hello" />
     </div>
   {/snippet}
@@ -203,11 +191,11 @@
 
 <Story name="SquareCard">
   {#snippet template()}
-    <div class="ui:relative ui:mx-auto ui:w-64 ui:rounded-lg ui:border ui:p-6">
-      <SquareCardIcon class="ui:right-2 ui:top-2" />
+    <div class="relative mx-auto w-64 rounded-lg border p-6">
+      <SquareCardIcon class="top-2 right-2" />
       <SquareCardBody>
         {#snippet children()}
-          <p class="ui:text-sm">Square card body with icon</p>
+          <p class="text-sm">Square card body with icon</p>
         {/snippet}
       </SquareCardBody>
     </div>

--- a/packages/storybook/src/molecules/attachment-list/attachment-list.stories.svelte
+++ b/packages/storybook/src/molecules/attachment-list/attachment-list.stories.svelte
@@ -54,7 +54,7 @@
 
 <Story name="ViewMode" parameters={{ layout: 'padded' }}>
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-xl">
+    <div class="w-full max-w-xl">
       <AttachmentList
         mode="view"
         files={sampleFiles}
@@ -68,7 +68,7 @@
 
 <Story name="EditMode" parameters={{ layout: 'padded' }}>
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-xl">
+    <div class="w-full max-w-xl">
       <AttachmentList
         mode="edit"
         files={sampleFiles}
@@ -87,7 +87,7 @@
 
 <Story name="SingleFile" parameters={{ layout: 'padded' }}>
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-xl">
+    <div class="w-full max-w-xl">
       <AttachmentList
         mode="view"
         files={[sampleFiles[0]]}

--- a/packages/storybook/src/molecules/button-group/button-group.stories.svelte
+++ b/packages/storybook/src/molecules/button-group/button-group.stories.svelte
@@ -133,7 +133,7 @@
             </DropdownMenu.Group>
             <DropdownMenu.Separator />
             <DropdownMenu.Group>
-              <DropdownMenu.Item class="text-destructive focus:text-destructive">
+              <DropdownMenu.Item class="ui:text-destructive ui:focus:text-destructive">
                 <Trash2 />
                 Trash
               </DropdownMenu.Item>
@@ -268,7 +268,7 @@
                       onclick={() => (voiceEnabled = !voiceEnabled)}
                       size="icon-xs"
                       data-active={voiceEnabled}
-                      class="ui:data-[active=true]:bg-orange-100 ui:data-[active=true]:text-orange-700 ui:dark:data-[active=true]:bg-orange-800 ui:dark:data-[active=true]:text-orange-100"
+                      class="data-[active=true]:bg-orange-100 data-[active=true]:text-orange-700 dark:data-[active=true]:bg-orange-800 dark:data-[active=true]:text-orange-100"
                       aria-pressed={voiceEnabled}
                     >
                       <AudioLines />
@@ -349,7 +349,7 @@
             {#each CURRENCIES as currencyOption (currencyOption.value)}
               <Select.Item value={currencyOption.value}>
                 {currencyOption.value}
-                <span class="text-muted-foreground">{currencyOption.label}</span>
+                <span class="ui:text-muted-foreground">{currencyOption.label}</span>
               </Select.Item>
             {/each}
           </Select.Content>
@@ -388,7 +388,7 @@
           <div class="p-4 text-sm *:[p:not(:last-child)]:mb-2">
             <Textarea placeholder="Describe your task in natural language." class="mb-4 resize-none" />
             <p class="font-medium">Start a new task with Copilot</p>
-            <p class="text-muted-foreground">
+            <p class="ui:text-muted-foreground">
               Describe your task in natural language. Copilot will work in the background and open a pull request for
               your review.
             </p>

--- a/packages/storybook/src/molecules/card/card.stories.svelte
+++ b/packages/storybook/src/molecules/card/card.stories.svelte
@@ -36,15 +36,15 @@
       </Card.Header>
       <Card.Content>
         <form>
-          <div class="ui:flex ui:flex-col ui:gap-6">
-            <div class="ui:grid ui:gap-2">
+          <div class="flex flex-col gap-6">
+            <div class="grid gap-2">
               <Label for="email">Email</Label>
               <Input id="email" type="email" bind:value={email} placeholder="m@example.com" required />
             </div>
-            <div class="ui:grid ui:gap-2">
-              <div class="ui:flex ui:items-center">
+            <div class="grid gap-2">
+              <div class="flex items-center">
                 <Label for="password">Password</Label>
-                <a href="/" class="ui:ms-auto ui:inline-block ui:text-sm ui:underline-offset-4 hover:ui:underline">
+                <a href="/" class="ms-auto inline-block text-sm underline-offset-4 hover:underline">
                   Forgot your password?
                 </a>
               </div>
@@ -53,9 +53,9 @@
           </div>
         </form>
       </Card.Content>
-      <Card.Footer class="ui:flex-col ui:gap-2">
-        <Button type="submit" class="ui:w-full">Login</Button>
-        <Button variant="outline" class="ui:w-full">Login with Google</Button>
+      <Card.Footer class="flex-col gap-2">
+        <Button type="submit" class="w-full">Login</Button>
+        <Button variant="outline" class="w-full">Login with Google</Button>
       </Card.Footer>
     </Card.Root>
   {/snippet}
@@ -63,7 +63,7 @@
 
 <Story name="Simple">
   {#snippet template()}
-    <Card.Root class="ui:w-full ui:max-w-sm">
+    <Card.Root class="w-full max-w-sm">
       <Card.Header>
         <Card.Title>Card Title</Card.Title>
         <Card.Description>Card description goes here.</Card.Description>
@@ -77,7 +77,7 @@
 
 <Story name="With Footer">
   {#snippet template()}
-    <Card.Root class="ui:w-full ui:max-w-sm">
+    <Card.Root class="w-full max-w-sm">
       <Card.Header>
         <Card.Title>Card Title</Card.Title>
         <Card.Description>Card description goes here.</Card.Description>
@@ -94,7 +94,7 @@
 
 <Story name="With Action">
   {#snippet template()}
-    <Card.Root class="ui:w-full ui:max-w-sm">
+    <Card.Root class="w-full max-w-sm">
       <Card.Header>
         <Card.Title>Card Title</Card.Title>
         <Card.Description>Card description goes here.</Card.Description>
@@ -111,7 +111,7 @@
 
 <Story name="No Header">
   {#snippet template()}
-    <Card.Root class="ui:w-full ui:max-w-sm">
+    <Card.Root class="w-full max-w-sm">
       <Card.Content>
         <p>Card content without header.</p>
       </Card.Content>

--- a/packages/storybook/src/molecules/chat-textarea/chat-textarea.stories.svelte
+++ b/packages/storybook/src/molecules/chat-textarea/chat-textarea.stories.svelte
@@ -77,17 +77,17 @@
         {/snippet}
 
         {#snippet actions()}
-          <button class="ui:text-muted-foreground hover:ui:bg-muted ui:rounded-md ui:p-1.5 ui:transition-colors">
+          <button class="ui:text-muted-foreground ui:hover:bg-muted rounded-md p-1.5 transition-colors">
             <PaperclipIcon size={16} />
           </button>
-          <div class="ui:flex-1"></div>
-          <Button size="icon" variant="default" onclick={handleSend} disabled={!value.trim()} class="ui:size-7">
+          <div class="flex-1"></div>
+          <Button size="icon" variant="default" onclick={handleSend} disabled={!value.trim()} class="size-7">
             <SendIcon size={14} />
           </Button>
         {/snippet}
       </ChatTextarea>
-      <p class="ui:text-muted-foreground ui:mt-2 ui:text-xs">
-        Press Enter to send. Current value: <code class="ui:text-xs">{value || '(empty)'}</code>
+      <p class="ui:text-muted-foreground mt-2 text-xs">
+        Press Enter to send. Current value: <code class="text-xs">{value || '(empty)'}</code>
       </p>
     </div>
   {/snippet}
@@ -133,11 +133,11 @@
           {/snippet}
 
           {#snippet actions()}
-            <button class="ui:text-muted-foreground hover:ui:bg-muted ui:rounded-md ui:p-1.5 ui:transition-colors">
+            <button class="ui:text-muted-foreground ui:hover:bg-muted rounded-md p-1.5 transition-colors">
               <PaperclipIcon size={16} />
             </button>
-            <div class="ui:flex-1"></div>
-            <Button size="icon" variant="default" onclick={handleSend} disabled={!value.trim()} class="ui:size-7">
+            <div class="flex-1"></div>
+            <Button size="icon" variant="default" onclick={handleSend} disabled={!value.trim()} class="size-7">
               <SendIcon size={14} />
             </Button>
           {/snippet}
@@ -160,11 +160,11 @@
     <div style="width: 360px;">
       <ChatTextarea value="Streaming response..." disabled placeholder="Ask the AI assistant...">
         {#snippet actions()}
-          <button class="ui:text-muted-foreground ui:rounded-md ui:p-1.5 ui:opacity-50" disabled>
+          <button class="ui:text-muted-foreground rounded-md p-1.5 opacity-50" disabled>
             <PaperclipIcon size={16} />
           </button>
-          <div class="ui:flex-1"></div>
-          <Button size="icon" variant="outline" class="ui:size-7">
+          <div class="flex-1"></div>
+          <Button size="icon" variant="outline" class="size-7">
             <SquareIcon size={12} />
           </Button>
         {/snippet}

--- a/packages/storybook/src/molecules/checkbox-option-card/checkbox-option-card.stories.svelte
+++ b/packages/storybook/src/molecules/checkbox-option-card/checkbox-option-card.stories.svelte
@@ -79,38 +79,38 @@
 
 <Story name="Course Picker (stacked horizontally)">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-xl">
-      <Field.Description class="ui:mb-4 ui:block">
+    <div class="w-full max-w-xl">
+      <Field.Description class="mb-4 block">
         Pick one or more courses. Each card stacks vertically and lays out title and checkbox horizontally.
       </Field.Description>
-      <CheckboxOptionCardGroup options={courseOptions} bind:value={selectedCourses} class="ui:grid-cols-1" />
-      <p class="ui:mt-3 ui:text-muted-foreground ui:text-sm">Selected: {selectedCourses.join(', ') || 'none'}</p>
+      <CheckboxOptionCardGroup options={courseOptions} bind:value={selectedCourses} class="grid-cols-1" />
+      <p class="ui:text-muted-foreground mt-3 text-sm">Selected: {selectedCourses.join(', ') || 'none'}</p>
     </div>
   {/snippet}
 </Story>
 
 <Story name="Feature Toggles (Group)">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-xl">
-      <Field.Description class="ui:mb-4 ui:block">
+    <div class="w-full max-w-xl">
+      <Field.Description class="mb-4 block">
         Toggle one or more product features. Bound value is an array of selected option values.
       </Field.Description>
       <CheckboxOptionCardGroup options={featureOptions} bind:value={selectedFeatures} />
-      <p class="ui:mt-3 ui:text-muted-foreground ui:text-sm">Selected: {selectedFeatures.join(', ') || 'none'}</p>
+      <p class="ui:text-muted-foreground mt-3 text-sm">Selected: {selectedFeatures.join(', ') || 'none'}</p>
     </div>
   {/snippet}
 </Story>
 
 <Story name="With Disabled Option and Title Suffix">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-xl">
-      <Field.Description class="ui:mb-4 ui:block">
+    <div class="w-full max-w-xl">
+      <Field.Description class="mb-4 block">
         Use the <code>titleSuffix(option)</code> snippet to render per-option content.
       </Field.Description>
       <CheckboxOptionCardGroup options={courseOptions} bind:value={selectedCourses}>
         {#snippet titleSuffix(option)}
           {#if option.disabled}
-            <Badge variant="secondary" class="ui:text-xs">Coming soon</Badge>
+            <Badge variant="secondary" class="text-xs">Coming soon</Badge>
           {/if}
         {/snippet}
       </CheckboxOptionCardGroup>
@@ -120,16 +120,16 @@
 
 <Story name="Custom Columns (Group class override)">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-3xl">
-      <Field.Description class="ui:mb-4 ui:block">
+    <div class="w-full max-w-3xl">
+      <Field.Description class="mb-4 block">
         Override grid with the <code>class</code> prop on <code>CheckboxOptionCardGroup</code>.
       </Field.Description>
       <CheckboxOptionCardGroup
         options={audienceOptions}
         bind:value={selectedAudiences}
-        class="ui:grid-cols-1 ui:sm:grid-cols-2 ui:lg:grid-cols-3"
+        class="grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
       />
-      <p class="ui:mt-3 ui:text-muted-foreground ui:text-sm">Selected: {selectedAudiences.join(', ') || 'none'}</p>
+      <p class="ui:text-muted-foreground mt-3 text-sm">Selected: {selectedAudiences.join(', ') || 'none'}</p>
     </div>
   {/snippet}
 </Story>

--- a/packages/storybook/src/molecules/code/code.stories.svelte
+++ b/packages/storybook/src/molecules/code/code.stories.svelte
@@ -79,7 +79,7 @@ class CodeRootState {
 
 <Story name="Default">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-3xl">
+    <div class="w-full max-w-3xl">
       <Code.Root code={sampleTypeScript} lang="typescript" />
     </div>
   {/snippet}
@@ -87,7 +87,7 @@ class CodeRootState {
 
 <Story name="With Copy Button">
   {#snippet template()}
-    <div class="ui:relative ui:w-full ui:max-w-3xl">
+    <div class="relative w-full max-w-3xl">
       <Code.Root code={sampleTypeScript} lang="typescript">
         <Code.CopyButton />
       </Code.Root>
@@ -97,15 +97,15 @@ class CodeRootState {
 
 <Story name="Variants">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-6 ui:w-full ui:max-w-3xl">
+    <div class="flex w-full max-w-3xl flex-col gap-6">
       <div>
-        <p class="ui:mb-2 ui:text-sm ui:font-medium ui:text-muted-foreground">Default variant</p>
+        <p class="ui:text-muted-foreground mb-2 text-sm font-medium">Default variant</p>
         <Code.Root code={sampleTypeScript} lang="typescript" variant="default">
           <Code.CopyButton />
         </Code.Root>
       </div>
       <div>
-        <p class="ui:mb-2 ui:text-sm ui:font-medium ui:text-muted-foreground">Secondary variant</p>
+        <p class="ui:text-muted-foreground mb-2 text-sm font-medium">Secondary variant</p>
         <Code.Root code={sampleTypeScript} lang="typescript" variant="secondary">
           <Code.CopyButton />
         </Code.Root>
@@ -116,7 +116,7 @@ class CodeRootState {
 
 <Story name="Languages">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-6 ui:w-full ui:max-w-3xl">
+    <div class="flex w-full max-w-3xl flex-col gap-6">
       <Code.Block filename="example.ts" code={sampleTypeScript} />
       <Code.Block filename="script.sh" code={sampleBash} />
       <Code.Block filename="package.json" code={sampleJson} />
@@ -127,7 +127,7 @@ class CodeRootState {
 
 <Story name="With Line Highlighting">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-2xl">
+    <div class="w-full max-w-2xl">
       <Code.Root code={sampleTypeScript} lang="typescript" highlight={[2, [4, 5]]} />
     </div>
   {/snippet}
@@ -135,7 +135,7 @@ class CodeRootState {
 
 <Story name="Hide Line Numbers">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-2xl">
+    <div class="w-full max-w-2xl">
       <Code.Root code={sampleTypeScript} lang="typescript" hideLines={true} />
     </div>
   {/snippet}
@@ -143,7 +143,7 @@ class CodeRootState {
 
 <Story name="With Overflow">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-2xl">
+    <div class="w-full max-w-2xl">
       <Code.Overflow>
         <Code.Root code={longCode} lang="typescript">
           <Code.CopyButton />
@@ -155,7 +155,7 @@ class CodeRootState {
 
 <Story name="Overflow Expanded">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-2xl">
+    <div class="w-full max-w-2xl">
       <Code.Overflow collapsed={false}>
         <Code.Root code={longCode} lang="typescript">
           <Code.CopyButton />

--- a/packages/storybook/src/molecules/copy-button/copy-button.stories.svelte
+++ b/packages/storybook/src/molecules/copy-button/copy-button.stories.svelte
@@ -38,7 +38,7 @@
 
 <Story name="Variants">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:items-start">
+    <div class="flex flex-col items-start gap-4">
       <CopyButton text="Default variant" variant="default" />
       <CopyButton text="Outline variant" variant="outline" />
       <CopyButton text="Secondary variant" variant="secondary" />
@@ -50,7 +50,7 @@
 
 <Story name="With Input Group">
   {#snippet template()}
-    <InputGroup.Root class="ui:w-96">
+    <InputGroup.Root class="w-96">
       <InputGroup.Input value="https://classroomio.com/courses/123" readonly />
       <InputGroup.Addon align="inline-end">
         <CopyButton text="https://classroomio.com/courses/123" size="icon-sm" />
@@ -61,15 +61,15 @@
 
 <Story name="Reactive Text">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputGroup.Root>
         <InputGroup.Input bind:value={textToCopy} placeholder="Enter text to copy" />
         <InputGroup.Addon align="inline-end">
           <CopyButton text={textToCopy} size="icon-sm" />
         </InputGroup.Addon>
       </InputGroup.Root>
-      <div class="ui:text-sm ui:text-muted-foreground">
-        <p>Text to copy: <code class="ui:bg-muted ui:px-2 ui:py-1 ui:rounded">{textToCopy}</code></p>
+      <div class="ui:text-muted-foreground text-sm">
+        <p>Text to copy: <code class="ui:bg-muted rounded px-2 py-1">{textToCopy}</code></p>
       </div>
     </div>
   {/snippet}
@@ -77,9 +77,9 @@
 
 <Story name="Code Block">
   {#snippet template()}
-    <div class="ui:rounded-lg ui:border ui:bg-muted/50 ui:p-4 ui:w-full ui:max-w-2xl">
-      <div class="ui:flex ui:items-center ui:justify-between ui:mb-2">
-        <span class="ui:text-sm ui:font-medium">Installation</span>
+    <div class="ui:bg-muted/50 w-full max-w-2xl rounded-lg border p-4">
+      <div class="mb-2 flex items-center justify-between">
+        <span class="text-sm font-medium">Installation</span>
         <CopyButton
           text="pnpm add @cio/ui"
           size="sm"
@@ -93,9 +93,9 @@
           Copy
         </CopyButton>
       </div>
-      <pre class="ui:text-sm"><code>pnpm add @cio/ui</code></pre>
+      <pre class="text-sm"><code>pnpm add @cio/ui</code></pre>
       {#if copiedText}
-        <p class="ui:mt-2 ui:text-green-600">Last copied: {copiedText}</p>
+        <p class="mt-2 text-green-600">Last copied: {copiedText}</p>
       {/if}
     </div>
   {/snippet}

--- a/packages/storybook/src/molecules/document-card/document-card.stories.svelte
+++ b/packages/storybook/src/molecules/document-card/document-card.stories.svelte
@@ -16,27 +16,34 @@
   });
 </script>
 
-<Story name="WithViewAndDownload">
-  {#snippet template()}
-    <DocumentCard
-      title="report.pdf"
-      subtitle="PDF · 2.4 MB"
-      fileUrl="https://example.com/report.pdf"
-      viewLabel="View"
-      downloadLabel="Download"
-    />
-  {/snippet}
-</Story>
+<Story
+  name="WithViewAndDownload"
+  args={{
+    title: 'report.pdf',
+    subtitle: 'PDF · 2.4 MB',
+    fileUrl: 'https://example.com/report.pdf',
+    viewLabel: 'View',
+    downloadLabel: 'Download'
+  }}
+/>
 
-<Story name="WithoutUrl">
-  {#snippet template()}
-    <DocumentCard title="draft.docx" subtitle="DOCX · 156 KB" />
-  {/snippet}
-</Story>
+<Story
+  name="WithoutUrl"
+  args={{
+    title: 'draft.docx',
+    subtitle: 'DOCX · 156 KB'
+  }}
+/>
 
-<Story name="WithCustomActions">
-  {#snippet template()}
-    <DocumentCard title="lesson-doc.pdf" subtitle="PDF · 1.2 MB">
+<Story
+  name="WithCustomActions"
+  args={{
+    title: 'lesson-doc.pdf',
+    subtitle: 'PDF · 1.2 MB'
+  }}
+>
+  {#snippet template(args)}
+    <DocumentCard {...args}>
       {#snippet actions()}
         <button
           type="button"

--- a/packages/storybook/src/molecules/document-card/document-card.stories.svelte
+++ b/packages/storybook/src/molecules/document-card/document-card.stories.svelte
@@ -1,46 +1,56 @@
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
   import { DocumentCard } from '@cio/ui';
+  import { FIELDS } from './fields';
 
   const { Story } = defineMeta({
     title: 'Molecules/DocumentCard',
     component: DocumentCard,
     parameters: {
-      layout: 'centered'
+      layout: 'centered',
+      controls: {
+        include: FIELDS
+      }
     },
     tags: ['autodocs']
   });
 </script>
 
 <Story name="WithViewAndDownload">
-  <DocumentCard
-    title="report.pdf"
-    subtitle="PDF · 2.4 MB"
-    fileUrl="https://example.com/report.pdf"
-    viewLabel="View"
-    downloadLabel="Download"
-  />
+  {#snippet template()}
+    <DocumentCard
+      title="report.pdf"
+      subtitle="PDF · 2.4 MB"
+      fileUrl="https://example.com/report.pdf"
+      viewLabel="View"
+      downloadLabel="Download"
+    />
+  {/snippet}
 </Story>
 
 <Story name="WithoutUrl">
-  <DocumentCard title="draft.docx" subtitle="DOCX · 156 KB" />
+  {#snippet template()}
+    <DocumentCard title="draft.docx" subtitle="DOCX · 156 KB" />
+  {/snippet}
 </Story>
 
 <Story name="WithCustomActions">
-  <DocumentCard title="lesson-doc.pdf" subtitle="PDF · 1.2 MB">
-    {#snippet actions()}
-      <button
-        type="button"
-        class="ui:border-input ui:bg-background ui:text-foreground ui:hover:bg-accent ui:hover:text-accent-foreground inline-flex shrink items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium"
-      >
-        View PDF
-      </button>
-      <button
-        type="button"
-        class="ui:border-input ui:bg-background ui:text-foreground ui:hover:bg-accent ui:hover:text-accent-foreground inline-flex shrink items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium"
-      >
-        Download
-      </button>
-    {/snippet}
-  </DocumentCard>
+  {#snippet template()}
+    <DocumentCard title="lesson-doc.pdf" subtitle="PDF · 1.2 MB">
+      {#snippet actions()}
+        <button
+          type="button"
+          class="ui:border-input ui:bg-background ui:text-foreground ui:hover:bg-accent ui:hover:text-accent-foreground inline-flex shrink items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium"
+        >
+          View PDF
+        </button>
+        <button
+          type="button"
+          class="ui:border-input ui:bg-background ui:text-foreground ui:hover:bg-accent ui:hover:text-accent-foreground inline-flex shrink items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium"
+        >
+          Download
+        </button>
+      {/snippet}
+    </DocumentCard>
+  {/snippet}
 </Story>

--- a/packages/storybook/src/molecules/document-card/document-card.stories.svelte
+++ b/packages/storybook/src/molecules/document-card/document-card.stories.svelte
@@ -31,13 +31,13 @@
     {#snippet actions()}
       <button
         type="button"
-        class="ui:border-input ui:bg-background ui:text-foreground hover:ui:bg-accent hover:ui:text-accent-foreground ui:shrink ui:inline-flex ui:items-center ui:gap-1.5 ui:rounded-md ui:border ui:px-3 ui:py-1.5 ui:text-sm ui:font-medium"
+        class="ui:border-input ui:bg-background ui:text-foreground ui:hover:bg-accent ui:hover:text-accent-foreground inline-flex shrink items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium"
       >
         View PDF
       </button>
       <button
         type="button"
-        class="ui:border-input ui:bg-background ui:text-foreground hover:ui:bg-accent hover:ui:text-accent-foreground ui:shrink ui:inline-flex ui:items-center ui:gap-1.5 ui:rounded-md ui:border ui:px-3 ui:py-1.5 ui:text-sm ui:font-medium"
+        class="ui:border-input ui:bg-background ui:text-foreground ui:hover:bg-accent ui:hover:text-accent-foreground inline-flex shrink items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium"
       >
         Download
       </button>

--- a/packages/storybook/src/molecules/document-card/fields.ts
+++ b/packages/storybook/src/molecules/document-card/fields.ts
@@ -1,0 +1,10 @@
+export const FIELDS = [
+  'title',
+  'subtitle',
+  'fileUrl',
+  'viewLabel',
+  'downloadLabel',
+  'actions',
+  'header',
+  'class'
+] as string[];

--- a/packages/storybook/src/molecules/empty/empty.stories.svelte
+++ b/packages/storybook/src/molecules/empty/empty.stories.svelte
@@ -72,7 +72,7 @@
 
 <Story name="Background">
   {#snippet template()}
-    <Empty.Root class="ui:from-muted/50 ui:to-background ui:h-full ui:bg-gradient-to-b ui:from-30%">
+    <Empty.Root class="ui:from-muted/50 ui:to-background h-full bg-gradient-to-b from-30%">
       <Empty.Header>
         <Empty.Media variant="icon">
           <BellIcon />
@@ -117,7 +117,7 @@
     <Empty.Root>
       <Empty.Header>
         <Empty.Media>
-          <div class="*:ring-background flex -space-x-2 *:size-12 *:ring-2 *:grayscale">
+          <div class="ui:*:ring-background flex -space-x-2 *:size-12 *:ring-2 *:grayscale">
             <Avatar.Root>
               <Avatar.Image src="https://github.com/shadcn.png" alt="@shadcn" />
               <Avatar.Fallback>CN</Avatar.Fallback>

--- a/packages/storybook/src/molecules/empty/empty.stories.svelte
+++ b/packages/storybook/src/molecules/empty/empty.stories.svelte
@@ -117,16 +117,16 @@
     <Empty.Root>
       <Empty.Header>
         <Empty.Media>
-          <div class="ui:*:ring-background flex -space-x-2 *:size-12 *:ring-2 *:grayscale">
-            <Avatar.Root>
+          <div class="flex -space-x-2">
+            <Avatar.Root class="ui:ring-background size-12 ring-2 grayscale">
               <Avatar.Image src="https://github.com/shadcn.png" alt="@shadcn" />
               <Avatar.Fallback>CN</Avatar.Fallback>
             </Avatar.Root>
-            <Avatar.Root>
+            <Avatar.Root class="ui:ring-background size-12 ring-2 grayscale">
               <Avatar.Image src="https://github.com/maxleiter.png" alt="@maxleiter" />
               <Avatar.Fallback>LR</Avatar.Fallback>
             </Avatar.Root>
-            <Avatar.Root>
+            <Avatar.Root class="ui:ring-background size-12 ring-2 grayscale">
               <Avatar.Image src="https://github.com/evilrabbit.png" alt="@evilrabbit" />
               <Avatar.Fallback>ER</Avatar.Fallback>
             </Avatar.Root>

--- a/packages/storybook/src/molecules/exercise-question/exercise-question.stories.svelte
+++ b/packages/storybook/src/molecules/exercise-question/exercise-question.stories.svelte
@@ -54,7 +54,7 @@
 
 <Story name="Exercise Sections - Section Intro">
   {#snippet template()}
-    <div class="ui:max-w-5xl">
+    <div class="max-w-5xl">
       <ExerciseQuestion.SectionOverview
         sectionTitle={SECTIONED_EXERCISE_FIXTURE[0].title}
         sectionDescription={SECTIONED_EXERCISE_FIXTURE[0].description}
@@ -73,7 +73,7 @@
 
 <Story name="Exercise Sections - Auto Grouped Existing Questions">
   {#snippet template()}
-    <div class="ui:max-w-5xl">
+    <div class="max-w-5xl">
       <ExerciseQuestion.SectionOverview
         sectionTitle={autoGroupedSection.title}
         sectionDescription={autoGroupedSection.description}
@@ -92,7 +92,7 @@
 
 <Story name="Exercise Sections - Question In Progress">
   {#snippet template()}
-    <div class="ui:grid ui:max-w-5xl ui:gap-6 ui:lg:grid-cols-[190px_minmax(0,1fr)]">
+    <div class="grid max-w-5xl gap-6 lg:grid-cols-[190px_minmax(0,1fr)]">
       <ExerciseQuestion.SectionNavigationSidebar
         sections={SECTIONED_EXERCISE_FIXTURE.map((section, sectionIndex) => ({
           id: section.id,
@@ -107,7 +107,7 @@
         }))}
       />
 
-      <section class="ui:space-y-4">
+      <section class="space-y-4">
         <ExerciseQuestion.SectionHeader
           title={SECTIONED_EXERCISE_FIXTURE[0].title}
           description={SECTIONED_EXERCISE_FIXTURE[0].description}
@@ -134,9 +134,9 @@
 
 <Story name="Exercise Sections - Grading View">
   {#snippet template()}
-    <div class="ui:max-w-4xl ui:space-y-8">
+    <div class="max-w-4xl space-y-8">
       {#each SECTIONED_EXERCISE_FIXTURE as section, sectionIndex (section.id)}
-        <section class="ui:space-y-4">
+        <section class="space-y-4">
           <ExerciseQuestion.SectionHeader
             title={section.title}
             description={section.description}
@@ -163,10 +163,10 @@
               },
               disabled: true
             }}
-            itemClass="ui:mb-4"
+            itemClass="mb-4"
           />
 
-          <div class="ui:flex ui:justify-end ui:border-t ui:pt-3 ui:text-sm ui:font-medium">
+          <div class="flex justify-end border-t pt-3 text-sm font-medium">
             Section subtotal: {section.questions.length * 4}/{section.questions.length * 5}
           </div>
         </section>
@@ -238,7 +238,7 @@
 >
   {#snippet template()}
     <div
-      class="ui:mb-4 ui:rounded-md ui:border ui:border-amber-500/50 ui:bg-amber-500/10 ui:px-4 ui:py-3 ui:text-sm ui:text-amber-800 ui:dark:text-amber-200"
+      class="mb-4 rounded-md border border-amber-500/50 bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-200"
     >
       <strong>Hidden – still in development.</strong> Not available in the exercise editor.
     </div>
@@ -273,7 +273,7 @@
 >
   {#snippet template()}
     <div
-      class="ui:mb-4 ui:rounded-md ui:border ui:border-amber-500/50 ui:bg-amber-500/10 ui:px-4 ui:py-3 ui:text-sm ui:text-amber-800 ui:dark:text-amber-200"
+      class="mb-4 rounded-md border border-amber-500/50 bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-200"
     >
       <strong>Hidden – still in development.</strong> Not available in the exercise editor.
     </div>

--- a/packages/storybook/src/molecules/exercise-question/question-type-modes.svelte
+++ b/packages/storybook/src/molecules/exercise-question/question-type-modes.svelte
@@ -190,9 +190,9 @@
   });
 </script>
 
-<div class="ui:mb-5 ui:space-y-4">
-  <div class="ui:rounded-md ui:border ui:p-4 ui:space-y-3">
-    <p class="ui:text-sm ui:font-semibold">View Mode</p>
+<div class="mb-5 space-y-4">
+  <div class="space-y-3 rounded-md border p-4">
+    <p class="text-sm font-semibold">View Mode</p>
     <ExerciseQuestion.QuestionRenderer
       showContainer={false}
       contract={{
@@ -205,8 +205,8 @@
     />
   </div>
 
-  <div class="ui:rounded-md ui:border ui:p-4 ui:space-y-3">
-    <p class="ui:text-sm ui:font-semibold">Edit Mode</p>
+  <div class="space-y-3 rounded-md border p-4">
+    <p class="text-sm font-semibold">Edit Mode</p>
     <ExerciseQuestion.QuestionRenderer
       showContainer={false}
       contract={{
@@ -218,8 +218,8 @@
     />
   </div>
 
-  <div class="ui:rounded-md ui:border ui:p-4 ui:space-y-3">
-    <p class="ui:text-sm ui:font-semibold">Preview Mode</p>
+  <div class="space-y-3 rounded-md border p-4">
+    <p class="text-sm font-semibold">Preview Mode</p>
     <ExerciseQuestion.QuestionRenderer
       showContainer={false}
       contract={{
@@ -232,9 +232,9 @@
     />
   </div>
 
-  <div class="ui:rounded-md ui:border ui:p-4 ui:space-y-3">
-    <p class="ui:text-sm ui:font-semibold">Review Mode</p>
-    <p class="ui:text-muted-foreground ui:text-xs">
+  <div class="space-y-3 rounded-md border p-4">
+    <p class="text-sm font-semibold">Review Mode</p>
+    <p class="ui:text-muted-foreground text-xs">
       Read-only submission replay with correctness (same as grading / finished exercise in the app).
     </p>
     <ExerciseQuestion.QuestionRenderer
@@ -250,9 +250,9 @@
   </div>
 
   {#if wrongAnswer !== undefined}
-    <div class="ui:rounded-md ui:border ui:p-4 ui:space-y-3">
-      <p class="ui:text-sm ui:font-semibold">Review Mode (incorrect)</p>
-      <p class="ui:text-muted-foreground ui:text-xs">
+    <div class="space-y-3 rounded-md border p-4">
+      <p class="text-sm font-semibold">Review Mode (incorrect)</p>
+      <p class="ui:text-muted-foreground text-xs">
         Same review UI when the submitted answer does not match the correct solution.
       </p>
       <ExerciseQuestion.QuestionRenderer
@@ -268,8 +268,8 @@
     </div>
   {/if}
 
-  <div class="ui:rounded-md ui:border ui:p-4 ui:space-y-3">
-    <p class="ui:text-sm ui:font-semibold">Submission Mode (12 respondents)</p>
+  <div class="space-y-3 rounded-md border p-4">
+    <p class="text-sm font-semibold">Submission Mode (12 respondents)</p>
     <ExerciseQuestion.QuestionRenderer
       showContainer={false}
       contract={{

--- a/packages/storybook/src/molecules/file-drop-zone/file-drop-zone.stories.svelte
+++ b/packages/storybook/src/molecules/file-drop-zone/file-drop-zone.stories.svelte
@@ -65,7 +65,7 @@
 
 <Story name="Default">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-md">
+    <div class="w-full max-w-md">
       <FileDropZone.Root onUpload={handleUpload} onFileRejected={handleFileRejected}>
         <FileDropZone.Trigger />
       </FileDropZone.Root>
@@ -75,7 +75,7 @@
 
 <Story name="With Limits">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-md">
+    <div class="w-full max-w-md">
       <FileDropZone.Root
         maxFiles={3}
         fileCount={0}
@@ -91,7 +91,7 @@
 
 <Story name="Images Only">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-md">
+    <div class="w-full max-w-md">
       <FileDropZone.Root accept={ACCEPT_IMAGE} onUpload={handleUpload} onFileRejected={handleFileRejected}>
         <FileDropZone.Trigger />
       </FileDropZone.Root>
@@ -101,11 +101,11 @@
 
 <Story name="With Textarea">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-md">
+    <div class="w-full max-w-md">
       <FileDropZone.Root onUpload={handleUpload} onFileRejected={handleFileRejected}>
         <FileDropZone.Textarea
           placeholder="Paste or drag and drop files here to attach to your submission..."
-          class="ui:min-h-24 ui:w-full ui:resize-none ui:rounded-md ui:border ui:border-input ui:bg-background ui:px-3 ui:py-2 ui:text-sm ui:ring-offset-background placeholder:ui:text-muted-foreground focus-visible:ui:outline-none focus-visible:ui:ring-2 focus-visible:ui:ring-ring focus-visible:ui:ring-offset-2"
+          class="ui:border-input ui:bg-background ui:ring-offset-background ui:placeholder:text-muted-foreground ui:focus-visible:ring-ring min-h-24 w-full resize-none rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         />
       </FileDropZone.Root>
     </div>

--- a/packages/storybook/src/molecules/hover-card/hover-card.stories.svelte
+++ b/packages/storybook/src/molecules/hover-card/hover-card.stories.svelte
@@ -36,7 +36,7 @@
     <HoverCard.Root>
       <HoverCard.Trigger
         href="/instructors/sarah-johnson"
-        class="ui:rounded-sm ui:underline-offset-4 ui:hover:underline ui:focus-visible:outline-2 ui:focus-visible:outline-offset-8 ui:focus-visible:outline-black ui:flex ui:items-center ui:gap-2"
+        class="flex items-center gap-2 rounded-sm underline-offset-4 hover:underline focus-visible:outline-2 focus-visible:outline-offset-8 focus-visible:outline-black"
       >
         <Avatar.Root>
           <Avatar.Image src="https://github.com/shadcn.png" />
@@ -54,7 +54,7 @@
             <p class="text-sm">Senior Full-Stack Developer & Instructor</p>
             <div class="flex items-center pt-2">
               <CalendarDaysIcon class="me-2 size-4 opacity-70" />
-              <span class="text-muted-foreground text-xs">Teaching since January 2020</span>
+              <span class="ui:text-muted-foreground text-xs">Teaching since January 2020</span>
             </div>
           </div>
         </div>
@@ -66,13 +66,13 @@
 <Story name="Course Preview">
   {#snippet template()}
     <HoverCard.Root>
-      <HoverCard.Trigger href="/courses/advanced-react" class="text-primary underline-offset-4 hover:underline">
+      <HoverCard.Trigger href="/courses/advanced-react" class="ui:text-primary underline-offset-4 hover:underline">
         Advanced React Patterns
       </HoverCard.Trigger>
       <HoverCard.Content class="w-64">
         <div class="space-y-2">
           <h4 class="text-sm font-semibold">Advanced React Patterns</h4>
-          <p class="text-muted-foreground text-sm">
+          <p class="ui:text-muted-foreground text-sm">
             Master advanced React concepts including hooks, context, performance optimization, and modern patterns used
             in production applications.
           </p>
@@ -85,7 +85,7 @@
 <Story name="Student Profile">
   {#snippet template()}
     <HoverCard.Root>
-      <HoverCard.Trigger class="text-primary ui:flex ui:items-center ui:gap-2 underline-offset-4 hover:underline">
+      <HoverCard.Trigger class="ui:text-primary flex items-center gap-2 underline-offset-4 hover:underline">
         <Avatar.Root>
           <Avatar.Image src="https://github.com/rotimi-best.png" />
           <Avatar.Fallback>AM</Avatar.Fallback>
@@ -101,15 +101,15 @@
             </Avatar.Root>
             <div>
               <h4 class="text-sm font-semibold">Alex Martinez</h4>
-              <p class="text-muted-foreground text-xs">Student</p>
+              <p class="ui:text-muted-foreground text-xs">Student</p>
             </div>
           </div>
           <div class="space-y-2">
-            <div class="text-muted-foreground flex items-center gap-2 text-xs">
+            <div class="ui:text-muted-foreground flex items-center gap-2 text-xs">
               <BookOpenIcon class="size-4" />
               <span>5 courses enrolled</span>
             </div>
-            <div class="text-muted-foreground flex items-center gap-2 text-xs">
+            <div class="ui:text-muted-foreground flex items-center gap-2 text-xs">
               <UsersIcon class="size-4" />
               <span>Active since March 2024</span>
             </div>

--- a/packages/storybook/src/molecules/icon-button/icon-button.stories.svelte
+++ b/packages/storybook/src/molecules/icon-button/icon-button.stories.svelte
@@ -56,7 +56,7 @@
 
 <Story name="Multiple Icons">
   {#snippet template()}
-    <div class="ui:flex ui:items-center ui:gap-4">
+    <div class="flex items-center gap-4">
       <IconButton tooltip="Settings">
         <SettingsIcon />
       </IconButton>
@@ -81,11 +81,11 @@
 
 <Story name="Tooltip Positions">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:items-center ui:gap-8 ui:p-8">
+    <div class="flex flex-col items-center gap-8 p-8">
       <IconButton tooltip="Top tooltip" tooltipSide="top">
         <SettingsIcon />
       </IconButton>
-      <div class="ui:flex ui:items-center ui:gap-8">
+      <div class="flex items-center gap-8">
         <IconButton tooltip="Left tooltip" tooltipSide="left">
           <SettingsIcon />
         </IconButton>

--- a/packages/storybook/src/molecules/image-cropper/image-cropper.stories.svelte
+++ b/packages/storybook/src/molecules/image-cropper/image-cropper.stories.svelte
@@ -42,7 +42,7 @@
 
 <Story name="Default">
   {#snippet template(args)}
-    <div class="ui:flex ui:flex-col ui:items-center ui:gap-4">
+    <div class="flex flex-col items-center gap-4">
       <ImageCropper.Root
         {...args}
         accept="image/*"
@@ -68,7 +68,7 @@
 
 <Story name="Square Preview">
   {#snippet template(args)}
-    <div class="ui:flex ui:flex-col ui:items-center ui:gap-4">
+    <div class="flex flex-col items-center gap-4">
       <ImageCropper.Root
         {...args}
         accept="image/*"
@@ -78,7 +78,7 @@
         }}
       >
         <ImageCropper.UploadTrigger>
-          <ImageCropper.Preview class="ui:rounded-md" />
+          <ImageCropper.Preview class="rounded-md" />
         </ImageCropper.UploadTrigger>
         <ImageCropper.Dialog>
           <ImageCropper.Cropper cropShape="rect" />
@@ -122,7 +122,7 @@
 
 <Story name="Custom Preview">
   {#snippet template(args)}
-    <div class="ui:flex ui:flex-col ui:items-center ui:gap-4">
+    <div class="flex flex-col items-center gap-4">
       <ImageCropper.Root
         src="https://github.com/shadcn.png"
         onUnsupportedFile={(file) => {
@@ -132,7 +132,7 @@
         <ImageCropper.UploadTrigger>
           <ImageCropper.Preview>
             {#snippet child({ src })}
-              <img {src} alt="your avatar" class="ui:size-32 ui:border-2 ui:border-blue-500" />
+              <img {src} alt="your avatar" class="size-32 border-2 border-blue-500" />
             {/snippet}
           </ImageCropper.Preview>
         </ImageCropper.UploadTrigger>

--- a/packages/storybook/src/molecules/input-field/input-field.stories.svelte
+++ b/packages/storybook/src/molecules/input-field/input-field.stories.svelte
@@ -29,21 +29,21 @@
 
 <Story name="Default">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputField
         label="Student Name"
         placeholder="Enter student's full name"
         bind:value={studentName}
         name="student-name"
       />
-      <p class="ui:text-sm ui:text-muted-foreground">Value: {studentName || '(empty)'}</p>
+      <p class="ui:text-muted-foreground text-sm">Value: {studentName || '(empty)'}</p>
     </div>
   {/snippet}
 </Story>
 
 <Story name="With Label and Helper">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputField
         label="Student Email"
         placeholder="student@example.com"
@@ -58,7 +58,7 @@
 
 <Story name="Required Field">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputField
         label="Course Title"
         placeholder="Introduction to Web Development"
@@ -73,7 +73,7 @@
 
 <Story name="Password Field">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <Field.Field>
         <Field.Label for="password">Password</Field.Label>
         <Field.Content>
@@ -81,14 +81,14 @@
           <Field.Description>Must be at least 8 characters long</Field.Description>
         </Field.Content>
       </Field.Field>
-      <p class="ui:text-sm ui:text-muted-foreground">Value: {password ? '•'.repeat(password.length) : '(empty)'}</p>
+      <p class="ui:text-muted-foreground text-sm">Value: {password ? '•'.repeat(password.length) : '(empty)'}</p>
     </div>
   {/snippet}
 </Story>
 
 <Story name="With Error">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputField
         label="Student Email"
         placeholder="student@example.com"
@@ -103,7 +103,7 @@
 
 <Story name="Disabled">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputField
         label="Student Email"
         placeholder="student@example.com"
@@ -119,7 +119,7 @@
 
 <Story name="Number Input">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputField
         label="Course Price"
         placeholder="0.00"
@@ -135,7 +135,7 @@
 
 <Story name="Date Input">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputField
         label="Enrollment Date"
         bind:value={enrollmentDate}
@@ -149,7 +149,7 @@
 
 <Story name="Auto Focus">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputField
         label="Course Title"
         placeholder="Introduction to Web Development"
@@ -164,15 +164,15 @@
 
 <Story name="Custom Styling">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputField
         label="Student Name"
         placeholder="Enter student's full name"
         bind:value={studentName}
         name="student-name-custom"
-        className="ui:border ui:border-primary ui:rounded-lg ui:p-4"
+        className="border ui:border-primary rounded-lg p-4"
         inputClassName="ui:bg-primary/5"
-        labelClassName="ui:font-semibold ui:text-primary"
+        labelClassName="font-semibold ui:text-primary"
       />
     </div>
   {/snippet}
@@ -180,7 +180,7 @@
 
 <Story name="Form Example">
   {#snippet template()}
-    <form class="ui:flex ui:flex-col ui:gap-4 ui:w-96" onsubmit={(e) => e.preventDefault()}>
+    <form class="flex w-96 flex-col gap-4" onsubmit={(e) => e.preventDefault()}>
       <InputField
         label="Full Name"
         placeholder="John Doe"
@@ -206,7 +206,7 @@
       </Field.Field>
       <button
         type="submit"
-        class="ui:mt-2 ui:rounded-md ui:bg-primary ui:px-4 ui:py-2 ui:text-primary-foreground ui:hover:bg-primary/90"
+        class="ui:bg-primary ui:text-primary-foreground ui:hover:bg-primary/90 mt-2 rounded-md px-4 py-2"
       >
         Enroll Student
       </button>

--- a/packages/storybook/src/molecules/input-group/input-group.stories.svelte
+++ b/packages/storybook/src/molecules/input-group/input-group.stories.svelte
@@ -101,7 +101,7 @@
 
 <Story name="Text">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputGroup.Root>
         <InputGroup.Addon align="inline-start">
           <InputGroup.Text>https://</InputGroup.Text>
@@ -135,7 +135,7 @@
 
 <Story name="Button">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputGroup.Root>
         <InputGroup.Input placeholder="https://x.com/shadcn" />
         <InputGroup.Addon align="inline-end">
@@ -159,7 +159,7 @@
 
 <Story name="Tooltip">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputGroup.Root>
         <InputGroup.Addon align="inline-start">
           <LockIcon />
@@ -236,7 +236,7 @@
 
 <Story name="Textarea">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <InputGroup.Root>
         <InputGroup.Addon align="block-start">
           <InputGroup.Text>Code</InputGroup.Text>
@@ -282,7 +282,7 @@
           <LoaderIcon class="animate-spin" />
         </InputGroup.Addon>
         <InputGroup.Addon align="inline-end">
-          <InputGroup.Text class="text-muted-foreground">Please wait...</InputGroup.Text>
+          <InputGroup.Text class="ui:text-muted-foreground">Please wait...</InputGroup.Text>
         </InputGroup.Addon>
       </InputGroup.Root>
     </div>

--- a/packages/storybook/src/molecules/mention-popover/mention-popover.stories.svelte
+++ b/packages/storybook/src/molecules/mention-popover/mention-popover.stories.svelte
@@ -50,7 +50,7 @@
       {/snippet}
     </MentionPopover>
     {#if lastSelected}
-      <p class="ui:mt-3 ui:text-muted-foreground ui:text-sm">Selected: {lastSelected}</p>
+      <p class="ui:text-muted-foreground mt-3 text-sm">Selected: {lastSelected}</p>
     {/if}
   {/snippet}
 </Story>

--- a/packages/storybook/src/molecules/multi-select-list/multi-select-list.stories.svelte
+++ b/packages/storybook/src/molecules/multi-select-list/multi-select-list.stories.svelte
@@ -34,7 +34,7 @@
 
 <Story name="Default">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-md">
+    <div class="w-full max-w-md">
       <MultiSelectList
         heading="Select items"
         emptyMessage="No items to show."
@@ -43,14 +43,14 @@
         onToggle={toggle}
         namePrefix="story-ms"
       />
-      <p class="ui:mt-3 ui:text-muted-foreground ui:text-sm">Selected: {[...selected].join(', ') || 'none'}</p>
+      <p class="ui:text-muted-foreground mt-3 text-sm">Selected: {[...selected].join(', ') || 'none'}</p>
     </div>
   {/snippet}
 </Story>
 
 <Story name="Empty">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-md">
+    <div class="w-full max-w-md">
       <MultiSelectList
         heading="Select items"
         emptyMessage="Nothing here yet."

--- a/packages/storybook/src/molecules/navigation-menu/navigation-menu.stories.svelte
+++ b/packages/storybook/src/molecules/navigation-menu/navigation-menu.stories.svelte
@@ -18,19 +18,19 @@
 
 <Story name="Default">
   {#snippet template()}
-    <NavigationMenu.Root class="ui:relative">
-      <NavigationMenu.List class="ui:flex ui:gap-2">
+    <NavigationMenu.Root class="relative">
+      <NavigationMenu.List class="flex gap-2">
         <NavigationMenu.Item>
           <NavigationMenu.Trigger>Getting started</NavigationMenu.Trigger>
           <NavigationMenu.Content>
-            <ul class="ui:grid ui:gap-3 ui:p-6 ui:md:w-[400px] ui:lg:w-[500px] ui:lg:grid-cols-[.75fr_1fr]">
-              <li class="ui:row-span-3">
+            <ul class="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
+              <li class="row-span-3">
                 <NavigationMenu.Link
                   href="/"
-                  class="ui:from-muted/50 ui:to-muted ui:flex ui:h-full ui:w-full ui:select-none ui:flex-col ui:justify-end ui:rounded-md ui:bg-gradient-to-b ui:p-6 ui:no-underline ui:outline-none ui:focus:shadow-md"
+                  class="ui:from-muted/50 ui:to-muted flex h-full w-full flex-col justify-end rounded-md bg-gradient-to-b p-6 no-underline outline-none select-none focus:shadow-md"
                 >
-                  <div class="ui:mb-2 ui:mt-4 ui:text-lg ui:font-medium">ClassroomIO</div>
-                  <p class="ui:text-muted-foreground ui:text-sm ui:leading-tight">
+                  <div class="mt-4 mb-2 text-lg font-medium">ClassroomIO</div>
+                  <p class="ui:text-muted-foreground text-sm leading-tight">
                     A powerful learning management system for creating and managing online courses.
                   </p>
                 </NavigationMenu.Link>
@@ -38,10 +38,10 @@
               <li>
                 <NavigationMenu.Link
                   href="/docs"
-                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground ui:block ui:select-none ui:space-y-1 ui:rounded-md ui:p-3 ui:leading-none ui:no-underline ui:outline-none ui:transition-colors"
+                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground block space-y-1 rounded-md p-3 leading-none no-underline transition-colors outline-none select-none"
                 >
-                  <div class="ui:text-sm ui:font-medium ui:leading-none">Introduction</div>
-                  <p class="ui:text-muted-foreground ui:line-clamp-2 ui:text-sm ui:leading-snug">
+                  <div class="text-sm leading-none font-medium">Introduction</div>
+                  <p class="ui:text-muted-foreground line-clamp-2 text-sm leading-snug">
                     Learn how to get started with ClassroomIO.
                   </p>
                 </NavigationMenu.Link>
@@ -49,10 +49,10 @@
               <li>
                 <NavigationMenu.Link
                   href="/docs/installation"
-                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground ui:block ui:select-none ui:space-y-1 ui:rounded-md ui:p-3 ui:leading-none ui:no-underline ui:outline-none ui:transition-colors"
+                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground block space-y-1 rounded-md p-3 leading-none no-underline transition-colors outline-none select-none"
                 >
-                  <div class="ui:text-sm ui:font-medium ui:leading-none">Installation</div>
-                  <p class="ui:text-muted-foreground ui:line-clamp-2 ui:text-sm ui:leading-snug">
+                  <div class="text-sm leading-none font-medium">Installation</div>
+                  <p class="ui:text-muted-foreground line-clamp-2 text-sm leading-snug">
                     How to install and configure your instance.
                   </p>
                 </NavigationMenu.Link>
@@ -60,10 +60,10 @@
               <li>
                 <NavigationMenu.Link
                   href="/docs/components"
-                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground ui:block ui:select-none ui:space-y-1 ui:rounded-md ui:p-3 ui:leading-none ui:no-underline ui:outline-none ui:transition-colors"
+                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground block space-y-1 rounded-md p-3 leading-none no-underline transition-colors outline-none select-none"
                 >
-                  <div class="ui:text-sm ui:font-medium ui:leading-none">Components</div>
-                  <p class="ui:text-muted-foreground ui:line-clamp-2 ui:text-sm ui:leading-snug">
+                  <div class="text-sm leading-none font-medium">Components</div>
+                  <p class="ui:text-muted-foreground line-clamp-2 text-sm leading-snug">
                     Explore the available UI components.
                   </p>
                 </NavigationMenu.Link>
@@ -75,14 +75,14 @@
         <NavigationMenu.Item>
           <NavigationMenu.Trigger>Features</NavigationMenu.Trigger>
           <NavigationMenu.Content>
-            <ul class="ui:grid ui:w-[400px] ui:gap-3 ui:p-4 md:ui:w-[500px] md:ui:grid-cols-2 lg:ui:w-[600px]">
+            <ul class="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px]">
               <li>
                 <NavigationMenu.Link
                   href="/courses"
-                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground ui:block ui:select-none ui:space-y-1 ui:rounded-md ui:p-3 ui:leading-none ui:no-underline ui:outline-none ui:transition-colors"
+                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground block space-y-1 rounded-md p-3 leading-none no-underline transition-colors outline-none select-none"
                 >
-                  <div class="ui:text-sm ui:font-medium ui:leading-none">Course Management</div>
-                  <p class="ui:text-muted-foreground ui:line-clamp-2 ui:text-sm ui:leading-snug">
+                  <div class="text-sm leading-none font-medium">Course Management</div>
+                  <p class="ui:text-muted-foreground line-clamp-2 text-sm leading-snug">
                     Create and organize your courses with ease.
                   </p>
                 </NavigationMenu.Link>
@@ -90,10 +90,10 @@
               <li>
                 <NavigationMenu.Link
                   href="/students"
-                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground ui:block ui:select-none ui:space-y-1 ui:rounded-md ui:p-3 ui:leading-none ui:no-underline ui:outline-none ui:transition-colors"
+                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground block space-y-1 rounded-md p-3 leading-none no-underline transition-colors outline-none select-none"
                 >
-                  <div class="ui:text-sm ui:font-medium ui:leading-none">Student Tracking</div>
-                  <p class="ui:text-muted-foreground ui:line-clamp-2 ui:text-sm ui:leading-snug">
+                  <div class="text-sm leading-none font-medium">Student Tracking</div>
+                  <p class="ui:text-muted-foreground line-clamp-2 text-sm leading-snug">
                     Monitor student progress and performance.
                   </p>
                 </NavigationMenu.Link>
@@ -101,10 +101,10 @@
               <li>
                 <NavigationMenu.Link
                   href="/assessments"
-                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground ui:block ui:select-none ui:space-y-1 ui:rounded-md ui:p-3 ui:leading-none ui:no-underline ui:outline-none ui:transition-colors"
+                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground block space-y-1 rounded-md p-3 leading-none no-underline transition-colors outline-none select-none"
                 >
-                  <div class="ui:text-sm ui:font-medium ui:leading-none">Assessments</div>
-                  <p class="ui:text-muted-foreground ui:line-clamp-2 ui:text-sm ui:leading-snug">
+                  <div class="text-sm leading-none font-medium">Assessments</div>
+                  <p class="ui:text-muted-foreground line-clamp-2 text-sm leading-snug">
                     Create quizzes, assignments, and exams.
                   </p>
                 </NavigationMenu.Link>
@@ -112,10 +112,10 @@
               <li>
                 <NavigationMenu.Link
                   href="/analytics"
-                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground ui:block ui:select-none ui:space-y-1 ui:rounded-md ui:p-3 ui:leading-none ui:no-underline ui:outline-none ui:transition-colors"
+                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground block space-y-1 rounded-md p-3 leading-none no-underline transition-colors outline-none select-none"
                 >
-                  <div class="ui:text-sm ui:font-medium ui:leading-none">Analytics</div>
-                  <p class="ui:text-muted-foreground ui:line-clamp-2 ui:text-sm ui:leading-snug">
+                  <div class="text-sm leading-none font-medium">Analytics</div>
+                  <p class="ui:text-muted-foreground line-clamp-2 text-sm leading-snug">
                     View detailed analytics and reports.
                   </p>
                 </NavigationMenu.Link>
@@ -123,10 +123,10 @@
               <li>
                 <NavigationMenu.Link
                   href="/collaboration"
-                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground ui:block ui:select-none ui:space-y-1 ui:rounded-md ui:p-3 ui:leading-none ui:no-underline ui:outline-none ui:transition-colors"
+                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground block space-y-1 rounded-md p-3 leading-none no-underline transition-colors outline-none select-none"
                 >
-                  <div class="ui:text-sm ui:font-medium ui:leading-none">Collaboration</div>
-                  <p class="ui:text-muted-foreground ui:line-clamp-2 ui:text-sm ui:leading-snug">
+                  <div class="text-sm leading-none font-medium">Collaboration</div>
+                  <p class="ui:text-muted-foreground line-clamp-2 text-sm leading-snug">
                     Enable team collaboration and discussions.
                   </p>
                 </NavigationMenu.Link>
@@ -134,10 +134,10 @@
               <li>
                 <NavigationMenu.Link
                   href="/integrations"
-                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground ui:block ui:select-none ui:space-y-1 ui:rounded-md ui:p-3 ui:leading-none ui:no-underline ui:outline-none ui:transition-colors"
+                  class="ui:hover:bg-accent ui:hover:text-accent-foreground ui:focus:bg-accent ui:focus:text-accent-foreground block space-y-1 rounded-md p-3 leading-none no-underline transition-colors outline-none select-none"
                 >
-                  <div class="ui:text-sm ui:font-medium ui:leading-none">Integrations</div>
-                  <p class="ui:text-muted-foreground ui:line-clamp-2 ui:text-sm ui:leading-snug">
+                  <div class="text-sm leading-none font-medium">Integrations</div>
+                  <p class="ui:text-muted-foreground line-clamp-2 text-sm leading-snug">
                     Connect with your favorite tools.
                   </p>
                 </NavigationMenu.Link>

--- a/packages/storybook/src/molecules/newsfeed-reactions/newsfeed-reactions.stories.svelte
+++ b/packages/storybook/src/molecules/newsfeed-reactions/newsfeed-reactions.stories.svelte
@@ -70,7 +70,7 @@
 
 <Story name="Summary">
   {#snippet template()}
-    <div class="ui:w-[360px] ui:rounded-2xl ui:border ui:bg-background ui:p-4">
+    <div class="ui:bg-background w-[360px] rounded-2xl border p-4">
       <NewsfeedReactions reactionCounts={summaryReactionCounts} selectedReactionType={summarySelectedReaction} />
     </div>
   {/snippet}
@@ -78,7 +78,7 @@
 
 <Story name="Popover Open">
   {#snippet template()}
-    <div class="ui:w-[360px] ui:rounded-2xl ui:border ui:bg-background ui:p-4">
+    <div class="ui:bg-background w-[360px] rounded-2xl border p-4">
       <NewsfeedReactions
         bind:open={openPopover}
         reactionCounts={openReactionCounts}
@@ -90,7 +90,7 @@
 
 <Story name="Interactive">
   {#snippet template()}
-    <div class="ui:w-[360px] ui:rounded-2xl ui:border ui:bg-background ui:p-4">
+    <div class="ui:bg-background w-[360px] rounded-2xl border p-4">
       <NewsfeedReactions
         bind:open={interactivePopover}
         reactionCounts={interactiveReactionCounts}
@@ -104,7 +104,7 @@
           interactiveSelectedReaction = interactiveSelectedReaction === reactionType ? null : reactionType;
         }}
       />
-      <p class="ui:mt-3 ui:text-sm ui:text-muted-foreground">
+      <p class="ui:text-muted-foreground mt-3 text-sm">
         Click the trigger, pick a reaction, then click the active reaction again to clear it.
       </p>
     </div>

--- a/packages/storybook/src/molecules/page/page.stories.svelte
+++ b/packages/storybook/src/molecules/page/page.stories.svelte
@@ -399,7 +399,7 @@
         {#snippet child()}
           <div class="space-y-4">
             {#each Array.from({ length: 8 }) as _, index (index)}
-              <div class="text-muted-foreground rounded-lg border border-dashed p-6 text-sm">
+              <div class="ui:text-muted-foreground rounded-lg border border-dashed p-6 text-sm">
                 Settings section {index + 1}
               </div>
             {/each}
@@ -428,7 +428,7 @@
       </Page.Header>
       <Page.Body>
         {#snippet child()}
-          <div class="text-muted-foreground rounded-lg border border-dashed p-6 text-sm">
+          <div class="ui:text-muted-foreground rounded-lg border border-dashed p-6 text-sm">
             All changes saved. The compact save card stays hidden until the form is dirty.
           </div>
         {/snippet}

--- a/packages/storybook/src/molecules/password/password.stories.svelte
+++ b/packages/storybook/src/molecules/password/password.stories.svelte
@@ -22,16 +22,16 @@
 
 <Story name="Default">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <Password bind:value={password} placeholder="Enter password" />
-      <p class="ui:text-sm ui:text-muted-foreground">Value: {password || '(empty)'}</p>
+      <p class="ui:text-muted-foreground text-sm">Value: {password || '(empty)'}</p>
     </div>
   {/snippet}
 </Story>
 
 <Story name="With Field">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <Field.Field>
         <Field.Label for="password">Password</Field.Label>
         <Field.Content>
@@ -45,7 +45,7 @@
 
 <Story name="With Error">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <Field.Field>
         <Field.Label for="password-error">Password</Field.Label>
         <Field.Content>
@@ -64,7 +64,7 @@
 
 <Story name="Disabled">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <Field.Field>
         <Field.Label for="password-disabled">Password</Field.Label>
         <Field.Content>
@@ -82,7 +82,7 @@
 
 <Story name="Custom Labels">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <Password
         bind:value={password}
         placeholder="Enter your password"

--- a/packages/storybook/src/molecules/pricing-card/pricing-card.stories.svelte
+++ b/packages/storybook/src/molecules/pricing-card/pricing-card.stories.svelte
@@ -103,7 +103,7 @@
 
 <Story name="Basic Plan">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <PricingCard
         plan={BASIC_PLAN}
         planName="BASIC"
@@ -118,7 +118,7 @@
 
 <Story name="Early Adopter Plan (Popular)">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <PricingCard
         plan={EARLY_ADOPTER_PLAN}
         planName="EARLY_ADOPTER"
@@ -133,7 +133,7 @@
 
 <Story name="Enterprise Plan">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <PricingCard
         plan={ENTERPRISE_PLAN}
         planName="ENTERPRISE"
@@ -148,7 +148,7 @@
 
 <Story name="Monthly Pricing">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <PricingCard
         plan={EARLY_ADOPTER_PLAN}
         planName="EARLY_ADOPTER"
@@ -163,7 +163,7 @@
 
 <Story name="Yearly Pricing">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <PricingCard
         plan={EARLY_ADOPTER_PLAN}
         planName="EARLY_ADOPTER"
@@ -178,7 +178,7 @@
 
 <Story name="Loading State">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <PricingCard
         plan={EARLY_ADOPTER_PLAN}
         planName="EARLY_ADOPTER"
@@ -193,7 +193,7 @@
 
 <Story name="Custom Labels">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <PricingCard
         plan={EARLY_ADOPTER_PLAN}
         planName="EARLY_ADOPTER"
@@ -210,7 +210,7 @@
 
 <Story name="All Plans Comparison">
   {#snippet template()}
-    <div class="ui:grid ui:grid-cols-1 ui:gap-6 md:ui:grid-cols-3 ui:p-4">
+    <div class="grid grid-cols-1 gap-6 p-4 md:grid-cols-3">
       <PricingCard
         plan={BASIC_PLAN}
         planName="BASIC"
@@ -241,10 +241,10 @@
 
 <Story name="Monthly vs Yearly Toggle">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-6 ui:p-4">
-      <div class="ui:flex ui:items-center ui:justify-center ui:gap-4">
+    <div class="flex flex-col gap-6 p-4">
+      <div class="flex items-center justify-center gap-4">
         <button
-          class="ui:rounded-md ui:bg-primary ui:px-4 ui:py-2 ui:text-primary-foreground ui:hover:bg-primary/90"
+          class="ui:bg-primary ui:text-primary-foreground ui:hover:bg-primary/90 rounded-md px-4 py-2"
           onclick={() => {
             const isYearly = $state.snapshot(isYearlyPlan);
             isYearlyPlan = !isYearly;
@@ -252,11 +252,11 @@
         >
           Toggle to {isYearlyPlan ? 'Monthly' : 'Yearly'}
         </button>
-        <span class="ui:text-sm ui:text-muted-foreground">
+        <span class="ui:text-muted-foreground text-sm">
           Current: {isYearlyPlan ? 'Yearly' : 'Monthly'}
         </span>
       </div>
-      <div class="ui:grid ui:grid-cols-1 ui:gap-6 md:ui:grid-cols-3">
+      <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
         <PricingCard
           plan={BASIC_PLAN}
           planName="BASIC"
@@ -288,7 +288,7 @@
 
 <Story name="Website Version">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <PricingCard
         plan={BASIC_PLAN}
         planName="BASIC"
@@ -299,16 +299,14 @@
         ctaLabel="Signup Now"
         isDisabled={false}
       />
-      <p class="ui:text-sm ui:text-muted-foreground ui:text-center">
-        Website version uses "Signup Now" and is enabled.
-      </p>
+      <p class="ui:text-muted-foreground text-center text-sm">Website version uses "Signup Now" and is enabled.</p>
     </div>
   {/snippet}
 </Story>
 
 <Story name="Disabled CTA">
   {#snippet template()}
-    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+    <div class="flex w-96 flex-col gap-4">
       <PricingCard
         plan={BASIC_PLAN}
         planName="BASIC"
@@ -317,7 +315,7 @@
         {isLoadingPlan}
         {handleClick}
       />
-      <p class="ui:text-sm ui:text-muted-foreground ui:text-center">The CTA button is disabled (current plan)</p>
+      <p class="ui:text-muted-foreground text-center text-sm">The CTA button is disabled (current plan)</p>
     </div>
   {/snippet}
 </Story>

--- a/packages/storybook/src/molecules/public-course/public-course.stories.svelte
+++ b/packages/storybook/src/molecules/public-course/public-course.stories.svelte
@@ -100,7 +100,7 @@
 
 <Story name="Sidebar · states only">
   {#snippet template()}
-    <div class="ui:mx-auto ui:max-w-xs ui:border-r ui:border-border">
+    <div class="ui:border-border mx-auto max-w-xs border-r">
       <PublicCourse.PublicCourseSidebar sections={SIDEBAR_FIXTURE} activeSlug="hallucination-and-limitations" />
     </div>
   {/snippet}
@@ -161,31 +161,29 @@
 
 <Story name="Callout · inline + full variants">
   {#snippet template()}
-    <div class="ui:mx-auto ui:max-w-2xl ui:space-y-8 ui:p-8">
+    <div class="mx-auto max-w-2xl space-y-8 p-8">
       <div>
-        <h3 class="ui:mb-2 ui:text-sm ui:font-semibold ui:text-muted-foreground">Inline · waves (default)</h3>
+        <h3 class="ui:text-muted-foreground mb-2 text-sm font-semibold">Inline · waves (default)</h3>
         <PublicCourse.PublicCourseCallout callout={CALLOUT_FIXTURE} variant="inline" animation="waves" />
       </div>
       <div>
-        <h3 class="ui:mb-2 ui:text-sm ui:font-semibold ui:text-muted-foreground">Inline · dotted</h3>
+        <h3 class="ui:text-muted-foreground mb-2 text-sm font-semibold">Inline · dotted</h3>
         <PublicCourse.PublicCourseCallout callout={CALLOUT_FIXTURE} variant="inline" animation="dotted" />
       </div>
       <div>
-        <h3 class="ui:mb-2 ui:text-sm ui:font-semibold ui:text-muted-foreground">
-          Full (locked item replacement) · waves
-        </h3>
+        <h3 class="ui:text-muted-foreground mb-2 text-sm font-semibold">Full (locked item replacement) · waves</h3>
         <PublicCourse.PublicCourseCallout callout={CALLOUT_FIXTURE} variant="full" animation="waves" />
       </div>
       <div>
-        <h3 class="ui:mb-2 ui:text-sm ui:font-semibold ui:text-muted-foreground">Full · dotted</h3>
+        <h3 class="ui:text-muted-foreground mb-2 text-sm font-semibold">Full · dotted</h3>
         <PublicCourse.PublicCourseCallout callout={CALLOUT_FIXTURE} variant="full" animation="dotted" />
       </div>
       <div>
-        <h3 class="ui:mb-2 ui:text-sm ui:font-semibold ui:text-muted-foreground">Inline · none (no motion)</h3>
+        <h3 class="ui:text-muted-foreground mb-2 text-sm font-semibold">Inline · none (no motion)</h3>
         <PublicCourse.PublicCourseCallout callout={CALLOUT_FIXTURE} variant="inline" animation="none" />
       </div>
       <div>
-        <h3 class="ui:mb-2 ui:text-sm ui:font-semibold ui:text-muted-foreground">Full (no callout configured)</h3>
+        <h3 class="ui:text-muted-foreground mb-2 text-sm font-semibold">Full (no callout configured)</h3>
         <PublicCourse.PublicCourseCallout callout={null} variant="full" />
       </div>
     </div>

--- a/packages/storybook/src/molecules/question-type-picker/question-type-picker.stories.svelte
+++ b/packages/storybook/src/molecules/question-type-picker/question-type-picker.stories.svelte
@@ -20,7 +20,7 @@
 
 <Story name="Default">
   {#snippet template()}
-    <div class="ui:max-w-5xl">
+    <div class="max-w-5xl">
       <QuestionTypePicker />
     </div>
   {/snippet}

--- a/packages/storybook/src/molecules/radio-option-card/radio-option-card.stories.svelte
+++ b/packages/storybook/src/molecules/radio-option-card/radio-option-card.stories.svelte
@@ -75,76 +75,71 @@
 
 <Story name="Course Type Selector (Group)">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-xl">
-      <Field.Description class="ui:mb-4 ui:block">
-        Choose how your course will be delivered to students.
-      </Field.Description>
+    <div class="w-full max-w-xl">
+      <Field.Description class="mb-4 block">Choose how your course will be delivered to students.</Field.Description>
       <RadioOptionCardGroup options={courseTypeOptions} bind:value={courseType} />
-      <p class="ui:mt-3 ui:text-muted-foreground ui:text-sm">Selected: {courseType}</p>
+      <p class="ui:text-muted-foreground mt-3 text-sm">Selected: {courseType}</p>
     </div>
   {/snippet}
 </Story>
 
 <Story name="Add Content Type (Group, 3 columns)">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-2xl">
-      <Field.Description class="ui:mb-4 ui:block">
+    <div class="w-full max-w-2xl">
+      <Field.Description class="mb-4 block">
         Add a new item to your course. Sections group lessons and exercises.
       </Field.Description>
-      <RadioOptionCardGroup options={contentTypeOptions} bind:value={contentType} class="ui:md:grid-cols-3" />
-      <p class="ui:mt-3 ui:text-muted-foreground ui:text-sm">Selected: {contentType}</p>
+      <RadioOptionCardGroup options={contentTypeOptions} bind:value={contentType} class="md:grid-cols-3" />
+      <p class="ui:text-muted-foreground mt-3 text-sm">Selected: {contentType}</p>
     </div>
   {/snippet}
 </Story>
 
 <Story name="With Disabled Option and Title Suffix (Group)">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-xl">
-      <Field.Description class="ui:mb-4 ui:block">
+    <div class="w-full max-w-xl">
+      <Field.Description class="mb-4 block">
         How would you like to create your exercise? Use the <code>titleSuffix(option)</code> snippet to render per-option
         content (e.g. Coming soon for disabled).
       </Field.Description>
       <RadioOptionCardGroup options={exerciseCreateOptions} bind:value={exerciseCreateType}>
         {#snippet titleSuffix(option)}
           {#if option.disabled}
-            <Badge variant="secondary" class="ui:text-xs">Coming soon</Badge>
+            <Badge variant="secondary" class="text-xs">Coming soon</Badge>
           {/if}
         {/snippet}
       </RadioOptionCardGroup>
-      <p class="ui:mt-3 ui:text-muted-foreground ui:text-sm">Selected: {exerciseCreateType}</p>
+      <p class="ui:text-muted-foreground mt-3 text-sm">Selected: {exerciseCreateType}</p>
     </div>
   {/snippet}
 </Story>
 
 <Story name="Custom Columns (Group class override)">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-3xl">
-      <Field.Description class="ui:mb-4 ui:block">
+    <div class="w-full max-w-3xl">
+      <Field.Description class="mb-4 block">
         Override grid with the <code>class</code> prop on <code>RadioOptionCardGroup</code> (uses <code>cn</code> so your
         classes win).
       </Field.Description>
       <RadioOptionCardGroup
         options={deliveryOptions}
         bind:value={deliveryMethod}
-        class="ui:grid-cols-1 ui:sm:grid-cols-2 ui:lg:grid-cols-4"
+        class="grid-cols-1 sm:grid-cols-2 lg:grid-cols-4"
       />
-      <p class="ui:mt-3 ui:text-muted-foreground ui:text-sm">Selected: {deliveryMethod}</p>
+      <p class="ui:text-muted-foreground mt-3 text-sm">Selected: {deliveryMethod}</p>
     </div>
   {/snippet}
 </Story>
 
 <Story name="Individual cards (card class prop)">
   {#snippet template()}
-    <div class="ui:w-full ui:max-w-3xl">
-      <Field.Description class="ui:mb-4 ui:block">
+    <div class="w-full max-w-3xl">
+      <Field.Description class="mb-4 block">
         When using <code>RadioOptionCard</code> inside <code>RadioGroup.Root</code>, override per card with the card
         <code>class</code>
-        prop (e.g. <code>ui:lg:col-span-2</code>).
+        prop (e.g. <code>lg:col-span-2</code>).
       </Field.Description>
-      <RadioGroup.Root
-        bind:value={deliveryMethod}
-        class="ui:grid ui:gap-3 ui:grid-cols-1 ui:sm:grid-cols-2 ui:lg:grid-cols-4"
-      >
+      <RadioGroup.Root bind:value={deliveryMethod} class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <RadioOptionCard id="live" title="Live" description="Real-time sessions with your students." value="live" />
         <RadioOptionCard
           id="async"
@@ -158,10 +153,10 @@
           title="On-demand"
           description="Fully self-paced, no fixed schedule."
           value="ondemand"
-          class="ui:lg:col-span-2"
+          class="lg:col-span-2"
         />
       </RadioGroup.Root>
-      <p class="ui:mt-3 ui:text-muted-foreground ui:text-sm">Selected: {deliveryMethod}</p>
+      <p class="ui:text-muted-foreground mt-3 text-sm">Selected: {deliveryMethod}</p>
     </div>
   {/snippet}
 </Story>

--- a/packages/storybook/src/molecules/resource-list-row/resource-list-row.stories.svelte
+++ b/packages/storybook/src/molecules/resource-list-row/resource-list-row.stories.svelte
@@ -112,34 +112,34 @@
     ]}
     <ResourceListRow.Group class="@container w-full">
       {#each sampleCourses as course (course.title)}
-        <ResourceListRow.Root variant="default" align="start" class="ui:cursor-pointer ui:py-3">
+        <ResourceListRow.Root variant="default" align="start" class="cursor-pointer py-3">
           <div
-            class="ui:grid ui:w-full ui:items-start grid-cols-1 gap-x-3 gap-y-2 @3xl:grid-cols-[var(--row-cols)]"
+            class="grid w-full grid-cols-1 items-start gap-x-3 gap-y-2 @3xl:grid-cols-[var(--row-cols)]"
             style="--row-cols: 2fr 5.5rem 2fr 4.5rem 6rem 2.5rem"
           >
             <!-- Title -->
-            <div class="ui:flex ui:min-w-0 ui:flex-col ui:gap-0.5">
-              <p class="ui:line-clamp-1 ui:font-semibold ui:text-sm">{course.title}</p>
-              <p class="ui:text-muted-foreground ui:mt-0.5 ui:text-sm">{course.type}</p>
-              <p class="ui:text-muted-foreground ui:mt-0.5 ui:text-xs">{course.lastUpdated}</p>
+            <div class="flex min-w-0 flex-col gap-0.5">
+              <p class="line-clamp-1 text-sm font-semibold">{course.title}</p>
+              <p class="ui:text-muted-foreground mt-0.5 text-sm">{course.type}</p>
+              <p class="ui:text-muted-foreground mt-0.5 text-xs">{course.lastUpdated}</p>
             </div>
 
             <!-- Published -->
             <div>
               {#if course.published}
-                <Badge variant="success" class="ui:whitespace-nowrap">Published</Badge>
+                <Badge variant="success" class="whitespace-nowrap">Published</Badge>
               {:else}
-                <Badge variant="secondary" class="ui:whitespace-nowrap">Draft</Badge>
+                <Badge variant="secondary" class="whitespace-nowrap">Draft</Badge>
               {/if}
             </div>
 
             <!-- Tags -->
-            <div class="ui:flex ui:min-w-0 ui:flex-wrap ui:items-center ui:gap-1">
+            <div class="flex min-w-0 flex-wrap items-center gap-1">
               {#if course.tags.length === 0}
-                <span class="ui:text-muted-foreground ui:text-xs">—</span>
+                <span class="ui:text-muted-foreground text-xs">—</span>
               {:else}
                 {#each course.tags.slice(0, 3) as tag (tag)}
-                  <Badge variant="outline" class="ui:max-w-[140px] ui:truncate">{tag}</Badge>
+                  <Badge variant="outline" class="max-w-[140px] truncate">{tag}</Badge>
                 {/each}
                 {#if course.tags.length > 3}
                   <Badge variant="secondary" class="shrink-0 tabular-nums">+{course.tags.length - 3}</Badge>
@@ -148,14 +148,14 @@
             </div>
 
             <!-- Lessons / exercises -->
-            <div class="ui:flex ui:flex-col ui:gap-1 ui:tabular-nums">
-              <p class="ui:flex ui:items-center ui:gap-1.5 ui:text-sm" aria-label="{course.lessons} lessons">
-                <BookOpenIcon class="ui:text-muted-foreground ui:size-3.5 ui:shrink-0" aria-hidden="true" />
-                <span class="ui:font-medium">{course.lessons}</span>
+            <div class="flex flex-col gap-1 tabular-nums">
+              <p class="flex items-center gap-1.5 text-sm" aria-label="{course.lessons} lessons">
+                <BookOpenIcon class="ui:text-muted-foreground size-3.5 shrink-0" aria-hidden="true" />
+                <span class="font-medium">{course.lessons}</span>
               </p>
-              <p class="ui:flex ui:items-center ui:gap-1.5 ui:text-sm" aria-label="{course.exercises} exercises">
-                <ListChecksIcon class="ui:text-muted-foreground ui:size-3.5 ui:shrink-0" aria-hidden="true" />
-                <span class="ui:font-medium">{course.exercises}</span>
+              <p class="flex items-center gap-1.5 text-sm" aria-label="{course.exercises} exercises">
+                <ListChecksIcon class="ui:text-muted-foreground size-3.5 shrink-0" aria-hidden="true" />
+                <span class="font-medium">{course.exercises}</span>
               </p>
             </div>
 
@@ -165,30 +165,30 @@
                 <div class="flex -space-x-2">
                   {#each studentAvatarSrc as src, index (src)}
                     {#if index < Math.min(2, course.students)}
-                      <Avatar.Root class="ui:size-6 ui:border-2 ui:border-background">
+                      <Avatar.Root class="ui:border-background size-6 border-2">
                         <Avatar.Image {src} alt="" />
                         <Avatar.Fallback>?</Avatar.Fallback>
                       </Avatar.Root>
                     {/if}
                   {/each}
                   {#if course.students > 2}
-                    <Avatar.Root class="ui:size-6 ui:border-2 ui:border-background">
-                      <Avatar.Fallback class="ui:text-[10px]">+{course.students - 2}</Avatar.Fallback>
+                    <Avatar.Root class="ui:border-background size-6 border-2">
+                      <Avatar.Fallback class="text-[10px]">+{course.students - 2}</Avatar.Fallback>
                     </Avatar.Root>
                   {/if}
                 </div>
               {:else}
-                <Avatar.Root class="ui:size-6">
+                <Avatar.Root class="size-6">
                   <Avatar.Fallback>
-                    <UserIcon class="ui:size-3 ui:text-muted-foreground" />
+                    <UserIcon class="ui:text-muted-foreground size-3" />
                   </Avatar.Fallback>
                 </Avatar.Root>
-                <p class="ui:text-xs">0</p>
+                <p class="text-xs">0</p>
               {/if}
             </div>
 
             <!-- Actions -->
-            <div class="ui:flex ui:justify-end">
+            <div class="flex justify-end">
               <DropdownMenu.Root>
                 <DropdownMenu.Trigger>
                   {#snippet child({ props })}
@@ -196,11 +196,11 @@
                       {...props}
                       variant="ghost"
                       size="icon"
-                      class="ui:size-8"
+                      class="size-8"
                       aria-label="Course actions"
                       onclick={(e) => e.stopPropagation()}
                     >
-                      <EllipsisVerticalIcon class="ui:size-4" />
+                      <EllipsisVerticalIcon class="size-4" />
                     </Button>
                   {/snippet}
                 </DropdownMenu.Trigger>
@@ -227,14 +227,14 @@
           <Checkbox.Root aria-label="Select all domains" />
         </ResourceListRow.Lead>
         <ResourceListRow.Main>
-          <span class="ui:text-sm ui:font-semibold">Select all</span>
+          <span class="text-sm font-semibold">Select all</span>
         </ResourceListRow.Main>
         <Item.Actions>
           <DropdownMenu.Root>
             <DropdownMenu.Trigger>
               {#snippet child({ props })}
-                <Button {...props} variant="ghost" size="icon" class="ui:size-8" aria-label="Bulk actions">
-                  <MoreHorizontalIcon class="ui:size-4" />
+                <Button {...props} variant="ghost" size="icon" class="size-8" aria-label="Bulk actions">
+                  <MoreHorizontalIcon class="size-4" />
                 </Button>
               {/snippet}
             </DropdownMenu.Trigger>
@@ -249,22 +249,22 @@
           <Checkbox.Root aria-label="Select fastlearner.io" />
         </ResourceListRow.Lead>
         <ResourceListRow.Main>
-          <Item.Title class="ui:font-semibold">fastlearner.io</Item.Title>
-          <p class="ui:flex ui:items-center ui:gap-1.5 ui:text-sm ui:text-amber-800 dark:ui:text-amber-200">
-            <ClockIcon class="ui:size-3.5 ui:shrink-0" />
+          <Item.Title class="font-semibold">fastlearner.io</Item.Title>
+          <p class="flex items-center gap-1.5 text-sm text-amber-800 dark:text-amber-200">
+            <ClockIcon class="size-3.5 shrink-0" />
             Expires 16 Jan 2027
           </p>
         </ResourceListRow.Main>
         <ResourceListRow.End>
-          <span class="ui:text-muted-foreground ui:text-sm">Jan 16</span>
-          <Avatar.Root class="ui:size-8">
+          <span class="ui:text-muted-foreground text-sm">Jan 16</span>
+          <Avatar.Root class="size-8">
             <Avatar.Image src="https://github.com/shadcn.png" alt="" />
             <Avatar.Fallback>CN</Avatar.Fallback>
           </Avatar.Root>
         </ResourceListRow.End>
         <Item.Actions>
-          <Button variant="ghost" size="icon" class="ui:size-8" aria-label="Row actions">
-            <MoreHorizontalIcon class="ui:size-4" />
+          <Button variant="ghost" size="icon" class="size-8" aria-label="Row actions">
+            <MoreHorizontalIcon class="size-4" />
           </Button>
         </Item.Actions>
       </ResourceListRow.Root>
@@ -273,19 +273,19 @@
           <Checkbox.Root aria-label="Select macusaone.com" />
         </ResourceListRow.Lead>
         <ResourceListRow.Main>
-          <Item.Title class="ui:font-semibold">macusaone.com</Item.Title>
-          <p class="ui:text-muted-foreground ui:text-sm">Third Party</p>
+          <Item.Title class="font-semibold">macusaone.com</Item.Title>
+          <p class="ui:text-muted-foreground text-sm">Third Party</p>
         </ResourceListRow.Main>
         <ResourceListRow.End>
-          <span class="ui:text-muted-foreground ui:text-sm">11/20/25</span>
-          <Avatar.Root class="ui:size-8">
+          <span class="ui:text-muted-foreground text-sm">11/20/25</span>
+          <Avatar.Root class="size-8">
             <Avatar.Image src="https://github.com/maxleiter.png" alt="" />
             <Avatar.Fallback>ML</Avatar.Fallback>
           </Avatar.Root>
         </ResourceListRow.End>
         <Item.Actions>
-          <Button variant="ghost" size="icon" class="ui:size-8" aria-label="Row actions">
-            <MoreHorizontalIcon class="ui:size-4" />
+          <Button variant="ghost" size="icon" class="size-8" aria-label="Row actions">
+            <MoreHorizontalIcon class="size-4" />
           </Button>
         </Item.Actions>
       </ResourceListRow.Root>
@@ -298,40 +298,40 @@
     <ResourceListRow.Group class="w-3xl!">
       <ResourceListRow.Root>
         <ResourceListRow.Main>
-          <Item.Title class="ui:font-semibold">fastlearner.io</Item.Title>
-          <p class="ui:flex ui:items-center ui:gap-1.5 ui:text-sm ui:text-amber-800 dark:ui:text-amber-200">
-            <ClockIcon class="ui:size-3.5 ui:shrink-0" />
+          <Item.Title class="font-semibold">fastlearner.io</Item.Title>
+          <p class="flex items-center gap-1.5 text-sm text-amber-800 dark:text-amber-200">
+            <ClockIcon class="size-3.5 shrink-0" />
             Expires 16 Jan 2027
           </p>
         </ResourceListRow.Main>
         <ResourceListRow.End>
-          <span class="ui:text-muted-foreground ui:text-sm">Jan 16</span>
-          <Avatar.Root class="ui:size-8">
+          <span class="ui:text-muted-foreground text-sm">Jan 16</span>
+          <Avatar.Root class="size-8">
             <Avatar.Image src="https://github.com/shadcn.png" alt="" />
             <Avatar.Fallback>CN</Avatar.Fallback>
           </Avatar.Root>
         </ResourceListRow.End>
         <Item.Actions>
-          <Button variant="ghost" size="icon" class="ui:size-8" aria-label="Row actions">
-            <MoreHorizontalIcon class="ui:size-4" />
+          <Button variant="ghost" size="icon" class="size-8" aria-label="Row actions">
+            <MoreHorizontalIcon class="size-4" />
           </Button>
         </Item.Actions>
       </ResourceListRow.Root>
       <ResourceListRow.Root>
         <ResourceListRow.Main>
-          <Item.Title class="ui:font-semibold">macusaone.com</Item.Title>
-          <p class="ui:text-muted-foreground ui:text-sm">Third Party</p>
+          <Item.Title class="font-semibold">macusaone.com</Item.Title>
+          <p class="ui:text-muted-foreground text-sm">Third Party</p>
         </ResourceListRow.Main>
         <ResourceListRow.End>
-          <span class="ui:text-muted-foreground ui:text-sm">11/20/25</span>
-          <Avatar.Root class="ui:size-8">
+          <span class="ui:text-muted-foreground text-sm">11/20/25</span>
+          <Avatar.Root class="size-8">
             <Avatar.Image src="https://github.com/maxleiter.png" alt="" />
             <Avatar.Fallback>ML</Avatar.Fallback>
           </Avatar.Root>
         </ResourceListRow.End>
         <Item.Actions>
-          <Button variant="ghost" size="icon" class="ui:size-8" aria-label="Row actions">
-            <MoreHorizontalIcon class="ui:size-4" />
+          <Button variant="ghost" size="icon" class="size-8" aria-label="Row actions">
+            <MoreHorizontalIcon class="size-4" />
           </Button>
         </Item.Actions>
       </ResourceListRow.Root>
@@ -341,19 +341,19 @@
 
 <Story name="Density">
   {#snippet template()}
-    <div class="ui:text-muted-foreground ui:mb-3 ui:w-full ui:max-w-md ui:text-xs">
+    <div class="ui:text-muted-foreground mb-3 w-full max-w-md text-xs">
       Use rows inside <code>ResourceListGroup</code>. Optional <code>density=&quot;toolbar&quot;</code> shortens the row
       for a “select all” header.
     </div>
     <ResourceListRow.Group class="max-w-md">
       <ResourceListRow.Root density="default">
         <ResourceListRow.Main>
-          <span class="ui:text-sm ui:font-medium">density=&quot;default&quot;</span>
+          <span class="text-sm font-medium">density=&quot;default&quot;</span>
         </ResourceListRow.Main>
       </ResourceListRow.Root>
       <ResourceListRow.Root density="toolbar">
         <ResourceListRow.Main>
-          <span class="ui:text-sm ui:font-medium">density=&quot;toolbar&quot;</span>
+          <span class="text-sm font-medium">density=&quot;toolbar&quot;</span>
         </ResourceListRow.Main>
       </ResourceListRow.Root>
     </ResourceListRow.Group>
@@ -363,85 +363,79 @@
 <Story name="DeploymentStyle">
   {#snippet template()}
     <ResourceListRow.Group class="w-5xl">
-      <ResourceListRow.Root align="start" class="ui:py-3">
-        <ResourceListRow.Main class="ui:max-w-[140px]">
-          <span class="ui:font-mono ui:text-sm ui:font-semibold">2CSQFANmQ</span>
-          <button
-            type="button"
-            class="ui:text-primary ui:w-fit ui:text-left ui:text-xs ui:underline ui:underline-offset-2"
-          >
+      <ResourceListRow.Root align="start" class="py-3">
+        <ResourceListRow.Main class="max-w-[140px]">
+          <span class="font-mono text-sm font-semibold">2CSQFANmQ</span>
+          <button type="button" class="ui:text-primary w-fit text-left text-xs underline underline-offset-2">
             Preview
           </button>
         </ResourceListRow.Main>
-        <div class="ui:flex ui:min-w-0 ui:shrink-0 ui:items-center ui:gap-2 ui:px-2">
-          <span class="ui:bg-destructive ui:size-2 ui:shrink-0 ui:rounded-full" aria-hidden="true"></span>
-          <div class="ui:flex ui:min-w-0 ui:flex-col ui:gap-0.5">
-            <span class="ui:text-sm ui:font-medium">Error</span>
-            <span class="ui:text-muted-foreground ui:text-xs">3s</span>
+        <div class="flex min-w-0 shrink-0 items-center gap-2 px-2">
+          <span class="ui:bg-destructive size-2 shrink-0 rounded-full" aria-hidden="true"></span>
+          <div class="flex min-w-0 flex-col gap-0.5">
+            <span class="text-sm font-medium">Error</span>
+            <span class="ui:text-muted-foreground text-xs">3s</span>
           </div>
         </div>
-        <div class="ui:flex ui:shrink-0 ui:items-center ui:gap-2 ui:px-2">
-          <span class="ui:flex ui:size-6 ui:items-center ui:justify-center ui:rounded-full ui:bg-blue-600/15">
-            <span class="ui:size-2 ui:rounded-full ui:bg-blue-600"></span>
+        <div class="flex shrink-0 items-center gap-2 px-2">
+          <span class="flex size-6 items-center justify-center rounded-full bg-blue-600/15">
+            <span class="size-2 rounded-full bg-blue-600"></span>
           </span>
-          <span class="ui:text-sm">cio-com</span>
+          <span class="text-sm">cio-com</span>
         </div>
-        <div class="ui:min-w-0 ui:flex-1 ui:px-2">
-          <p class="ui:flex ui:items-center ui:gap-1.5 ui:text-sm">
-            <GitBranchIcon class="ui:text-muted-foreground ui:size-3.5 ui:shrink-0" />
-            <span class="ui:truncate">release-v2/debug-course</span>
+        <div class="min-w-0 flex-1 px-2">
+          <p class="flex items-center gap-1.5 text-sm">
+            <GitBranchIcon class="ui:text-muted-foreground size-3.5 shrink-0" />
+            <span class="truncate">release-v2/debug-course</span>
           </p>
-          <p class="ui:text-muted-foreground ui:flex ui:items-center ui:gap-1.5 ui:truncate ui:text-xs">
-            <GitCommitHorizontalIcon class="ui:size-3.5 ui:shrink-0" />
-            <span class="ui:truncate">b00bf14 fix: move org id into the inv…</span>
+          <p class="ui:text-muted-foreground flex items-center gap-1.5 truncate text-xs">
+            <GitCommitHorizontalIcon class="size-3.5 shrink-0" />
+            <span class="truncate">b00bf14 fix: move org id into the inv…</span>
           </p>
         </div>
-        <ResourceListRow.End class="ui:flex-col ui:items-end ui:gap-1 ui:self-start">
-          <span class="ui:text-muted-foreground ui:text-xs">Mar 30</span>
-          <span class="ui:text-muted-foreground ui:text-xs">by Chifez</span>
-          <Avatar.Root class="ui:size-6">
+        <ResourceListRow.End class="flex-col items-end gap-1 self-start">
+          <span class="ui:text-muted-foreground text-xs">Mar 30</span>
+          <span class="ui:text-muted-foreground text-xs">by Chifez</span>
+          <Avatar.Root class="size-6">
             <Avatar.Image src="https://github.com/shadcn.png" alt="" />
             <Avatar.Fallback>C</Avatar.Fallback>
           </Avatar.Root>
         </ResourceListRow.End>
       </ResourceListRow.Root>
-      <ResourceListRow.Root align="start" class="ui:py-3">
-        <ResourceListRow.Main class="ui:max-w-[140px]">
-          <span class="ui:font-mono ui:text-sm ui:font-semibold">AiS1LEGci</span>
-          <button
-            type="button"
-            class="ui:text-primary ui:w-fit ui:text-left ui:text-xs ui:underline ui:underline-offset-2"
-          >
+      <ResourceListRow.Root align="start" class="py-3">
+        <ResourceListRow.Main class="max-w-[140px]">
+          <span class="font-mono text-sm font-semibold">AiS1LEGci</span>
+          <button type="button" class="ui:text-primary w-fit text-left text-xs underline underline-offset-2">
             Preview
           </button>
         </ResourceListRow.Main>
-        <div class="ui:flex ui:min-w-0 ui:shrink-0 ui:items-center ui:gap-2 ui:px-2">
-          <span class="ui:bg-destructive ui:size-2 ui:shrink-0 ui:rounded-full" aria-hidden="true"></span>
-          <div class="ui:flex ui:min-w-0 ui:flex-col ui:gap-0.5">
-            <span class="ui:text-sm ui:font-medium">Error</span>
-            <span class="ui:text-muted-foreground ui:text-xs">8s</span>
+        <div class="flex min-w-0 shrink-0 items-center gap-2 px-2">
+          <span class="ui:bg-destructive size-2 shrink-0 rounded-full" aria-hidden="true"></span>
+          <div class="flex min-w-0 flex-col gap-0.5">
+            <span class="text-sm font-medium">Error</span>
+            <span class="ui:text-muted-foreground text-xs">8s</span>
           </div>
         </div>
-        <div class="ui:flex ui:shrink-0 ui:items-center ui:gap-2 ui:px-2">
-          <span class="ui:flex ui:size-6 ui:items-center ui:justify-center ui:rounded-full ui:bg-blue-600/15">
-            <span class="ui:size-2 ui:rounded-full ui:bg-blue-600"></span>
+        <div class="flex shrink-0 items-center gap-2 px-2">
+          <span class="flex size-6 items-center justify-center rounded-full bg-blue-600/15">
+            <span class="size-2 rounded-full bg-blue-600"></span>
           </span>
-          <span class="ui:text-sm">cio-docs</span>
+          <span class="text-sm">cio-docs</span>
         </div>
-        <div class="ui:min-w-0 ui:flex-1 ui:px-2">
-          <p class="ui:flex ui:items-center ui:gap-1.5 ui:text-sm">
-            <GitBranchIcon class="ui:text-muted-foreground ui:size-3.5 ui:shrink-0" />
-            <span class="ui:truncate">feat/release-v2</span>
+        <div class="min-w-0 flex-1 px-2">
+          <p class="flex items-center gap-1.5 text-sm">
+            <GitBranchIcon class="ui:text-muted-foreground size-3.5 shrink-0" />
+            <span class="truncate">feat/release-v2</span>
           </p>
-          <p class="ui:text-muted-foreground ui:flex ui:items-center ui:gap-1.5 ui:truncate ui:text-xs">
-            <GitCommitHorizontalIcon class="ui:size-3.5 ui:shrink-0" />
-            <span class="ui:truncate">a1b2c3d docs: update API reference</span>
+          <p class="ui:text-muted-foreground flex items-center gap-1.5 truncate text-xs">
+            <GitCommitHorizontalIcon class="size-3.5 shrink-0" />
+            <span class="truncate">a1b2c3d docs: update API reference</span>
           </p>
         </div>
-        <ResourceListRow.End class="ui:flex-col ui:items-end ui:gap-1 ui:self-start">
-          <span class="ui:text-muted-foreground ui:text-xs">Mar 29</span>
-          <span class="ui:text-muted-foreground ui:text-xs">by rotimi-best</span>
-          <Avatar.Root class="ui:size-6">
+        <ResourceListRow.End class="flex-col items-end gap-1 self-start">
+          <span class="ui:text-muted-foreground text-xs">Mar 29</span>
+          <span class="ui:text-muted-foreground text-xs">by rotimi-best</span>
+          <Avatar.Root class="size-6">
             <Avatar.Image src="https://github.com/maxleiter.png" alt="" />
             <Avatar.Fallback>R</Avatar.Fallback>
           </Avatar.Root>

--- a/packages/storybook/src/molecules/sidebar/sidebar.stories.svelte
+++ b/packages/storybook/src/molecules/sidebar/sidebar.stories.svelte
@@ -57,7 +57,7 @@
           </SidebarGroup>
         </SidebarContent>
         <SidebarFooter>
-          <p class="text-muted-foreground px-4 text-sm">© 2024 My App</p>
+          <p class="ui:text-muted-foreground px-4 text-sm">© 2024 My App</p>
         </SidebarFooter>
       </Sidebar>
       <main class="flex-1 p-4">

--- a/packages/storybook/src/templates/org-landing-page/course-landing-page.stories.svelte
+++ b/packages/storybook/src/templates/org-landing-page/course-landing-page.stories.svelte
@@ -64,26 +64,26 @@
 </Story>
 
 <Story name="Gallery · all themes">
-  <div class="ui:flex ui:flex-col">
-    <div class="ui:sticky ui:top-0 ui:z-50 ui:bg-black/85 ui:text-white ui:text-xs ui:px-4 ui:py-2">Minimal</div>
+  <div class="flex flex-col">
+    <div class="sticky top-0 z-50 bg-black/85 px-4 py-2 text-xs text-white">Minimal</div>
     <MinimalCourseLanding {...mockProps} />
-    <div class="ui:sticky ui:top-0 ui:z-50 ui:bg-black/85 ui:text-white ui:text-xs ui:px-4 ui:py-2">Bold</div>
+    <div class="sticky top-0 z-50 bg-black/85 px-4 py-2 text-xs text-white">Bold</div>
     <BoldCourseLanding {...mockProps} />
-    <div class="ui:sticky ui:top-0 ui:z-50 ui:bg-black/85 ui:text-white ui:text-xs ui:px-4 ui:py-2">Classic</div>
+    <div class="sticky top-0 z-50 bg-black/85 px-4 py-2 text-xs text-white">Classic</div>
     <ClassicCourseLanding {...mockProps} />
-    <div class="ui:sticky ui:top-0 ui:z-50 ui:bg-black/85 ui:text-white ui:text-xs ui:px-4 ui:py-2">SaaS</div>
+    <div class="sticky top-0 z-50 bg-black/85 px-4 py-2 text-xs text-white">SaaS</div>
     <SaasCourseLanding {...mockProps} />
-    <div class="ui:sticky ui:top-0 ui:z-50 ui:bg-black/85 ui:text-white ui:text-xs ui:px-4 ui:py-2">Tech</div>
+    <div class="sticky top-0 z-50 bg-black/85 px-4 py-2 text-xs text-white">Tech</div>
     <TechCourseLanding {...mockProps} />
-    <div class="ui:sticky ui:top-0 ui:z-50 ui:bg-black/85 ui:text-white ui:text-xs ui:px-4 ui:py-2">Studio</div>
+    <div class="sticky top-0 z-50 bg-black/85 px-4 py-2 text-xs text-white">Studio</div>
     <StudioCourseLanding {...mockProps} />
-    <div class="ui:sticky ui:top-0 ui:z-50 ui:bg-black/85 ui:text-white ui:text-xs ui:px-4 ui:py-2">Corporate</div>
+    <div class="sticky top-0 z-50 bg-black/85 px-4 py-2 text-xs text-white">Corporate</div>
     <CorporateCourseLanding {...mockProps} />
-    <div class="ui:sticky ui:top-0 ui:z-50 ui:bg-black/85 ui:text-white ui:text-xs ui:px-4 ui:py-2">Terminal</div>
+    <div class="sticky top-0 z-50 bg-black/85 px-4 py-2 text-xs text-white">Terminal</div>
     <TerminalCourseLanding {...mockProps} />
-    <div class="ui:sticky ui:top-0 ui:z-50 ui:bg-black/85 ui:text-white ui:text-xs ui:px-4 ui:py-2">Editorial</div>
+    <div class="sticky top-0 z-50 bg-black/85 px-4 py-2 text-xs text-white">Editorial</div>
     <EditorialCourseLanding {...mockProps} />
-    <div class="ui:sticky ui:top-0 ui:z-50 ui:bg-black/85 ui:text-white ui:text-xs ui:px-4 ui:py-2">Vibrant</div>
+    <div class="sticky top-0 z-50 bg-black/85 px-4 py-2 text-xs text-white">Vibrant</div>
     <VibrantCourseLanding {...mockProps} />
   </div>
 </Story>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1341,6 +1341,9 @@ importers:
       '@cio/utils':
         specifier: workspace:*
         version: link:../utils
+      '@lucide/svelte':
+        specifier: ^0.562.0
+        version: 0.562.0(svelte@5.56.9(@typescript-eslint/types@8.50.1))
       svelte-inview:
         specifier: ^4.0.4
         version: 4.0.4(svelte@5.56.9(@typescript-eslint/types@8.50.1))


### PR DESCRIPTION
## What does this PR do?

This PR updates multiple areas in storybook package, where css utilities were not properly used (e.g. correcting `text-muted-foreground` to `ui:text-muted-foreground`). 
Note: It adds `@lucide/svelte` to the packages.

## Demo

[Video Recording](https://www.awesomescreenshot.com/video/56090262?key=d797d11f6b5fe445773d1b9b5c3585c9)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Some random existing UIs in Storybook will now have effects that weren't visible prior to now

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
- [x] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Standardized Tailwind utility usage across Storybook examples, with clearer scoping for UI-specific colors and states.
  - Refined avatar styling, hover states, layout, spacing, typography, responsive behavior, and course gallery presentation.
  - Improved document card examples with more focused controls.

- **Documentation**
  - Updated Storybook styling guidance to explain when to use standard utilities versus UI-scoped theme styles.
  - Refreshed component examples for consistency while preserving existing functionality, content, controls, and interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns Storybook theme-color utilities with the `ui:` prefix while leaving Storybook-owned layout utilities unprefixed.
- Updates utility classes across Storybook stories and corresponding contributor guidance.
- Moves avatar ring utilities directly onto each avatar, completing the previously discussed styling fix.
- Adds the direct `@lucide/svelte` dependency required by Storybook icon imports.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/storybook/src/atoms/item/item.stories.svelte | Moves ring and grayscale utilities onto each avatar; `ui:ring-background` is independently included in the precompiled UI stylesheet source scan. |
| packages/storybook/README.md | Documents the split between unprefixed Storybook layout utilities and prefixed UI theme tokens. |
| packages/storybook/package.json | Adds the direct Lucide Svelte dependency used throughout Storybook, with its resolved version pinned by the workspace lockfile. |
| packages/storybook/src/molecules/animation/animation.stories.svelte | Removes `ui:` from structural utilities while retaining it on UI theme-color utilities. |

<sub>Reviews (2): Last reviewed commit: ["invisible document-card stories items ma..."](https://github.com/classroomio/classroomio/commit/8ce3638c90bb581ecc42bffa7981b90e3c457b29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58072032)</sub>

<!-- /greptile_comment -->