### PR TITLE
fix(billing): ignore inactive plans in sidebar labels

### DIFF
--- a/apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/app-logo.svelte
+++ b/apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/app-logo.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import * as Avatar from '@cio/ui/base/avatar';
   import * as Sidebar from '@cio/ui/base/sidebar';
-  import { currentOrg } from '$lib/utils/store/org';
+  import { currentOrg, currentOrgPlan } from '$lib/utils/store/org';
   import { Badge } from '@cio/ui/base/badge';
   import { PLAN_NAMES, PLAN } from '@cio/utils/plans';
   import { BRAND_ROOT_DOMAIN, TENANT_ROOT_DOMAIN } from '@cio/utils/constants';
 
-  const plan = $derived($currentOrg.plans?.[0]?.planName || PLAN.BASIC);
+  const plan = $derived($currentOrgPlan?.planName || PLAN.BASIC);
   const utmSource = $derived(
     $currentOrg.customDomain ||
       ($currentOrg.siteName ? `${$currentOrg.siteName}.${TENANT_ROOT_DOMAIN}` : BRAND_ROOT_DOMAIN)

--- a/apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/org-switcher.svelte
+++ b/apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/org-switcher.svelte
@@ -12,7 +12,13 @@
   import type { AccountOrg } from '$features/app/types';
 
   import { setTheme } from '$lib/utils/functions/theme';
-  import { currentOrg, currentOrgPath, managedOrgs, mergeAccountOrgFromServer } from '$lib/utils/store/org';
+  import {
+    currentOrg,
+    currentOrgPath,
+    currentOrgPlan,
+    managedOrgs,
+    mergeAccountOrgFromServer
+  } from '$lib/utils/store/org';
   import { t } from '$lib/utils/functions/translations';
 
   import ComingSoon from '$features/ui/coming-soon.svelte';
@@ -32,6 +38,7 @@
   }
 
   const accountRootId = $derived(rootIdFor($currentOrg));
+  const currentPlanName = $derived($currentOrgPlan?.planName || 'Free');
 
   const switchableOrgs = $derived($managedOrgs);
   const accountWorkspaces = $derived(switchableOrgs.filter((org) => rootIdFor(org) === accountRootId));
@@ -73,7 +80,7 @@
             </Avatar.Root>
             <div class="grid flex-1 text-left text-sm leading-tight">
               <span class="truncate font-normal">{$currentOrg.name}</span>
-              <span class="truncate text-xs">{$currentOrg.plans?.[0]?.planName || 'Free'}</span>
+              <span class="truncate text-xs">{currentPlanName}</span>
             </div>
           {:else}
             <Skeleton class="h-full w-full" />
@@ -174,7 +181,7 @@
                     {$currentOrg.name}
                   </span>
                   <span class="truncate text-xs">
-                    {$currentOrg.plans?.[0]?.planName || 'Free'}
+                    {currentPlanName}
                   </span>
                 </div>
                 <ChevronsUpDownIcon class="ml-auto" />

