### PR TITLE
fix(dashboard): reposition app update toast

### DIFF
--- a/apps/dashboard/src/lib/features/app/app-version-notifier.svelte
+++ b/apps/dashboard/src/lib/features/app/app-version-notifier.svelte
@@ -10,7 +10,9 @@
     toast.info(t.get('common.app_update.title'), {
       id: UPDATE_TOAST_ID,
       duration: Number.POSITIVE_INFINITY,
+      position: 'bottom-right',
       description: t.get('common.app_update.description'),
+      actionButtonStyle: 'background: var(--primary); color: var(--primary-foreground);',
       action: {
         label: t.get('common.app_update.reload'),
         onClick: () => location.reload()


### PR DESCRIPTION
## What does this PR do?

- Moves the persistent app-version update toast to the bottom-right.
- Uses the shared primary Button component for the Reload action.
- Shows the button standard loading spinner from component-local state after click, then reloads the page.
- Keeps the behavior scoped to the app update notification; other snackbars retain their existing position.

## Demo

The notification is shown when SvelteKit detects a newly deployed app version or a Vite preload error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Deploy a newer dashboard version while an older version remains open, then return focus to the older tab.
- Confirm the update toast appears at the bottom-right.
- Confirm the Reload action uses the active primary theme color.
- Click Reload and confirm the button disables and shows its loading spinner before the page reloads.

## Checklist

### Required

- [x] Filled out the How to test section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits (no additional comments needed)
- [x] Ran the dashboard production build
- [ ] Checked for warnings, there are none (the build has existing unrelated Svelte warnings)
- [x] Removed all console.logs
- [x] Branch is based on the latest origin/main at creation
- [x] My changes do not cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the ClassroomIO Contributor License Agreement
- [x] This PR does not change pnpm-lock.yaml, workflows, or publish config

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the ClassroomIO Docs if changes were necessary (not necessary)