### PR TITLE
ci(opencode): use Go subscription model in PR trigger

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -33,4 +33,4 @@ jobs:
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
-          model: opencode/gpt-5.6-sol
+          model: opencode-go/gpt-5.6-luna


### PR DESCRIPTION
## Summary

Switch the opencode PR-trigger workflow from the Zen-only `opencode/gpt-5.6-sol` model to the Go subscription's `opencode-go/gpt-5.6-luna`.

## Why

`opencode/gpt-5.6-sol` bills against the Zen pay-as-you-go balance, which is empty, so triggering the agent on a PR fails with `insufficient balance`. `opencode-go/gpt-5.6-luna` uses the $10/month Go subscription instead.

## Notes

- Same `OPENCODE_API_KEY` secret works; the `opencode-go/` provider prefix selects Go billing.
- Added trailing newline to the YAML file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code-generation workflow to use the GPT-5.6 Luna model.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Switches the OpenCode pull-request workflow to the Go subscription provider so runs no longer depend on the empty Zen pay-as-you-go balance.
- Changes the model from `opencode/gpt-5.6-sol` to `opencode-go/gpt-5.6-luna`.
- Adds the missing trailing newline to the workflow file.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the new provider and model identifier match the intended Go subscription configuration.

The workflow retains its existing action, API-key secret, permissions, and invocation structure while replacing only the model identifier with the supported Go-provider form.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/opencode.yml | Updates the OpenCode action's model identifier to a valid Go subscription model without changing workflow triggers, permissions, or secret handling. |

<sub>Reviews (1): Last reviewed commit: ["ci(opencode): use Go subscription model ..."](https://github.com/classroomio/classroomio/commit/33175ede71f6c4a0c6d75cdca6a4eb25226d1231) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58351418)</sub>

<!-- /greptile_comment -->