--- a/apps/dashboard/src/lib/utils/store/org.ts
+++ b/apps/dashboard/src/lib/utils/store/org.ts
@@ -7,6 +7,7 @@ import type { OrgTeamMember } from '../types/org';
 import {
   canUseBasicAuthSettings,
   canUsePublicApi,
+  getActiveOrgPlan,
   getStudentLimit,
   isOrgOnFreePlan,
   isResourceLimitReached,
@@ -89,11 +90,7 @@ export const isOrgTeamMember = derived(currentOrg, ($currentOrg) => {
   return isOrgManagerRole($currentOrg.roleId);
 });
 
-const getActivePlan = (org: AccountOrg) => {
-  return org.plans.find((p) => p.isActive);
-};
-
-export const currentOrgPlan = derived(currentOrg, ($currentOrg) => getActivePlan($currentOrg));
+export const currentOrgPlan = derived(currentOrg, ($currentOrg) => getActiveOrgPlan($currentOrg.plans));
 
 export const currentOrgPath = derived(currentOrg, ($currentOrg) =>
   $currentOrg.siteName ? `/org/${$currentOrg.siteName}` : '#'
@@ -171,19 +168,19 @@ export const isFreePlan = derived(currentOrg, ($currentOrg) =>
 export const isEnterprisePlan = derived(currentOrg, ($currentOrg) => {
   if (PUBLIC_IS_SELFHOSTED === 'true') return true;
 
-  const plan = getActivePlan($currentOrg);
+  const plan = getActiveOrgPlan($currentOrg.plans);
 
   return plan?.planName === PLAN.ENTERPRISE;
 });
 
 export const hasPublicApiAccess = derived(currentOrg, ($currentOrg) => {
-  const plan = getActivePlan($currentOrg);
+  const plan = getActiveOrgPlan($currentOrg.plans);
 
   return canUsePublicApi(plan?.planName, PUBLIC_IS_SELFHOSTED === 'true');
 });
 
 export const hasBasicAuthSettingsAccess = derived(currentOrg, ($currentOrg) => {
-  const plan = getActivePlan($currentOrg);
+  const plan = getActiveOrgPlan($currentOrg.plans);
 
   return canUseBasicAuthSettings(plan?.planName, PUBLIC_IS_SELFHOSTED === 'true');
 });

--- a/packages/utils/src/plans/org-plan.ts
+++ b/packages/utils/src/plans/org-plan.ts
@@ -11,6 +11,10 @@ export type IsOrgOnFreePlanOptions = {
   orgId?: string | null;
 };
 
+export function getActiveOrgPlan<T extends OrgPlanLike>(plans?: readonly T[] | null): T | undefined {
+  return plans?.find((plan) => plan.isActive === true);
+}
+
 export function isOrgOnFreePlan({ plans, isSelfHosted, orgId }: IsOrgOnFreePlanOptions): boolean {
   if (!orgId) {
     return false;
@@ -20,7 +24,7 @@ export function isOrgOnFreePlan({ plans, isSelfHosted, orgId }: IsOrgOnFreePlanO
     return false;
   }
 
-  const activePlan = plans?.find((plan) => plan.isActive);
+  const activePlan = getActiveOrgPlan(plans);
 
   return !activePlan || activePlan.planName === PLAN.BASIC;
 }

--- a/packages/utils/tests/org-plan.test.ts
+++ b/packages/utils/tests/org-plan.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { getActiveOrgPlan, isOrgOnFreePlan } from '../src/plans/org-plan';
+
+describe('organization plan selection', () => {
+  it('ignores an inactive historical plan', () => {
+    const plans = [{ planName: 'EARLY_ADOPTER', isActive: false }];
+
+    expect(getActiveOrgPlan(plans)).toBeUndefined();
+    expect(isOrgOnFreePlan({ plans, isSelfHosted: false, orgId: 'org-id' })).toBe(true);
+  });
+
+  it('selects the active plan instead of the first plan', () => {
+    const plans = [
+      { planName: 'EARLY_ADOPTER', isActive: false },
+      { planName: 'ENTERPRISE', isActive: true }
+    ];
+
+    expect(getActiveOrgPlan(plans)).toEqual(plans[1]);
+    expect(isOrgOnFreePlan({ plans, isSelfHosted: false, orgId: 'org-id' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- select the active organization plan through a shared helper
- use the active plan for the app badge and organization switcher labels
- fall back to Basic/Free when only inactive historical plans remain
- add regression coverage for expired Early Adopter plans

## Verification

- `pnpm --filter @cio/utils test`
- `pnpm --filter @cio/dashboard^... build`
- `pnpm --filter @cio/dashboard build`
- `pnpm format:check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes active organization-plan selection and updates sidebar labels and plan-dependent stores to ignore inactive historical plans.

- Adds a shared `getActiveOrgPlan` helper.
- Uses the selected active plan for the app badge and organization switcher.
- Falls back to Basic or Free when no active plan remains.
- Adds regression tests for inactive and reordered plans.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The shared helper selects the first explicitly active plan, its consumers retain appropriate fallback behavior, and the tests cover the reported inactive-plan regression.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/utils/src/plans/org-plan.ts | Adds a typed active-plan selector and reuses it for free-plan classification without identifying a correctness regression. |
| apps/dashboard/src/lib/utils/store/org.ts | Replaces the local selector with the shared helper while preserving existing access-check behavior. |
| apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/app-logo.svelte | Uses the active-plan store for the badge and retains the Basic fallback. |
| apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/org-switcher.svelte | Uses the active-plan store consistently in both organization label locations with a Free fallback. |
| packages/utils/tests/org-plan.test.ts | Covers inactive historical plans and active plans that are not first in the array. |

<sub>Reviews (1): Last reviewed commit: ["fix(billing): ignore inactive plans in s..."](https://github.com/classroomio/classroomio/commit/bb8ef9487bdbd7031159f2371859aa804dce3727) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58074810)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization plan badges and labels now consistently display the currently active plan.
  * Prevented outdated or inactive plans from being shown when organizations have plan history.
  * Free-plan and feature-access indicators now reflect the selected active plan accurately.

* **Tests**
  * Added coverage for active, inactive, and free-plan selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->