### PR TITLE
fix: make tutors see cohorts they are given access to only

### DIFF
--- a/apps/api/src/routes/cohort/cohort.ts
+++ b/apps/api/src/routes/cohort/cohort.ts
@@ -102,8 +102,9 @@ export const cohortRouter = new Hono()
    */
   .get('/', authMiddleware, zValidator('query', ZOrgQuery), async (c) => {
     try {
+      const user = c.get('user')!;
       const { organizationId } = c.req.valid('query');
-      const cohorts = await listOrgCohorts(organizationId);
+      const cohorts = await listOrgCohorts(organizationId, user.id);
       return c.json({ success: true, data: cohorts }, 200);
     } catch (error) {
       return handleError(c, error, 'Failed to list cohorts');

--- a/apps/api/src/services/cohort/cohort.ts
+++ b/apps/api/src/services/cohort/cohort.ts
@@ -28,6 +28,7 @@ import {
   getCohortNewsfeedCommentById,
   getCohortNewsfeedComments,
   getCohortsByOrg,
+  getCohortsByOrgForProfile,
   getCoursesByCohort,
   getCohortMemberRole,
   isCohortCourse,
@@ -148,9 +149,9 @@ export async function getCohort(cohortId: string) {
   }
 }
 
-export async function listOrgCohorts(organizationId: string) {
+export async function listOrgCohorts(organizationId: string, profileId: string) {
   try {
-    return getCohortsByOrg(organizationId);
+    return getCohortsByOrgForProfile(organizationId, profileId);
   } catch (error) {
     if (error instanceof AppError) throw error;
     throw new AppError(

--- a/packages/db/src/queries/cohort/cohort.ts
+++ b/packages/db/src/queries/cohort/cohort.ts
@@ -116,6 +116,49 @@ export async function getCohortsByOrg(
   }
 }
 
+/**
+ * Returns org cohorts the given profile can access.
+ * Org admins see all cohorts; other members see only cohorts they belong to.
+ */
+export async function getCohortsByOrgForProfile(
+  organizationId: string,
+  profileId: string
+): Promise<Array<TCohort & { courseCount: number; studentCount: number }>> {
+  try {
+    const [adminRow] = await db
+      .select({ id: schema.organizationmember.id })
+      .from(schema.organizationmember)
+      .where(
+        and(
+          eq(schema.organizationmember.organizationId, organizationId),
+          eq(schema.organizationmember.profileId, profileId),
+          eq(schema.organizationmember.roleId, ROLE.ADMIN)
+        )
+      )
+      .limit(1);
+
+    if (adminRow) {
+      return getCohortsByOrg(organizationId);
+    }
+
+    const memberRows = await db
+      .select({ cohortId: schema.cohortMember.cohortId })
+      .from(schema.cohortMember)
+      .innerJoin(schema.cohort, eq(schema.cohortMember.cohortId, schema.cohort.id))
+      .where(and(eq(schema.cohortMember.profileId, profileId), eq(schema.cohort.organizationId, organizationId)));
+
+    const cohortIds = memberRows.map((r) => r.cohortId);
+    if (cohortIds.length === 0) return [];
+
+    return getCohortsByOrg(organizationId, cohortIds);
+  } catch (error) {
+    console.error('getCohortsByOrgForProfile error:', error);
+    throw new Error(
+      `Failed to get cohorts for profile "${profileId}" in org "${organizationId}": ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}
+
 export interface TSearchOrgCohort {
   id: string;
   name: string;


### PR DESCRIPTION
## What does this PR do?

Fixed the problem of Tutors seeing cohorts they aren't assigned to.
- Non-admin members (such as Tutors and Students) are filtered to only see cohorts they are explicitly assigned to in `cohortMember`.

Fixes #863 

## Demo
https://www.awesomescreenshot.com/video/56083614?key=6e558b383b3c299b362d7f29f5634a56
<!-- Please upload a video here or attach a link to a video player like Awesome Screenshot or Loom to show the change in action. This speeds up reviews, especially for visual changes. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- **Test A (Admin View)**: Log in as an Organization Admin and navigate to the Cohorts page. Verify that all cohorts within the organization remain visible.
- **Test B (Tutor/Member View)**: Log in as a Tutor assigned to specific cohort(s). Verify that only assigned cohorts are displayed and unassigned cohorts are omitted.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes organization cohort listings profile-aware so administrators retain organization-wide visibility while tutors and other non-admin members receive only cohorts containing their membership.
- Passes the authenticated profile identity from the cohort route through the service layer.
- Adds an organization-admin lookup before applying cohort membership filtering.
- Preserves existing course and student count enrichment for returned cohorts.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the new filtering aligned to the repository’s identity, role, and cohort-membership contracts.

The authenticated user ID is the canonical profile ID, the administrator predicate matches the repository-wide role model, and the only service caller supplies the newly required profile argument.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/cohort/cohort.ts | Passes the authenticated user ID into the profile-aware cohort-listing service. |
| apps/api/src/services/cohort/cohort.ts | Delegates organization cohort listing to the new profile-aware database query. |
| packages/db/src/queries/cohort/cohort.ts | Returns all organization cohorts for administrators and membership-scoped cohorts for other profiles while retaining existing count enrichment. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Authenticated cohort-list request] --> B[Resolve organization and profile]
  B --> C{Profile is organization admin?}
  C -- Yes --> D[Return all organization cohorts]
  C -- No --> E[Find profile cohort memberships in organization]
  E --> F[Return assigned cohorts with counts]
```

<sub>Reviews (1): Last reviewed commit: ["Fixed the cohort issue"](https://github.com/classroomio/classroomio/commit/a8191e91427ddfdb68d963e9ab55fe1f7312f90e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58667999)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cohort listings now reflect the signed-in user’s access.
  * Organization administrators can continue to view all organization cohorts.
  * Other users see only cohorts they belong to.
  * Users without cohort memberships now receive an empty list instead of seeing unauthorized cohorts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->