### PR TITLE
fix(dashboard): keep UserJot off organization sites

### DIFF
--- a/apps/dashboard/src/lib/features/app/init.svelte.ts
+++ b/apps/dashboard/src/lib/features/app/init.svelte.ts
@@ -132,7 +132,8 @@ class AppInitApi extends BaseApi {
     setupAnalyticsBasedOnLicense(
       accountData.profile?.id
         ? { id: accountData.profile.id, email: accountData.profile.email, name: accountData.profile.fullname }
-        : undefined
+        : undefined,
+      params.isOrgSite
     );
     this.setUserAnalytics();
     this.routeUserToNextPage(params);

--- a/apps/dashboard/src/lib/utils/functions/appSetup.ts
+++ b/apps/dashboard/src/lib/utils/functions/appSetup.ts
@@ -14,20 +14,20 @@ function setupTracking(user?: PosthogBootstrapUser) {
   initUmami();
 }
 
-export function setupAnalytics(user?: PosthogBootstrapUser) {
-  initUserJot();
+export function setupAnalytics(user: PosthogBootstrapUser | undefined, isOrgSite: boolean) {
+  initUserJot(isOrgSite);
   setupTracking(user);
 }
 
 /** Checks if this is cloud deployment and initializes analytics */
-export function setupCloudAnalytics(user?: PosthogBootstrapUser) {
+export function setupCloudAnalytics(user: PosthogBootstrapUser | undefined, isOrgSite: boolean) {
   if (PUBLIC_IS_SELFHOSTED !== 'true') {
-    setupAnalytics(user);
+    setupAnalytics(user, isOrgSite);
   }
 }
 
-export function setupAnalyticsBasedOnLicense(user?: PosthogBootstrapUser) {
-  initUserJot();
+export function setupAnalyticsBasedOnLicense(user: PosthogBootstrapUser | undefined, isOrgSite: boolean) {
+  initUserJot(isOrgSite);
 
   if (licenseApi.hasAccess('no-tracking')) {
     return;

--- a/apps/dashboard/src/lib/utils/services/userjot/index.ts
+++ b/apps/dashboard/src/lib/utils/services/userjot/index.ts
@@ -41,8 +41,9 @@ function ensureSdkLoaded(): void {
   document.head.appendChild(script);
 }
 
-export function initUserJot(): void {
+export function initUserJot(isOrgSite: boolean): void {
   if (isInitialized) return;
+  if (isOrgSite) return;
   if (!isWidgetAllowed()) return;
 
   ensureSdkLoaded();
@@ -66,9 +67,8 @@ type UserJotIdentity = {
 };
 
 export function identifyUserJotUser({ id, email, fullname, avatarUrl }: UserJotIdentity): void {
+  if (!isInitialized) return;
   if (!isWidgetAllowed()) return;
-
-  ensureSdkLoaded();
 
   const [firstName, ...rest] = (fullname ?? '').trim().split(/\s+/);
   const lastName = rest.join(' ');
@@ -85,9 +85,8 @@ export function identifyUserJotUser({ id, email, fullname, avatarUrl }: UserJotI
 }
 
 export function clearUserJotUser(): void {
+  if (!isInitialized) return;
   if (!isWidgetAllowed()) return;
-
-  ensureSdkLoaded();
 
   window.uj.logout();
 }
@@ -95,9 +94,8 @@ export function clearUserJotUser(): void {
 export type UserJotWidgetSection = 'feedback' | 'roadmap' | 'updates';
 
 export function showUserJotWidget(section: UserJotWidgetSection): void {
+  if (!isInitialized) return;
   if (!isWidgetAllowed()) return;
-
-  ensureSdkLoaded();
 
   window.uj.open({ to: section });
 }

--- a/apps/dashboard/src/routes/+layout.svelte
+++ b/apps/dashboard/src/routes/+layout.svelte
@@ -34,7 +34,8 @@
 
     const sessionUser = data?.locals?.user;
     setupCloudAnalytics(
-      sessionUser ? { id: sessionUser.id, email: sessionUser.email, name: sessionUser.name } : undefined
+      sessionUser ? { id: sessionUser.id, email: sessionUser.email, name: sessionUser.name } : undefined,
+      data.isOrgSite
     );
 
     if (data?.locals?.user) {


### PR DESCRIPTION
## What does this PR do?

Ensures the UserJot widget is only initialized on the ClassroomIO dashboard and never on customer organization sites.

The root layout now passes its server-derived `isOrgSite` value directly into analytics setup, removing the timing window where the client store still held its default value. UserJot identify, logout, and open calls also require successful dashboard initialization, so none of them can independently load the SDK on a customer site.

Follow-up to #990.

## Demo

No visual layout changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Open a customer organization site and confirm no UserJot SDK request, iframe, launcher, or whisper is created.
- Open the SaaS admin dashboard and confirm Feedback and Updates still open the UserJot v3 widget.
- Verify with Node 20: `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`.

## Checklist

### Required

- [x] Filled out the How to test section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran the dashboard and dependency production builds
- [ ] Checked for warnings, there are none (the build reports existing unrelated Svelte warnings)
- [x] Removed all console.logs
- [x] Branch is based on current `origin/main`
- [x] My changes do not cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the ClassroomIO Contributor License Agreement
- [x] No changes to `pnpm-lock.yaml`, `.github/workflows/**`, or publish config

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] ClassroomIO Docs do not require changes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents UserJot from initializing on customer organization sites by passing the server-derived site mode into both analytics startup paths. It also requires successful dashboard initialization before identify, logout, or widget-open operations can interact with UserJot.

- Threads `isOrgSite` through cloud and license-based analytics setup.
- Adds an explicit organization-site guard to UserJot initialization.
- Prevents auxiliary UserJot operations from independently loading the SDK.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness, security, or build failures identified.

The organization-site flag is derived consistently across both startup paths, all changed function signatures have updated callers, and UserJot operations remain reachable after initialization on dashboard pages while being blocked on tenant sites.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/app/init.svelte.ts | Passes the resolved application mode into license-aware analytics initialization before user analytics identification. |
| apps/dashboard/src/lib/utils/functions/appSetup.ts | Requires analytics callers to provide the organization-site flag and forwards it consistently to UserJot initialization. |
| apps/dashboard/src/lib/utils/services/userjot/index.ts | Blocks initialization on organization sites and gates identify, logout, and open operations on prior successful initialization. |
| apps/dashboard/src/routes/+layout.svelte | Supplies the server-derived organization-site flag directly to analytics during root-layout mounting. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): keep UserJot off organiz..."](https://github.com/classroomio/classroomio/commit/27d9046fbcf4a45ea4ba90deb60da7400cdc953e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58185484)</sub>

**Context used:**

- Knowledge Base — [Administration dashboard](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/administration-dashboard.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved analytics initialization across dashboard site types.
  - User feedback widgets are no longer initialized or displayed on organization sites.
  - Prevented feedback services from loading unexpectedly when they are not enabled.
  - Added safeguards to user feedback actions when the service has not been initialized.
  - Ensured account and session context is consistently passed during analytics setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->