### PR TITLE
fix(api): make invite enrollment atomic

### DIFF
--- a/apps/api/src/services/cohort/cohort.ts
+++ b/apps/api/src/services/cohort/cohort.ts
@@ -49,7 +49,8 @@ import {
 } from '@cio/db/queries/organization';
 import { ROLE } from '@cio/utils/constants';
 import { db } from '@cio/db/drizzle';
-import { assertStudentCapacityOrThrow } from '../organization/student-limit';
+import { assertStudentCapacityOrThrow, notifyStudentMilestone } from '../organization/student-limit';
+import type { StudentMilestoneNotification } from '../organization/student-limit';
 
 type CohortMemberEnrollment = {
   profileId: string;
@@ -78,8 +79,6 @@ async function enrollCohortStudentsInGroups(
     studentProfileIds.filter((profileId) => !existingMemberProfileIds.has(profileId))
   );
 
-  await assertStudentCapacityOrThrow(organizationId, newStudentProfileIds.size);
-
   const organizationMemberRows = studentMembers.map((member) => ({
     organizationId,
     roleId: ROLE.STUDENT,
@@ -97,10 +96,21 @@ async function enrollCohortStudentsInGroups(
     }))
   );
 
+  let studentMilestoneNotification: StudentMilestoneNotification | null = null;
+
   await db.transaction(async (tx) => {
+    studentMilestoneNotification = await assertStudentCapacityOrThrow(organizationId, newStudentProfileIds.size, tx, {
+      deferNotification: true
+    });
     await insertOrganizationMembersOnConflictDoNothing(organizationMemberRows, tx);
     await insertGroupMembersOnConflictDoNothing(groupMemberRows, tx);
   });
+
+  if (studentMilestoneNotification) {
+    notifyStudentMilestone(studentMilestoneNotification).catch((error) => {
+      console.error('notifyStudentMilestone error:', error);
+    });
+  }
 
   return groupMemberRows.length;
 }

--- a/apps/api/src/services/cohort/cohort.ts
+++ b/apps/api/src/services/cohort/cohort.ts
@@ -253,7 +253,8 @@ export async function addCohortMembers(cohortId: string, data: TAddCohortMembers
           );
         }
 
