### PR TITLE
fix(api): keep organization creation read atomic

### DIFF
--- a/apps/api/src/__tests__/onboarding.test.ts
+++ b/apps/api/src/__tests__/onboarding.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@cio/db/queries', () => ({
+  checkSiteNameExists: vi.fn(),
+  createOrganization: vi.fn(),
+  createOrganizationMember: vi.fn(),
+  createOrganizationPlan: vi.fn(),
+  getOrganizationByProfileId: vi.fn(),
+  getOrganizationCount: vi.fn()
+}));
+
+vi.mock('@cio/db/queries/auth', () => ({
+  getProfileById: vi.fn(),
+  updateProfile: vi.fn()
+}));
+
+vi.mock('@cio/db/drizzle', () => ({
+  db: {
+    transaction: vi.fn()
+  }
+}));
+
+vi.mock('@cio/core/config/env', () => ({
+  env: { PUBLIC_IS_SELFHOSTED: 'false' }
+}));
+
+vi.mock('@api/services/jobs', () => ({
+  enqueueTransactionalEmail: vi.fn()
+}));
+
+import { createOrganizationWithOwner } from '@api/services/onboarding';
+import {
+  checkSiteNameExists,
+  createOrganization,
+  createOrganizationMember,
+  getOrganizationByProfileId
+} from '@cio/db/queries';
+import { db } from '@cio/db/drizzle';
+
+const PROFILE_ID = 'profile-1';
+const ORGANIZATION_ID = 'organization-1';
+
+describe('createOrganizationWithOwner', () => {
+  const transactionClient = { transaction: true };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(checkSiteNameExists).mockResolvedValue(false);
+    vi.mocked(createOrganization).mockResolvedValue({ id: ORGANIZATION_ID } as never);
+    vi.mocked(createOrganizationMember).mockResolvedValue({ id: 1 } as never);
+    vi.mocked(db.transaction).mockImplementation(async (callback) => callback(transactionClient as never));
+  });
+
+  it('reads the updated organization list inside the creation transaction', async () => {
+    const organizations = [{ id: ORGANIZATION_ID }];
+    vi.mocked(getOrganizationByProfileId).mockResolvedValue(organizations as never);
+
+    const result = await createOrganizationWithOwner(PROFILE_ID, {
+      orgName: 'Test organization',
+      siteName: 'test-organization'
+    });
+
+    expect(getOrganizationByProfileId).toHaveBeenCalledWith(PROFILE_ID, transactionClient);
+    expect(result.organizations).toBe(organizations);
+  });
+
+  it('rejects the transaction when reading the updated organization list fails', async () => {
+    vi.mocked(getOrganizationByProfileId).mockRejectedValue(new Error('Read failed'));
+
+    await expect(
+      createOrganizationWithOwner(PROFILE_ID, {
+        orgName: 'Test organization',
+        siteName: 'test-organization'
+      })
+    ).rejects.toMatchObject({ statusCode: 500 });
+
+    expect(db.transaction).toHaveBeenCalledOnce();
+    expect(getOrganizationByProfileId).toHaveBeenCalledWith(PROFILE_ID, transactionClient);
+  });
+});

--- a/apps/api/src/services/onboarding.ts
+++ b/apps/api/src/services/onboarding.ts
@@ -76,16 +76,15 @@ export async function createOrganizationWithOwner(
         );
       }
 
-      return { organization, member };
-    });
+      const organizations = await getOrganizationByProfileId(profileId, tx);
 
-    // Fetch updated organizations list
-    const organizations = await getOrganizationByProfileId(profileId);
+      return { organization, member, organizations };
+    });
 
     return {
       organization: result.organization,
       member: result.member,
-      organizations
+      organizations: result.organizations
     };
   } catch (error) {
     console.error('Error creating organization:', error);

--- a/packages/db/src/queries/organization/organization.ts
+++ b/packages/db/src/queries/organization/organization.ts
@@ -55,8 +55,11 @@ export async function getVerifiedCustomDomainHostnames(): Promise<string[]> {
   }
 }
 
-export const getOrganizationByProfileId = async (profileId: string): Promise<OrganizationWithMemberAndPlans[]> => {
-  const result = await db
+export const getOrganizationByProfileId = async (
+  profileId: string,
+  dbClient: DbOrTxClient = db
+): Promise<OrganizationWithMemberAndPlans[]> => {
+  const result = await dbClient
     .select({
       organization: schema.organization,
       memberId: schema.organizationmember.id,


### PR DESCRIPTION
## Summary
- allow `getOrganizationByProfileId` to use a transaction client
- fetch the updated organization list before the creation transaction commits
- add regression coverage for transaction-client usage and read failures

## Verification
- `pnpm --filter @cio/api^... build`
- `pnpm --filter @cio/api test --run src/__tests__/onboarding.test.ts`
- `pnpm --filter @cio/api build`
- `pnpm format:check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes organization creation and its returned organization-list read one atomic database operation.

- Adds optional transaction-client support to `getOrganizationByProfileId`.
- Moves the updated organization-list read into the creation transaction.
- Adds regression tests for transaction-client use and read-error propagation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the organization creation writes and resulting organization-list read consistently sharing one transaction.

The supplied transaction client is used throughout the unchanged organization query, read errors propagate out of the transaction, and no external side effect can become inconsistent when the transaction rolls back.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/services/onboarding.ts | Moves the updated organization-list read into the creation transaction so read failure rolls back all related writes. |
| packages/db/src/queries/organization/organization.ts | Allows the organization lookup to use either the shared database client or a supplied transaction client without changing its result contract. |
| apps/api/src/__tests__/onboarding.test.ts | Adds focused coverage for transaction-client forwarding and propagation of organization-list read failures. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Client
  participant API as Onboarding service
  participant TX as Database transaction
  participant DB as PostgreSQL

  Client->>API: Create organization
  API->>TX: Begin transaction
  TX->>DB: Insert organization
  TX->>DB: Insert owner membership
  opt Self-hosted deployment
    TX->>DB: Insert organization plan
  end
  TX->>DB: Read profile organizations using tx client
  DB-->>TX: Updated organization list
  TX->>DB: Commit
  TX-->>API: Organization, member, organizations
  API-->>Client: Creation result
```

<sub>Reviews (1): Last reviewed commit: ["fix(api): keep organization creation rea..."](https://github.com/classroomio/classroomio/commit/ee5a81b8a4010e8b9504889ba75322b80bcddf3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58994201)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Platform backend](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/platform-backend.md)
- Knowledge Base — [Data and identity](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/data-and-identity.md)
- Knowledge Base — [Database model and access](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/database-model-and-access.md)
</details>


<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved onboarding reliability by ensuring the organization list is retrieved as part of the organization creation process.
  - Organization data returned after onboarding now reflects the completed transaction.
  - Failures while loading organizations correctly reject the onboarding operation with an appropriate error.

- **Tests**
  - Added coverage for organization creation, returned organization data, transactional reads, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->