-        return db.transaction(async (tx) => {
+        const transactionResult = await db.transaction(async (tx) => {
+          let studentMilestoneNotification: StudentMilestoneNotification | null = null;
           const member = await addCohortMember(
             {
               cohortId,
@@ -273,7 +274,9 @@ export async function addCohortMembers(cohortId: string, data: TAddCohortMembers
               tx
             );
             if (!existingOrgMemberId) {
-              await assertStudentCapacityOrThrow(cohort.organizationId, 1);
+              studentMilestoneNotification = await assertStudentCapacityOrThrow(cohort.organizationId, 1, tx, {
+                deferNotification: true
+              });
             }
 
             await insertOrganizationMembersOnConflictDoNothing(
@@ -300,8 +303,16 @@ export async function addCohortMembers(cohortId: string, data: TAddCohortMembers
             );
           }
 
-          return member;
+          return { member, studentMilestoneNotification };
         });
+
+        if (transactionResult.studentMilestoneNotification) {
+          notifyStudentMilestone(transactionResult.studentMilestoneNotification).catch((error) => {
+            console.error('notifyStudentMilestone error:', error);
+          });
+        }
+
+        return transactionResult.member;
       })
     );
 

--- a/apps/api/src/services/course/compliance.ts
+++ b/apps/api/src/services/course/compliance.ts
@@ -14,7 +14,7 @@ import {
   updateCourseCompletionRecord,
   type OrgComplianceLearnerRow
 } from '@cio/db/queries/course/compliance';
-import { db } from '@cio/db/drizzle';
+import { db, type DbOrTxClient } from '@cio/db/drizzle';
 import { getCourseById } from '@cio/db/queries/course';
 
 import { ROLE } from '@cio/utils/constants';
@@ -90,8 +90,8 @@ function getStatusCounts(records: Array<{ record: TCourseCompletionRecord | null
   return counts;
 }
 
-async function getComplianceCourseOrThrow(courseId: string) {
-  const [course] = await getCourseById(courseId);
+async function getComplianceCourseOrThrow(courseId: string, dbClient: DbOrTxClient = db) {
+  const [course] = await getCourseById(courseId, dbClient);
 
   if (!course) {
     throw new AppError('Course not found', ErrorCodes.COURSE_NOT_FOUND, 404);
@@ -210,33 +210,45 @@ async function getComplianceCompletionSnapshot(params: {
   };
 }
 
-async function ensureComplianceEnrollmentRecordForLearner(courseId: string, groupMemberId: string, profileId: string) {
-  const course = await getComplianceCourseOrThrow(courseId);
+async function ensureComplianceEnrollmentRecordForLearner(
+  courseId: string,
+  groupMemberId: string,
+  profileId: string,
+  dbClient: DbOrTxClient = db
+) {
+  const course = await getComplianceCourseOrThrow(courseId, dbClient);
   const dueDate = getComplianceInitialDueDate(course);
 
   if (!dueDate) {
     return null;
   }
 
-  const [existingRecord] = await getLatestComplianceRecordsByProfiles(courseId, [profileId]);
+  const [existingRecord] = await getLatestComplianceRecordsByProfiles(courseId, [profileId], dbClient);
 
   if (existingRecord) {
     return existingRecord;
   }
 
-  return createCourseCompletionRecord({
-    courseId,
-    groupMemberId,
-    profileId,
-    cycleNumber: 1,
-    status: 'not_started',
-    dueDate,
-    attempts: 0,
-    timeSpentMinutes: 0
-  });
+  return createCourseCompletionRecord(
+    {
+      courseId,
+      groupMemberId,
+      profileId,
+      cycleNumber: 1,
+      status: 'not_started',
+      dueDate,
+      attempts: 0,
+      timeSpentMinutes: 0
+    },
+    dbClient
+  );
 }
 
-export async function ensureComplianceEnrollmentRecordsForProfiles(courseIds: string[], profileIds: string[]) {
+export async function ensureComplianceEnrollmentRecordsForProfiles(
+  courseIds: string[],
+  profileIds: string[],
+  dbClient: DbOrTxClient = db
+) {
   if (courseIds.length === 0 || profileIds.length === 0) {
     return {
       createdCount: 0
@@ -246,7 +258,7 @@ export async function ensureComplianceEnrollmentRecordsForProfiles(courseIds: st
   let createdCount = 0;
 
   for (const courseId of courseIds) {
-    const [course] = await getCourseById(courseId);
+    const [course] = await getCourseById(courseId, dbClient);
 
     if (!course || course.type !== 'COMPLIANCE' || !course.compliance) {
       continue;
@@ -257,19 +269,19 @@ export async function ensureComplianceEnrollmentRecordsForProfiles(courseIds: st
       continue;
     }
 
-    const learners = await getStudentCourseMembersForCompliance(courseId, profileIds);
+    const learners = await getStudentCourseMembersForCompliance(courseId, profileIds, dbClient);
     for (const learner of learners) {
       const profileId = learner.member.profileId;
       if (!profileId) {
         continue;
       }
 
-      const [existingRecord] = await getLatestComplianceRecordsByProfiles(courseId, [profileId]);
+      const [existingRecord] = await getLatestComplianceRecordsByProfiles(courseId, [profileId], dbClient);
       if (existingRecord) {
         continue;
       }
 
-      await ensureComplianceEnrollmentRecordForLearner(courseId, learner.member.id, profileId);
+      await ensureComplianceEnrollmentRecordForLearner(courseId, learner.member.id, profileId, dbClient);
       createdCount += 1;
     }
   }

--- a/apps/api/src/services/course/invite.ts
+++ b/apps/api/src/services/course/invite.ts
@@ -36,7 +36,8 @@ import { enqueueTransactionalEmail } from '@api/services/jobs';
 import { getProfileByEmail, markUserAndProfileEmailVerified } from '@cio/db/queries/auth';
 import { generateSlug } from '@cio/utils/functions';
 import { ensureComplianceEnrollmentRecordsForProfiles } from './compliance';
-import { assertStudentCapacityOrThrow } from '../organization/student-limit';
+import { assertStudentCapacityOrThrow, notifyStudentMilestone } from '../organization/student-limit';
+import type { StudentMilestoneNotification } from '../organization/student-limit';
 import { getWelcomeSessionIcs } from './session-invite';
 import { db } from '@cio/db/drizzle';
 import { trackServerEvent, SERVER_EVENTS } from '@cio/analytics';
@@ -993,7 +994,8 @@ export async function acceptStudentInvite(token: string, user: TAuthUser, contex
         orgCustomDomain: organization.customDomain,
         orgIsCustomDomainVerified: organization.isCustomDomainVerified,
         orgAvatarUrl: organization.avatarUrl,
-        orgTheme: organization.theme
+        orgTheme: organization.theme,
+        studentMilestoneNotification: null
       };
     }
 
@@ -1027,9 +1029,12 @@ export async function acceptStudentInvite(token: string, user: TAuthUser, contex
     }
 
     const orgMemberId = await getOrganizationMemberIdByOrgAndProfile(organization.id, user.id, tx);
+    let studentMilestoneNotification: StudentMilestoneNotification | null = null;
 
     if (!orgMemberId) {
-      await assertStudentCapacityOrThrow(organization.id, 1);
+      studentMilestoneNotification = await assertStudentCapacityOrThrow(organization.id, 1, tx, {
+        deferNotification: true
+      });
 
       await createOrganizationMember(
         {
@@ -1080,6 +1085,7 @@ export async function acceptStudentInvite(token: string, user: TAuthUser, contex
       orgIsCustomDomainVerified: organization.isCustomDomainVerified,
       orgAvatarUrl: organization.avatarUrl,
       orgTheme: organization.theme,
+      studentMilestoneNotification,
       welcomeEmailMessage:
         (course.metadata as { welcomeEmailMessage?: string | null } | null)?.welcomeEmailMessage ?? null
     };
@@ -1087,6 +1093,12 @@ export async function acceptStudentInvite(token: string, user: TAuthUser, contex
 
   if (!result.alreadyJoined) {
     await invalidateOrgStats(result.organizationId);
+  }
+
+  if (result.studentMilestoneNotification) {
+    notifyStudentMilestone(result.studentMilestoneNotification).catch((error) => {
+      console.error('notifyStudentMilestone error:', error);
+    });
   }
 
   await ensureComplianceEnrollmentRecordsForProfiles([result.courseId], [user.id]);

--- a/apps/api/src/services/organization/invite.ts
+++ b/apps/api/src/services/organization/invite.ts
@@ -29,7 +29,8 @@ import { ROLE } from '@cio/utils/constants';
 import type { TNewOrganizationInviteAudit } from '@db/types';
 import crypto from 'node:crypto';
 import { db, type DbOrTxClient } from '@cio/db/drizzle';
-import { assertStudentCapacityOrThrow } from './student-limit';
+import { assertStudentCapacityOrThrow, notifyStudentMilestone } from './student-limit';
+import type { StudentMilestoneNotification } from './student-limit';
 import { getAppBaseUrl } from '@cio/core/config/dashboard-url';
 import { parseCourseIdsFromInviteMetadata, parseCohortIdsFromInviteMetadata } from '@api/utils/org';
 import { getProfileById, markUserAndProfileEmailVerified } from '@cio/db/queries/auth/profile';
@@ -105,7 +106,7 @@ function getExpiryLabel(expiresAtIso: string): string {
 async function syncOrgMemberForOrgInvite(
   tx: DbOrTxClient,
   params: { organizationId: string; roleId: number; normalizedEmail: string; userId: string }
-): Promise<void> {
+): Promise<StudentMilestoneNotification | null> {
   const orgMemberByEmail = await selectOrganizationMemberByOrgAndNormalizedEmail(
     tx,
     params.organizationId,
@@ -124,7 +125,7 @@ async function syncOrgMemberForOrgInvite(
       verified: true
     });
 
-    return;
+    return null;
   }
 
   const orgMemberByProfile = await selectOrganizationMemberByOrgAndProfile(tx, params.organizationId, params.userId);
@@ -136,11 +137,14 @@ async function syncOrgMemberForOrgInvite(
       verified: true
     });
 
-    return;
+    return null;
   }
 
+  let studentMilestoneNotification: StudentMilestoneNotification | null = null;
   if (params.roleId === ROLE.STUDENT) {
-    await assertStudentCapacityOrThrow(params.organizationId, 1);
+    studentMilestoneNotification = await assertStudentCapacityOrThrow(params.organizationId, 1, {
+      deferNotification: true
+    });
   }
 
   await createOrganizationMember(
@@ -153,6 +157,8 @@ async function syncOrgMemberForOrgInvite(
     },
     tx
   );
+
+  return studentMilestoneNotification;
 }
 
 async function recordOrganizationInviteAudit(
@@ -427,9 +433,10 @@ export async function acceptOrganizationInvite(token: string, user: TAuthUser, c
     }
 
     const alreadyAccepted = status === 'ACCEPTED';
+    let studentMilestoneNotification: StudentMilestoneNotification | null = null;
 
     if (!alreadyAccepted) {
-      await syncOrgMemberForOrgInvite(tx, {
+      studentMilestoneNotification = await syncOrgMemberForOrgInvite(tx, {
         organizationId: row.invite.organizationId,
         roleId: row.invite.roleId,
         normalizedEmail,
@@ -458,6 +465,7 @@ export async function acceptOrganizationInvite(token: string, user: TAuthUser, c
       invite: row.invite,
       roleId: row.invite.roleId,
       alreadyAccepted,
+      studentMilestoneNotification,
       enrolledCount
     };
   });
@@ -474,6 +482,12 @@ export async function acceptOrganizationInvite(token: string, user: TAuthUser, c
 
   if (result.enrolledCount > 0 && result.invite.roleId === ROLE.STUDENT) {
     await invalidateOrgStats(result.invite.organizationId);
+  }
+
+  if (result.studentMilestoneNotification) {
+    notifyStudentMilestone(result.studentMilestoneNotification).catch((error) => {
+      console.error('notifyStudentMilestone error:', error);
+    });
   }
 
   const redirectTo = result.roleId === ROLE.STUDENT ? '/lms' : siteName ? `/org/${siteName}` : '/org';
@@ -693,9 +707,10 @@ export async function acceptOrganizationInviteById(
     }
 
     const alreadyAccepted = status === 'ACCEPTED';
+    let studentMilestoneNotification: StudentMilestoneNotification | null = null;
 
     if (!alreadyAccepted) {
-      await syncOrgMemberForOrgInvite(tx, {
+      studentMilestoneNotification = await syncOrgMemberForOrgInvite(tx, {
         organizationId: row.invite.organizationId,
         roleId: row.invite.roleId,
         normalizedEmail,
@@ -724,6 +739,7 @@ export async function acceptOrganizationInviteById(
       invite: row.invite,
       roleId: row.invite.roleId,
       alreadyAccepted,
+      studentMilestoneNotification,
       enrolledCount
     };
   });
@@ -738,6 +754,12 @@ export async function acceptOrganizationInviteById(
 
   if (result.enrolledCount > 0 && result.invite.roleId === ROLE.STUDENT) {
     await invalidateOrgStats(result.invite.organizationId);
+  }
+
+  if (result.studentMilestoneNotification) {
+    notifyStudentMilestone(result.studentMilestoneNotification).catch((error) => {
+      console.error('notifyStudentMilestone error:', error);
+    });
   }
 
   const siteName = result.organization.siteName || '';

--- a/apps/api/src/services/organization/invite.ts
+++ b/apps/api/src/services/organization/invite.ts
@@ -472,13 +472,15 @@ export async function acceptOrganizationInvite(token: string, user: TAuthUser, c
 
   const siteName = result.organization.siteName || '';
 
-  await recordOrganizationInviteAudit(result.invite.id, result.invite.organizationId, 'ACCEPTED', {
-    actorProfileId: user.id,
-    targetEmail: normalizedEmail,
-    ipAddress: context.ipAddress,
-    userAgent: context.userAgent,
-    metadata: { alreadyAccepted: result.alreadyAccepted }
-  });
+  if (!result.alreadyAccepted) {
+    await recordOrganizationInviteAudit(result.invite.id, result.invite.organizationId, 'ACCEPTED', {
+      actorProfileId: user.id,
+      targetEmail: normalizedEmail,
+      ipAddress: context.ipAddress,
+      userAgent: context.userAgent,
+      metadata: { alreadyAccepted: false }
+    });
+  }
 
   if (result.enrolledCount > 0 && result.invite.roleId === ROLE.STUDENT) {
     await invalidateOrgStats(result.invite.organizationId);
@@ -744,13 +746,15 @@ export async function acceptOrganizationInviteById(
     };
   });
 
-  await recordOrganizationInviteAudit(result.invite.id, result.invite.organizationId, 'ACCEPTED', {
-    actorProfileId: user.id,
-    targetEmail: normalizedEmail,
-    ipAddress: context.ipAddress,
-    userAgent: context.userAgent,
-    metadata: { alreadyAccepted: result.alreadyAccepted }
-  });
+  if (!result.alreadyAccepted) {
+    await recordOrganizationInviteAudit(result.invite.id, result.invite.organizationId, 'ACCEPTED', {
+      actorProfileId: user.id,
+      targetEmail: normalizedEmail,
+      ipAddress: context.ipAddress,
+      userAgent: context.userAgent,
+      metadata: { alreadyAccepted: false }
+    });
+  }
 
   if (result.enrolledCount > 0 && result.invite.roleId === ROLE.STUDENT) {
     await invalidateOrgStats(result.invite.organizationId);

--- a/apps/api/src/services/organization/invite.ts
+++ b/apps/api/src/services/organization/invite.ts
@@ -142,7 +142,7 @@ async function syncOrgMemberForOrgInvite(
 
   let studentMilestoneNotification: StudentMilestoneNotification | null = null;
   if (params.roleId === ROLE.STUDENT) {
-    studentMilestoneNotification = await assertStudentCapacityOrThrow(params.organizationId, 1, {
+    studentMilestoneNotification = await assertStudentCapacityOrThrow(params.organizationId, 1, tx, {
       deferNotification: true
     });
   }

--- a/apps/api/src/services/organization/invite.ts
+++ b/apps/api/src/services/organization/invite.ts
@@ -179,6 +179,72 @@ async function recordOrganizationInviteAudit(
   });
 }
 
+async function enrollOrganizationInviteUser(
+  tx: DbOrTxClient,
+  params: {
+    courseIds: string[];
+    cohortIds: string[];
+    profileId: string;
+    email: string;
+    roleId: number;
+  }
+): Promise<number> {
+  let enrolledCount = 0;
+
+  if (params.courseIds.length > 0) {
+    const courseGroupMappings = await getCourseGroupIds(params.courseIds, tx);
+    const courseGroupIds = courseGroupMappings.map((mapping) => mapping.groupId).filter(Boolean) as string[];
+
+    enrolledCount += await enrollUsersInCourseGroups(
+      courseGroupIds,
+      [{ profileId: params.profileId, email: params.email }],
+      params.roleId,
+      tx
+    );
+    await ensureComplianceEnrollmentRecordsForProfiles(params.courseIds, [params.profileId], tx);
+  }
+
+  if (params.cohortIds.length > 0) {
+    const existingCohortMemberships = await getExistingCohortMembers(
+      params.cohortIds.map((cohortId) => ({ cohortId, profileId: params.profileId })),
+      tx
+    );
+    const cohortIdsToInsert = params.cohortIds.filter(
+      (cohortId) => !existingCohortMemberships.has(`${cohortId}:${params.profileId}`)
+    );
+
+    for (const cohortId of cohortIdsToInsert) {
+      await addCohortMember(
+        {
+          cohortId,
+          roleId: params.roleId,
+          profileId: params.profileId,
+          email: params.email
+        },
+        tx
+      );
+    }
+
+    const cohortCourseIds = await getCourseIdsByCohortIds(params.cohortIds, tx);
+    const courseIdsToEnroll = cohortCourseIds.filter((courseId) => !params.courseIds.includes(courseId));
+
+    if (courseIdsToEnroll.length > 0) {
+      const cohortCourseGroups = await getCourseGroupIds(courseIdsToEnroll, tx);
+      const cohortGroupIds = cohortCourseGroups.map((mapping) => mapping.groupId).filter(Boolean) as string[];
+
+      enrolledCount += await enrollUsersInCourseGroups(
+        cohortGroupIds,
+        [{ profileId: params.profileId, email: params.email }],
+        params.roleId,
+        tx
+      );
+      await ensureComplianceEnrollmentRecordsForProfiles(courseIdsToEnroll, [params.profileId], tx);
+    }
+  }
+
+  return enrolledCount;
+}
+
 /**
  * Creates secure organization role invites from org settings.
  * Invites are role-aware and tokenized; legacy payload links are not used.
@@ -360,123 +426,54 @@ export async function acceptOrganizationInvite(token: string, user: TAuthUser, c
       throw new AppError('This invite is for a different email address', ErrorCodes.UNAUTHORIZED, 403);
     }
 
-    if (status === 'ACCEPTED') {
-      await markUserAndProfileEmailVerified(user.id, tx);
+    const alreadyAccepted = status === 'ACCEPTED';
 
-      return {
-        organization: row.organization,
+    if (!alreadyAccepted) {
+      await syncOrgMemberForOrgInvite(tx, {
+        organizationId: row.invite.organizationId,
         roleId: row.invite.roleId,
-        alreadyAccepted: true
-      };
-    }
+        normalizedEmail,
+        userId: user.id
+      });
 
-    await syncOrgMemberForOrgInvite(tx, {
-      organizationId: row.invite.organizationId,
-      roleId: row.invite.roleId,
-      normalizedEmail,
-      userId: user.id
-    });
+      const acceptedInvite = await claimPendingOrganizationInvite(tx, row.invite.id, user.id);
+
+      if (!acceptedInvite) {
+        throw new AppError('Invite is no longer available', ErrorCodes.VALIDATION_ERROR, 409);
+      }
+    }
 
     await markUserAndProfileEmailVerified(user.id, tx);
 
-    const acceptedInvite = await claimPendingOrganizationInvite(tx, row.invite.id, user.id);
-
-    if (!acceptedInvite) {
-      throw new AppError('Invite is no longer available', ErrorCodes.VALIDATION_ERROR, 409);
-    }
+    const enrolledCount = await enrollOrganizationInviteUser(tx, {
+      courseIds: parseCourseIdsFromInviteMetadata(row.invite.metadata),
+      cohortIds: parseCohortIdsFromInviteMetadata(row.invite.metadata),
+      profileId: user.id,
+      email: normalizedEmail,
+      roleId: row.invite.roleId
+    });
 
     return {
       organization: row.organization,
+      invite: row.invite,
       roleId: row.invite.roleId,
-      alreadyAccepted: false
+      alreadyAccepted,
+      enrolledCount
     };
   });
 
   const siteName = result.organization.siteName || '';
 
-  const invite = await getOrganizationInviteByTokenHash(tokenHash);
+  await recordOrganizationInviteAudit(result.invite.id, result.invite.organizationId, 'ACCEPTED', {
+    actorProfileId: user.id,
+    targetEmail: normalizedEmail,
+    ipAddress: context.ipAddress,
+    userAgent: context.userAgent,
+    metadata: { alreadyAccepted: result.alreadyAccepted }
+  });
 
-  if (invite) {
-    await recordOrganizationInviteAudit(invite.invite.id, invite.invite.organizationId, 'ACCEPTED', {
-      actorProfileId: user.id,
-      targetEmail: normalizedEmail,
-      ipAddress: context.ipAddress,
-      userAgent: context.userAgent,
-      metadata: { alreadyAccepted: result.alreadyAccepted }
-    });
-  }
-
-  // Auto-enroll in courses if invite metadata contains courseIds (from audience import).
-  // Run regardless of alreadyAccepted — enrollment is idempotent and the user may
-  // have accepted the org invite previously without getting course access.
-  if (invite) {
-    const metadata = invite.invite.metadata;
-    const courseIds = parseCourseIdsFromInviteMetadata(metadata);
-    const cohortIds = parseCohortIdsFromInviteMetadata(metadata);
-
-    if (courseIds.length > 0) {
-      try {
-        // Same as importAudienceMembers after course ids are known: resolve groups from course rows only.
-        const courseGroupMappings = await getCourseGroupIds(courseIds);
-        const validGroupIds = courseGroupMappings.map((m) => m.groupId).filter(Boolean) as string[];
-        const enrolledCount = await enrollUsersInCourseGroups(
-          validGroupIds,
-          [{ profileId: user.id, email: normalizedEmail }],
-          invite.invite.roleId
-        );
-
-        if (enrolledCount > 0 && invite.invite.roleId === ROLE.STUDENT) {
-          await invalidateOrgStats(invite.invite.organizationId);
-        }
-
-        await ensureComplianceEnrollmentRecordsForProfiles(courseIds, [user.id]);
-      } catch (error) {
-        console.error('acceptOrganizationInvite course enrollment error:', error);
-      }
-    }
-
-    if (cohortIds.length > 0) {
-      try {
-        const existingCohortMemberships = await getExistingCohortMembers(
-          cohortIds.map((cohortId) => ({ cohortId, profileId: user.id }))
-        );
-        const cohortIdsToInsert = cohortIds.filter(
-          (cohortId) => !existingCohortMemberships.has(`${cohortId}:${user.id}`)
-        );
-
-        await Promise.all(
-          cohortIdsToInsert.map((cohortId) =>
-            addCohortMember({
-              cohortId,
-              roleId: invite.invite.roleId,
-              profileId: user.id,
-              email: normalizedEmail
-            })
-          )
-        );
-
-        const cohortCourseIds = await getCourseIdsByCohortIds(cohortIds);
-        const courseIdsToEnroll = cohortCourseIds.filter((courseId) => !courseIds.includes(courseId));
-
-        if (courseIdsToEnroll.length > 0) {
-          const cohortCourseGroups = await getCourseGroupIds(courseIdsToEnroll);
-          const cohortGroupIds = cohortCourseGroups.map((mapping) => mapping.groupId).filter(Boolean) as string[];
-          const cohortEnrolledCount = await enrollUsersInCourseGroups(
-            cohortGroupIds,
-            [{ profileId: user.id, email: normalizedEmail }],
-            invite.invite.roleId
-          );
-
-          if (cohortEnrolledCount > 0 && invite.invite.roleId === ROLE.STUDENT) {
-            await invalidateOrgStats(invite.invite.organizationId);
-          }
-
-          await ensureComplianceEnrollmentRecordsForProfiles(courseIdsToEnroll, [user.id]);
-        }
-      } catch (error) {
-        console.error('acceptOrganizationInvite cohort enrollment error:', error);
-      }
-    }
+  if (result.enrolledCount > 0 && result.invite.roleId === ROLE.STUDENT) {
+    await invalidateOrgStats(result.invite.organizationId);
   }
 
   const redirectTo = result.roleId === ROLE.STUDENT ? '/lms' : siteName ? `/org/${siteName}` : '/org';
@@ -695,28 +692,40 @@ export async function acceptOrganizationInviteById(
       throw new AppError('This invite is for a different email address', ErrorCodes.UNAUTHORIZED, 403);
     }
 
-    if (status === 'ACCEPTED') {
-      await markUserAndProfileEmailVerified(user.id, tx);
+    const alreadyAccepted = status === 'ACCEPTED';
 
-      return { organization: row.organization, invite: row.invite, roleId: row.invite.roleId, alreadyAccepted: true };
+    if (!alreadyAccepted) {
+      await syncOrgMemberForOrgInvite(tx, {
+        organizationId: row.invite.organizationId,
+        roleId: row.invite.roleId,
+        normalizedEmail,
+        userId: user.id
+      });
+
+      const acceptedInvite = await claimPendingOrganizationInvite(tx, row.invite.id, user.id);
+
+      if (!acceptedInvite) {
+        throw new AppError('Invite is no longer available', ErrorCodes.VALIDATION_ERROR, 409);
+      }
     }
-
-    await syncOrgMemberForOrgInvite(tx, {
-      organizationId: row.invite.organizationId,
-      roleId: row.invite.roleId,
-      normalizedEmail,
-      userId: user.id
-    });
 
     await markUserAndProfileEmailVerified(user.id, tx);
 
-    const acceptedInvite = await claimPendingOrganizationInvite(tx, row.invite.id, user.id);
+    const enrolledCount = await enrollOrganizationInviteUser(tx, {
+      courseIds: parseCourseIdsFromInviteMetadata(row.invite.metadata),
+      cohortIds: parseCohortIdsFromInviteMetadata(row.invite.metadata),
+      profileId: user.id,
+      email: normalizedEmail,
+      roleId: row.invite.roleId
+    });
 
-    if (!acceptedInvite) {
-      throw new AppError('Invite is no longer available', ErrorCodes.VALIDATION_ERROR, 409);
-    }
-
-    return { organization: row.organization, invite: row.invite, roleId: row.invite.roleId, alreadyAccepted: false };
+    return {
+      organization: row.organization,
+      invite: row.invite,
+      roleId: row.invite.roleId,
+      alreadyAccepted,
+      enrolledCount
+    };
   });
 
   await recordOrganizationInviteAudit(result.invite.id, result.invite.organizationId, 'ACCEPTED', {
@@ -727,47 +736,8 @@ export async function acceptOrganizationInviteById(
     metadata: { alreadyAccepted: result.alreadyAccepted }
   });
 
-  const metadata = result.invite.metadata;
-  const courseIds = parseCourseIdsFromInviteMetadata(metadata);
-  const cohortIds = parseCohortIdsFromInviteMetadata(metadata);
-
-  if (courseIds.length > 0) {
-    try {
-      const courseGroupMappings = await getCourseGroupIds(courseIds);
-      const validGroupIds = courseGroupMappings.map((m) => m.groupId).filter(Boolean) as string[];
-      const enrolledCount = await enrollUsersInCourseGroups(
-        validGroupIds,
-        [{ profileId: user.id, email: normalizedEmail }],
-        result.invite.roleId
-      );
-
-      if (enrolledCount > 0 && result.invite.roleId === ROLE.STUDENT) {
-        await invalidateOrgStats(result.organization.id);
-      }
-
-      await ensureComplianceEnrollmentRecordsForProfiles(courseIds, [user.id]);
-    } catch (error) {
-      console.error('acceptOrganizationInviteById course enrollment error:', error);
-    }
-  }
-
-  if (cohortIds.length > 0) {
-    try {
-      const existingCohortMemberships = await getExistingCohortMembers(
-        cohortIds.map((cohortId) => ({ cohortId, profileId: user.id }))
-      );
-      const cohortIdsToInsert = cohortIds.filter(
-        (cohortId) => !existingCohortMemberships.has(`${cohortId}:${user.id}`)
-      );
-
-      await Promise.all(
-        cohortIdsToInsert.map((cohortId) =>
-          addCohortMember({ cohortId, roleId: result.invite.roleId, profileId: user.id, email: normalizedEmail })
-        )
-      );
-    } catch (error) {
-      console.error('acceptOrganizationInviteById cohort enrollment error:', error);
-    }
+  if (result.enrolledCount > 0 && result.invite.roleId === ROLE.STUDENT) {
+    await invalidateOrgStats(result.invite.organizationId);
   }
 
   const siteName = result.organization.siteName || '';

--- a/apps/api/src/services/organization/student-limit.ts
+++ b/apps/api/src/services/organization/student-limit.ts
@@ -3,11 +3,13 @@ import { enqueueTransactionalEmail } from '@api/services/jobs';
 import { getDashboardBaseUrl } from '@cio/core/config/dashboard-url';
 import { getStudentLimit } from '@cio/utils/plans';
 import { env } from '@cio/core/config/env';
+import { type DbOrTxClient, db } from '@cio/db/drizzle';
 import {
   countActiveStudents,
   getActiveOrganizationPlan,
   getOrganizationAdminEmails,
   getOrganizationById,
+  lockOrganizationForStudentCapacity,
   updateOrganization
 } from '@cio/db/queries/organization';
 
@@ -64,17 +66,20 @@ export async function notifyStudentMilestone(notification: StudentMilestoneNotif
 export async function assertStudentCapacityOrThrow(
   orgId: string,
   additionalStudents: number,
+  dbClient: DbOrTxClient = db,
   options: { deferNotification?: boolean } = {}
 ): Promise<StudentMilestoneNotification | null> {
   if (additionalStudents <= 0) return null;
   if (env.PUBLIC_IS_SELFHOSTED === 'true') return null;
 
-  const activePlan = await getActiveOrganizationPlan(orgId);
+  await lockOrganizationForStudentCapacity(orgId, dbClient);
+
+  const activePlan = await getActiveOrganizationPlan(orgId, dbClient);
   const limit = getStudentLimit(activePlan?.planName);
 
   if (!Number.isFinite(limit)) return null;
 
-  const currentCount = await countActiveStudents(orgId);
+  const currentCount = await countActiveStudents(orgId, dbClient);
   const newCount = currentCount + additionalStudents;
 
   if (newCount > limit) {

--- a/apps/api/src/services/organization/student-limit.ts
+++ b/apps/api/src/services/organization/student-limit.ts
@@ -13,18 +13,21 @@ import {
 
 type StudentMilestone = 'half' | 'reached';
 
+export type StudentMilestoneNotification = {
+  orgId: string;
+  milestone: StudentMilestone;
+  studentCount: number;
+  studentLimit: number;
+};
+
 /**
  * Emails org admins once when the org crosses a student-count milestone (50%
  * of the limit, or the limit itself). The "already notified" state is persisted
  * on `organization.settings` so each milestone fires at most once, ever — no
  * repeat emails on every subsequent blocked attempt.
  */
-async function notifyStudentMilestone(
-  orgId: string,
-  milestone: StudentMilestone,
-  studentCount: number,
-  studentLimit: number
-): Promise<void> {
+export async function notifyStudentMilestone(notification: StudentMilestoneNotification): Promise<void> {
+  const { orgId, milestone, studentCount, studentLimit } = notification;
   const org = await getOrganizationById(orgId);
   if (!org) return;
 
@@ -58,14 +61,18 @@ async function notifyStudentMilestone(
  * When the addition is allowed and crosses a milestone (50% or the limit), it
  * fires a one-time admin email (fire-and-forget). Blocked attempts do NOT email.
  */
-export async function assertStudentCapacityOrThrow(orgId: string, additionalStudents: number): Promise<void> {
-  if (additionalStudents <= 0) return;
-  if (env.PUBLIC_IS_SELFHOSTED === 'true') return;
+export async function assertStudentCapacityOrThrow(
+  orgId: string,
+  additionalStudents: number,
+  options: { deferNotification?: boolean } = {}
+): Promise<StudentMilestoneNotification | null> {
+  if (additionalStudents <= 0) return null;
+  if (env.PUBLIC_IS_SELFHOSTED === 'true') return null;
 
   const activePlan = await getActiveOrganizationPlan(orgId);
   const limit = getStudentLimit(activePlan?.planName);
 
-  if (!Number.isFinite(limit)) return;
+  if (!Number.isFinite(limit)) return null;
 
   const currentCount = await countActiveStudents(orgId);
   const newCount = currentCount + additionalStudents;
@@ -84,8 +91,16 @@ export async function assertStudentCapacityOrThrow(orgId: string, additionalStud
 
   if (crossedReached || crossedHalf) {
     const milestone: StudentMilestone = crossedReached ? 'reached' : 'half';
-    notifyStudentMilestone(orgId, milestone, newCount, limit).catch((error) => {
-      console.error('notifyStudentMilestone error:', error);
-    });
+    const notification = { orgId, milestone, studentCount: newCount, studentLimit: limit };
+
+    if (!options.deferNotification) {
+      notifyStudentMilestone(notification).catch((error) => {
+        console.error('notifyStudentMilestone error:', error);
+      });
+    }
+
+    return notification;
   }
+
+  return null;
 }

--- a/packages/db/src/queries/cohort/cohort.ts
+++ b/packages/db/src/queries/cohort/cohort.ts
@@ -188,7 +188,8 @@ export async function searchLmsCohorts(
 }
 
 export async function getExistingCohortMembers(
-  pairs: Array<{ cohortId: string; profileId: string }>
+  pairs: Array<{ cohortId: string; profileId: string }>,
+  dbClient: DbOrTxClient = db
 ): Promise<Set<string>> {
   if (pairs.length === 0) {
     return new Set();
@@ -198,7 +199,7 @@ export async function getExistingCohortMembers(
     const cohortIds = [...new Set(pairs.map((pair) => pair.cohortId))];
     const profileIds = [...new Set(pairs.map((pair) => pair.profileId))];
 
-    const rows = await db
+    const rows = await dbClient
       .select({ cohortId: schema.cohortMember.cohortId, profileId: schema.cohortMember.profileId })
       .from(schema.cohortMember)
       .where(and(inArray(schema.cohortMember.cohortId, cohortIds), inArray(schema.cohortMember.profileId, profileIds)));
@@ -513,11 +514,11 @@ export async function getCoursesByCohort(
   }
 }
 
-export async function getCourseIdsByCohortIds(cohortIds: string[]): Promise<string[]> {
+export async function getCourseIdsByCohortIds(cohortIds: string[], dbClient: DbOrTxClient = db): Promise<string[]> {
   try {
     if (cohortIds.length === 0) return [];
 
-    const rows = await db
+    const rows = await dbClient
       .selectDistinct({ courseId: schema.cohortCourse.courseId })
       .from(schema.cohortCourse)
       .where(inArray(schema.cohortCourse.cohortId, cohortIds));

--- a/packages/db/src/queries/course/compliance.ts
+++ b/packages/db/src/queries/course/compliance.ts
@@ -38,7 +38,8 @@ export type CourseComplianceReminderRow = {
 
 export async function getStudentCourseMembersForCompliance(
   courseId: string,
-  profileIds?: string[]
+  profileIds?: string[],
+  dbClient: DbOrTxClient = db
 ): Promise<Array<{ member: TGroupmember; profile: CourseMemberProfile | null }>> {
   try {
     const conditions = [
@@ -51,7 +52,7 @@ export async function getStudentCourseMembersForCompliance(
       conditions.push(inArray(schema.groupmember.profileId, profileIds));
     }
 
-    const result = await db
+    const result = await dbClient
       .select({
         member: schema.groupmember,
         profile: {
@@ -201,14 +202,15 @@ export async function getCourseComplianceHistoryRows(
 
 export async function getLatestComplianceRecordsByProfiles(
   courseId: string,
-  profileIds: string[]
+  profileIds: string[],
+  dbClient: DbOrTxClient = db
 ): Promise<TCourseCompletionRecord[]> {
   try {
     if (profileIds.length === 0) {
       return [];
     }
 
-    const latestCycles = db
+    const latestCycles = dbClient
       .select({
         courseId: schema.courseCompletionRecord.courseId,
         profileId: schema.courseCompletionRecord.profileId,
@@ -224,7 +226,7 @@ export async function getLatestComplianceRecordsByProfiles(
       .groupBy(schema.courseCompletionRecord.courseId, schema.courseCompletionRecord.profileId)
       .as('latest_course_compliance_cycles_by_profile');
 
-    return await db
+    return await dbClient
       .select({
         id: schema.courseCompletionRecord.id,
         courseId: schema.courseCompletionRecord.courseId,

--- a/packages/db/src/queries/course/course.ts
+++ b/packages/db/src/queries/course/course.ts
@@ -312,9 +312,9 @@ export const getCoursesBySiteNameForSetup = async (siteName: string) => {
     ...row.course
   }));
 };
-export async function getCourseById(courseId: string) {
+export async function getCourseById(courseId: string, dbClient: DbOrTxClient = db) {
   try {
-    return await db.select().from(schema.course).where(eq(schema.course.id, courseId)).limit(1);
+    return await dbClient.select().from(schema.course).where(eq(schema.course.id, courseId)).limit(1);
   } catch (error) {
     console.error('getCourseById error:', error);
     throw new Error(
@@ -1395,11 +1395,11 @@ export async function deleteCourseSection(sectionId: string, dbClient: DbOrTxCli
  * @param courseIds Array of course IDs
  * @returns Array of { courseId, groupId } mappings
  */
-export async function getCourseGroupIds(courseIds: string[]) {
+export async function getCourseGroupIds(courseIds: string[], dbClient: DbOrTxClient = db) {
   try {
     if (courseIds.length === 0) return [];
 
-    return db
+    return dbClient
       .select({ courseId: schema.course.id, groupId: schema.course.groupId })
       .from(schema.course)
       .where(inArray(schema.course.id, courseIds));

--- a/packages/db/src/queries/group/group.ts
+++ b/packages/db/src/queries/group/group.ts
@@ -24,10 +24,10 @@ export async function addGroupMember(values: TNewGroupmember, dbClient: DbOrTxCl
   }
 }
 
-export async function addGroupMembers(values: TNewGroupmember[]) {
+export async function addGroupMembers(values: TNewGroupmember[], dbClient: DbOrTxClient = db) {
   if (values.length === 0) return [];
   try {
-    return db.insert(schema.groupmember).values(values).returning();
+    return dbClient.insert(schema.groupmember).values(values).returning();
   } catch (error) {
     console.error('addGroupMembers error:', error);
     throw new Error(`Failed to bulk add group members: ${error instanceof Error ? error.message : 'Unknown error'}`);
@@ -35,7 +35,8 @@ export async function addGroupMembers(values: TNewGroupmember[]) {
 }
 
 export async function getExistingGroupMembers(
-  pairs: Array<{ groupId: string; profileId: string }>
+  pairs: Array<{ groupId: string; profileId: string }>,
+  dbClient: DbOrTxClient = db
 ): Promise<Set<string>> {
   if (pairs.length === 0) return new Set();
 
@@ -43,7 +44,7 @@ export async function getExistingGroupMembers(
     const groupIds = [...new Set(pairs.map((p) => p.groupId))];
     const profileIds = [...new Set(pairs.map((p) => p.profileId))];
 
-    const rows = await db
+    const rows = await dbClient
       .select({ groupId: schema.groupmember.groupId, profileId: schema.groupmember.profileId })
       .from(schema.groupmember)
       .where(and(inArray(schema.groupmember.groupId, groupIds), inArray(schema.groupmember.profileId, profileIds)));
@@ -64,12 +65,13 @@ export async function getExistingGroupMembers(
 export async function enrollUsersInCourseGroups(
   groupIds: string[],
   users: Array<{ profileId: string; email?: string }>,
-  roleId: number
+  roleId: number,
+  dbClient: DbOrTxClient = db
 ): Promise<number> {
   if (groupIds.length === 0 || users.length === 0) return 0;
 
   const pairs = users.flatMap((u) => groupIds.map((groupId) => ({ groupId, profileId: u.profileId })));
-  const existingSet = await getExistingGroupMembers(pairs);
+  const existingSet = await getExistingGroupMembers(pairs, dbClient);
   const emailByProfile = new Map(users.map((u) => [u.profileId, u.email]));
 
   const toInsert = pairs
@@ -82,7 +84,7 @@ export async function enrollUsersInCourseGroups(
     }));
 
   if (toInsert.length > 0) {
-    await addGroupMembers(toInsert);
+    await addGroupMembers(toInsert, dbClient);
   }
 
   return toInsert.length;

--- a/packages/db/src/queries/organization/organization.ts
+++ b/packages/db/src/queries/organization/organization.ts
@@ -275,8 +275,12 @@ export const getOrganizationByCustomDomain = async (customDomain: string): Promi
  * @param id Organization ID
  * @returns Organization or null if not found
  */
-export const getOrganizationById = async (id: string): Promise<TOrganization | null> => {
-  const [organization] = await db.select().from(schema.organization).where(eq(schema.organization.id, id)).limit(1);
+export const getOrganizationById = async (id: string, dbClient: DbOrTxClient = db): Promise<TOrganization | null> => {
+  const [organization] = await dbClient
+    .select()
+    .from(schema.organization)
+    .where(eq(schema.organization.id, id))
+    .limit(1);
 
   return organization || null;
 };
@@ -655,9 +659,18 @@ export const getOrganizationTeam = async (orgId: string) => {
 /**
  * Counts active organization members with the student role. Used to enforce per-plan student caps.
  */
-export async function countActiveStudents(orgId: string): Promise<number> {
+export async function lockOrganizationForStudentCapacity(orgId: string, dbClient: DbOrTxClient = db): Promise<void> {
+  await dbClient
+    .select({ id: schema.organization.id })
+    .from(schema.organization)
+    .where(eq(schema.organization.id, orgId))
+    .for('update')
+    .limit(1);
+}
+
+export async function countActiveStudents(orgId: string, dbClient: DbOrTxClient = db): Promise<number> {
   try {
-    const [row] = await db
+    const [row] = await dbClient
       .select({ count: count(schema.organizationmember.id) })
       .from(schema.organizationmember)
       .where(
@@ -674,9 +687,12 @@ export async function countActiveStudents(orgId: string): Promise<number> {
 /**
  * Gets verified admin emails for an organization. Used to notify admins about plan-limit events.
  */
-export async function getOrganizationAdminEmails(orgId: string): Promise<Array<{ email: string; fullname: string }>> {
+export async function getOrganizationAdminEmails(
+  orgId: string,
+  dbClient: DbOrTxClient = db
+): Promise<Array<{ email: string; fullname: string }>> {
   try {
-    const result = await db
+    const result = await dbClient
       .select({
         email: schema.organizationmember.email,
         profileEmail: schema.profile.email,
@@ -1174,11 +1190,15 @@ export const cancelOrganizationPlan = async (
  * @param data Partial organization data to update. When `settings` is provided, it is deep-merged with existing settings.
  * @returns Updated organization record
  */
-export const updateOrganization = async (id: string, data: Partial<TOrganization>): Promise<TOrganization> => {
+export const updateOrganization = async (
+  id: string,
+  data: Partial<TOrganization>,
+  dbClient: DbOrTxClient = db
+): Promise<TOrganization> => {
   let setData = { ...data };
 
   if (data.settings !== undefined) {
-    const [existing] = await db
+    const [existing] = await dbClient
       .select({ settings: schema.organization.settings })
       .from(schema.organization)
       .where(eq(schema.organization.id, id))
@@ -1208,7 +1228,7 @@ export const updateOrganization = async (id: string, data: Partial<TOrganization
     setData = { ...setData, settings: mergedSettings as TOrganization['settings'] };
   }
 
-  const [organization] = await db
+  const [organization] = await dbClient
     .update(schema.organization)
     .set(setData)
     .where(eq(schema.organization.id, id))
@@ -1234,8 +1254,8 @@ export const getOrganizationPlanStatus = async (orgId: string) => {
   return result;
 };
 
-export const getActiveOrganizationPlan = async (orgId: string) => {
-  const [plan] = await db
+export const getActiveOrganizationPlan = async (orgId: string, dbClient: DbOrTxClient = db) => {
+  const [plan] = await dbClient
     .select()
     .from(schema.organizationPlan)
     .where(and(eq(schema.organizationPlan.orgId, orgId), eq(schema.organizationPlan.isActive, true)))
@@ -1244,7 +1264,7 @@ export const getActiveOrganizationPlan = async (orgId: string) => {
   if (plan) return plan;
 
   // Secondary workspaces inherit their primary's plan.
-  const [org] = await db
+  const [org] = await dbClient
     .select({ parentOrganizationId: schema.organization.parentOrganizationId })
     .from(schema.organization)
     .where(eq(schema.organization.id, orgId))
@@ -1252,7 +1272,7 @@ export const getActiveOrganizationPlan = async (orgId: string) => {
 
   if (!org?.parentOrganizationId) return null;
 
-  const [parentPlan] = await db
+  const [parentPlan] = await dbClient
     .select()
     .from(schema.organizationPlan)
     .where(and(eq(schema.organizationPlan.orgId, org.parentOrganizationId), eq(schema.organizationPlan.isActive, true)))


### PR DESCRIPTION
## What does this PR do?

Makes organization invite acceptance atomic for both token-based and invite-ID flows. Course group memberships, cohort memberships, compliance records, organization membership, email verification, and invite claiming now use the same database transaction. Enrollment errors propagate and roll back the acceptance instead of being logged and swallowed.

## Demo

Not applicable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- `export PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH" && pnpm --filter @cio/api^... build && pnpm --filter @cio/api build` passed.
- `pnpm --filter @cio/db build` passed.
- `pnpm format:check` passed.
- `pnpm --filter @cio/api exec vitest run` ran 95 tests successfully; 7 existing suites remain blocked by workspace module-resolution failures unrelated to this change.
- Verify with an organization invite containing course or cohort metadata: force an enrollment query failure and confirm the organization member and invite claim are rolled back.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
- [x] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the ClassroomIO Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Organization invite acceptance now reliably completes course and cohort enrollments, including for previously accepted invitations.
  * Enrollment records and audit events are handled more consistently without creating duplicates.
  * Student enrollment milestone notifications are delivered after successful enrollment.

* **Reliability**
  * Enrollment workflows now complete transactionally, helping prevent partial updates.
  * Improved capacity checks reduce the risk of exceeding student limits during concurrent enrollments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves organization-invite membership, enrollment, compliance, verification, and invite claiming into shared database transactions, then defers capacity notifications until commit.
- Threads transaction clients through course, cohort, group, and compliance queries.
- Consolidates token and invite-ID enrollment into a transactional helper.
- Adds post-commit milestone notification handling, but the reusable link-invite caller currently drops the deferred notification.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because student link-invite acceptance silently drops required capacity-milestone notifications.

The new deferred-notification contract is handled by token and invite-ID acceptance, but acceptLinkInvite discards the returned notification, so successful link-invite joins can permanently miss the milestone email and state update.

**Files Needing Attention:** apps/api/src/services/organization/invite.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/services/organization/invite.ts | Makes invite enrollment transactional and dispatches deferred notifications after commit, but omits that dispatch for reusable link invites. |
| apps/api/src/services/organization/student-limit.ts | Adds a deferred notification result so transactional callers can avoid emitting milestone state before commit. |
| apps/api/src/services/course/compliance.ts | Threads an optional transaction client through compliance enrollment-record creation. |
| packages/db/src/queries/cohort/cohort.ts | Allows cohort membership lookups to participate in the caller's transaction. |
| packages/db/src/queries/course/compliance.ts | Adds transaction-client support to compliance queries used during atomic enrollment. |
| packages/db/src/queries/course/course.ts | Adds transaction-client support to course lookups used by invite enrollment. |
| packages/db/src/queries/group/group.ts | Adds transaction-client support to group enrollment operations. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User
  participant Invite as Invite service
  participant DB as Database transaction
  participant Limit as Student-limit service
  participant Jobs as Email queue

  User->>Invite: Accept organization invite
  Invite->>DB: Begin transaction
  Invite->>Limit: Check capacity (defer notification)
  Limit-->>Invite: Milestone notification or null
  Invite->>DB: Create member and enroll user
  DB-->>Invite: Commit
  alt Token or invite-ID flow
    Invite->>Jobs: Enqueue milestone notification
  else Link-invite flow
    Note over Invite,Jobs: Returned notification is discarded
  end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/api/src/services/organization/invite.ts`, line 622-627 ([link](https://github.com/classroomio/classroomio/blob/827b612441419df2c3facd0bfc95a939f2d1f163/apps/api/src/services/organization/invite.ts#L622-L627)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Link Invites Drop Notifications**

   When a student accepts a reusable organization link invite and the new membership crosses a capacity milestone, `acceptLinkInvite` discards the deferred notification returned by `syncOrgMemberForOrgInvite`, causing administrators to miss the milestone email and leaving `studentLimitNotified` unchanged.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(api): avoid duplicate invite audit e..."](https://github.com/classroomio/classroomio/commit/827b612441419df2c3facd0bfc95a939f2d1f163) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58995683)</sub>

<!-- /greptile_comment -->