### PR TITLE
fix(api): make course and tag updates atomic

### DIFF
--- a/apps/api/src/routes/course/course.ts
+++ b/apps/api/src/routes/course/course.ts
@@ -65,6 +65,7 @@ import { sectionRouter } from '@api/routes/course/section';
 import { submissionRouter } from '@api/routes/course/submission';
 import { updateCourseLandingPageService } from '@cio/core/services/course/landing-page';
 import { zValidator } from '@hono/zod-validator';
+import { updateCourseWithTags } from '@api/services/course/update-course';
 
 function slugifyForFilename(value: string): string {
   return (
@@ -337,8 +338,6 @@ export const courseRouter = new Hono()
           };
         }
 
-        const result = await updateCourse(courseId, courseData);
-
         if (tagIds !== undefined) {
           const orgId = c.req.header('cio-org-id');
           if (!orgId) {
@@ -353,19 +352,27 @@ export const courseRouter = new Hono()
           }
 
           const user = c.get('user')!;
-          const tags = await replaceCourseTags(orgId, courseId, { tagIds }, { updatedByUserId: user.id });
+          const result = await updateCourseWithTags({
+            courseId,
+            courseData,
+            orgId,
+            updatedByUserId: user.id,
+            tagIds
+          });
 
           return c.json(
             {
               success: true,
               data: {
-                ...result,
-                tags
+                ...result.course,
+                tags: result.tags
               }
             },
             200
           );
         }
+
+        const result = await updateCourse(courseId, courseData);
 
         return c.json(
           {

--- a/apps/api/src/services/course/__tests__/update-course.test.ts
+++ b/apps/api/src/services/course/__tests__/update-course.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  transaction: vi.fn(),
+  updateCourse: vi.fn(),
+  replaceCourseTags: vi.fn()
+}));
+
+vi.mock('@cio/db/drizzle', () => ({
+  db: { transaction: mocks.transaction }
+}));
+
+vi.mock('@cio/core/services/course/course', () => ({
+  updateCourse: mocks.updateCourse
+}));
+
+vi.mock('@api/services/tag', () => ({
+  replaceCourseTags: mocks.replaceCourseTags
+}));
+
+import { updateCourseWithTags } from '../update-course';
+
+const transactionClient = { id: 'transaction-client' };
+
+describe('updateCourseWithTags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.transaction.mockImplementation(async (callback) => callback(transactionClient));
+    mocks.updateCourse.mockResolvedValue({ id: 'course-1', title: 'Updated course' });
+    mocks.replaceCourseTags.mockResolvedValue([{ id: 'tag-1' }]);
+  });
+
+  it('updates the course and tags on the same transaction client', async () => {
+    const result = await updateCourseWithTags({
+      courseId: 'course-1',
+      courseData: { title: 'Updated course' },
+      orgId: 'org-1',
+      updatedByUserId: 'user-1',
+      tagIds: ['tag-1']
+    });
+
+    expect(mocks.transaction).toHaveBeenCalledOnce();
+    expect(mocks.updateCourse).toHaveBeenCalledWith('course-1', { title: 'Updated course' }, transactionClient);
+    expect(mocks.replaceCourseTags).toHaveBeenCalledWith(
+      'org-1',
+      'course-1',
+      { tagIds: ['tag-1'] },
+      { updatedByUserId: 'user-1', dbClient: transactionClient }
+    );
+    expect(result).toEqual({
+      course: { id: 'course-1', title: 'Updated course' },
+      tags: [{ id: 'tag-1' }]
+    });
+  });
+
+  it('propagates tag failures so the transaction can roll back the course update', async () => {
+    const tagError = new Error('One or more tags are invalid');
+    mocks.replaceCourseTags.mockRejectedValue(tagError);
+
+    await expect(
+      updateCourseWithTags({
+        courseId: 'course-1',
+        courseData: { title: 'Updated course' },
+        orgId: 'org-1',
+        updatedByUserId: 'user-1',
+        tagIds: ['missing-tag']
+      })
+    ).rejects.toBe(tagError);
+
+    expect(mocks.updateCourse).toHaveBeenCalledWith('course-1', { title: 'Updated course' }, transactionClient);
+    expect(mocks.transaction).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/services/course/update-course.ts
+++ b/apps/api/src/services/course/update-course.ts
@@ -1,0 +1,24 @@
+import { updateCourse } from '@cio/core/services/course/course';
+import { db } from '@cio/db/drizzle';
+import type { TCourse } from '@cio/db/types';
+import { replaceCourseTags } from '@api/services/tag';
+
+export async function updateCourseWithTags(params: {
+  courseId: string;
+  courseData: Partial<TCourse>;
+  orgId: string;
+  updatedByUserId: string;
+  tagIds: string[];
+}) {
+  return db.transaction(async (tx) => {
+    const course = await updateCourse(params.courseId, params.courseData, tx);
+    const tags = await replaceCourseTags(
+      params.orgId,
+      params.courseId,
+      { tagIds: params.tagIds },
+      { updatedByUserId: params.updatedByUserId, dbClient: tx }
+    );
+
+    return { course, tags };
+  });
+}

--- a/apps/api/src/services/tag.ts
+++ b/apps/api/src/services/tag.ts
@@ -27,6 +27,7 @@ import {
 import { getOrgIdBySiteName, isUserOrgAdmin } from '@cio/db/queries/organization';
 import { TAG_COLOR_OPTIONS, type TTagColor } from '@cio/utils/validation/tag';
 import { slugifyTagValue } from '@cio/db/queries/tag';
+import type { DbOrTxClient } from '@cio/db/drizzle';
 
 import { AppError, ErrorCodes } from '@api/utils/errors';
 
@@ -314,17 +315,18 @@ export async function replaceCourseTags(
   data: TCourseTagAssignment,
   options: {
     updatedByUserId?: string;
+    dbClient?: DbOrTxClient;
   } = {}
 ) {
   try {
     if (options.updatedByUserId) {
-      const isAdmin = await isUserOrgAdmin(orgId, options.updatedByUserId);
+      const isAdmin = await isUserOrgAdmin(orgId, options.updatedByUserId, options.dbClient);
       if (!isAdmin) {
         throw new AppError('Only organization admins can update course tags', ErrorCodes.UNAUTHORIZED, 403);
       }
     }
 
-    const courseOrgId = await getCourseOrganizationId(courseId);
+    const courseOrgId = await getCourseOrganizationId(courseId, options.dbClient);
 
     if (!courseOrgId) {
       throw new AppError('Course not found', ErrorCodes.COURSE_NOT_FOUND, 404);
@@ -337,15 +339,15 @@ export async function replaceCourseTags(
     const uniqueTagIds = Array.from(new Set(data.tagIds));
 
     if (uniqueTagIds.length > 0) {
-      const validTags = await getTagsByIds(orgId, uniqueTagIds);
+      const validTags = await getTagsByIds(orgId, uniqueTagIds, options.dbClient);
       if (validTags.length !== uniqueTagIds.length) {
         throw new AppError('One or more tags are invalid', ErrorCodes.VALIDATION_ERROR, 400, 'tagIds');
       }
     }
 
-    await replaceCourseTagAssignments(courseId, uniqueTagIds);
+    await replaceCourseTagAssignments(courseId, uniqueTagIds, options.dbClient);
 
-    return getCourseTagsForOrganization(orgId, courseId);
+    return getCourseTagsForOrganization(orgId, courseId, options.dbClient);
   } catch (error) {
     if (error instanceof AppError) {
       throw error;

--- a/packages/core/src/services/course/course.ts
+++ b/packages/core/src/services/course/course.ts
@@ -6,6 +6,7 @@ import {
   createCourseSections,
   deleteCourse as deleteCourseQuery,
   getCourseById,
+  getCourseContentItems,
   getCourseProgress as getCourseProgressQuery,
   getCourseWithRelations,
   getOrgIdByCourseId,
@@ -31,6 +32,7 @@ import { getCourseGroupId } from '@cio/db/queries/course/people';
 import { ContentType, ROLE } from '@cio/utils/constants';
 import { isPublishedComplianceMissingDeadline, resolveCourseCertificateDeadline } from '@cio/utils/functions';
 import type { TCourse } from '@cio/db/types';
+import type { DbOrTxClient } from '@cio/db/drizzle';
 import type { TCourseCreate } from '@cio/utils/validation/course';
 import { db } from '@cio/db/drizzle';
 import * as schema from '@cio/db/schema';
@@ -339,9 +341,9 @@ export async function createCourse(
  * @param data Course update data
  * @returns Updated course
  */
-export async function updateCourse(courseId: string, data: Partial<TCourse>) {
+export async function updateCourse(courseId: string, data: Partial<TCourse>, dbClient: DbOrTxClient = db) {
   try {
-    const [existingCourse] = await getCourseById(courseId);
+    const [existingCourse] = await getCourseById(courseId, dbClient);
 
     const effectiveCost = data.cost !== undefined ? data.cost : (existingCourse?.cost ?? 0);
     const effectivePaymentLink =
@@ -364,7 +366,7 @@ export async function updateCourse(courseId: string, data: Partial<TCourse>) {
       slug: data.slug
     };
 
-    const [currentCourse] = await getCourseById(courseId);
+    const [currentCourse] = await getCourseById(courseId, dbClient);
     if (!currentCourse) {
       throw new AppError('Course not found', ErrorCodes.COURSE_NOT_FOUND, 404);
     }
@@ -373,7 +375,8 @@ export async function updateCourse(courseId: string, data: Partial<TCourse>) {
       await guardCourseTypeTransition({
         courseId,
         currentType: currentCourse.type ?? null,
-        nextType: data.type
+        nextType: data.type,
+        dbClient
       });
     }
 
@@ -397,15 +400,15 @@ export async function updateCourse(courseId: string, data: Partial<TCourse>) {
     }
 
     if (data.certificate?.requiredExerciseId) {
-      const ok = await exerciseBelongsToCourse(data.certificate.requiredExerciseId, courseId);
+      const ok = await exerciseBelongsToCourse(data.certificate.requiredExerciseId, courseId, dbClient);
       if (!ok) {
         throw new AppError('Certification exercise must belong to this course', ErrorCodes.VALIDATION_ERROR, 400);
       }
 
-      await updateExercise(data.certificate.requiredExerciseId, { allowMultipleAttempts: true });
+      await updateExercise(data.certificate.requiredExerciseId, { allowMultipleAttempts: true }, dbClient);
     }
 
-    const updated = await updateCourseQuery(courseId, sanitizeUnknownStrings(sanitizedData));
+    const updated = await updateCourseQuery(courseId, sanitizeUnknownStrings(sanitizedData), dbClient);
     if (!updated) {
       throw new AppError('Course not found', ErrorCodes.COURSE_NOT_FOUND, 404);
     }
@@ -413,16 +416,20 @@ export async function updateCourse(courseId: string, data: Partial<TCourse>) {
     const isContentGroupingEnabled = (updated.metadata?.isContentGroupingEnabled ?? DEFAULT_CONTENT_GROUPING) === true;
 
     if (isContentGroupingEnabled) {
-      const courseWithRelations = await getCourseWithRelations(courseId);
-      if (courseWithRelations) {
-        const contentItems = courseWithRelations.contentItems;
+      const courseWithRelations = dbClient === db ? await getCourseWithRelations(courseId) : null;
+      const contentItems =
+        dbClient === db
+          ? courseWithRelations?.contentItems
+          : await getCourseContentItems(courseId, undefined, dbClient);
+
+      if (contentItems) {
         const hasSections = contentItems.some((item) => item.type === ContentType.Section);
         const hasUngroupedItems = contentItems.some(
           (item) => (item.type === ContentType.Lesson || item.type === ContentType.Exercise) && item.sectionId === null
         );
 
         if (!hasSections && hasUngroupedItems) {
-          await db.transaction(async (tx) => {
+          const createSectionAndMoveContent = async (transactionClient: DbOrTxClient) => {
             const [section] = await createCourseSections(
               [
                 {
@@ -431,22 +438,28 @@ export async function updateCourse(courseId: string, data: Partial<TCourse>) {
                   courseId
                 }
               ],
-              tx
+              transactionClient
             );
 
             if (!section) {
               throw new AppError('Failed to create course section', ErrorCodes.COURSE_SECTION_NOT_FOUND, 500);
             }
 
-            await updateLessonsSectionId(courseId, section.id, tx);
-            await updateExercisesSectionId(courseId, section.id, tx);
-          });
+            await updateLessonsSectionId(courseId, section.id, transactionClient);
+            await updateExercisesSectionId(courseId, section.id, transactionClient);
+          };
+
+          if (dbClient === db) {
+            await db.transaction((tx) => createSectionAndMoveContent(tx));
+          } else {
+            await createSectionAndMoveContent(dbClient);
+          }
         }
       }
     }
 
     if (data.status !== undefined) {
-      const statsOrgId = await getOrgIdByCourseId(courseId);
+      const statsOrgId = await getOrgIdByCourseId(courseId, dbClient);
       await invalidateOrgStats(statsOrgId);
     }
 

--- a/packages/core/src/services/course/public-course-guard.ts
+++ b/packages/core/src/services/course/public-course-guard.ts
@@ -1,4 +1,5 @@
 import { AppError, ErrorCodes } from '@cio/utils/errors';
+import type { DbOrTxClient } from '@cio/db/drizzle';
 import { findNonAutoGradableQuestionsInCourse, getCourseTypeById } from '@cio/db/queries/course';
 import { AUTO_GRADABLE_QUESTION_TYPE_IDS, isAutoGradableQuestionTypeId } from '@cio/question-types';
 
@@ -41,12 +42,17 @@ export async function guardCourseTypeTransition(params: {
   courseId: string;
   currentType: string | null;
   nextType: string | null | undefined;
+  dbClient?: DbOrTxClient;
 }): Promise<void> {
   if (!params.nextType) return;
   if (params.nextType !== 'PUBLIC') return;
   if (params.currentType === 'PUBLIC') return;
 
-  const offenders = await findNonAutoGradableQuestionsInCourse(params.courseId, AUTO_GRADABLE_QUESTION_TYPE_IDS);
+  const offenders = await findNonAutoGradableQuestionsInCourse(
+    params.courseId,
+    AUTO_GRADABLE_QUESTION_TYPE_IDS,
+    params.dbClient
+  );
   if (offenders.length === 0) return;
 
   const preview = offenders.slice(0, 5).map((item) => `"${item.questionTitle}" in "${item.exerciseTitle}"`);

--- a/packages/db/src/queries/course/certification-exercise.ts
+++ b/packages/db/src/queries/course/certification-exercise.ts
@@ -2,14 +2,18 @@ import * as schema from '@db/schema';
 
 import { and, asc, eq, or, sql } from 'drizzle-orm';
 
-import { db } from '@db/drizzle';
+import { db, type DbOrTxClient } from '@db/drizzle';
 
 /**
  * Whether an exercise is part of a course (direct course_id or via lesson).
  */
-export async function exerciseBelongsToCourse(exerciseId: string, courseId: string): Promise<boolean> {
+export async function exerciseBelongsToCourse(
+  exerciseId: string,
+  courseId: string,
+  dbClient: DbOrTxClient = db
+): Promise<boolean> {
   try {
-    const [row] = await db
+    const [row] = await dbClient
       .select({ id: schema.exercise.id })
       .from(schema.exercise)
       .leftJoin(schema.lesson, eq(schema.exercise.lessonId, schema.lesson.id))

--- a/packages/db/src/queries/course/content.ts
+++ b/packages/db/src/queries/course/content.ts
@@ -1,7 +1,7 @@
 import { sql } from 'drizzle-orm';
 
 import { ContentType } from '@cio/utils/constants';
-import { db, sql as drizzleSql } from '@db/drizzle';
+import { db, sql as drizzleSql, type DbOrTxClient } from '@db/drizzle';
 import { isExerciseCompletedSql } from './progression';
 
 export type CourseContentItemRow = {
@@ -28,7 +28,11 @@ export type CourseContentItemRow = {
  * @param courseId Course ID
  * @param profileId Optional profile ID for completion state
  */
-export async function getCourseContentItems(courseId: string, profileId?: string): Promise<CourseContentItemRow[]> {
+export async function getCourseContentItems(
+  courseId: string,
+  profileId?: string,
+  dbClient: DbOrTxClient = db
+): Promise<CourseContentItemRow[]> {
   try {
     const lessonCompletionSql = profileId
       ? drizzleSql`COALESCE(
@@ -43,7 +47,7 @@ export async function getCourseContentItems(courseId: string, profileId?: string
 
     const exerciseCompletionSql = profileId ? isExerciseCompletedSql('exercise', { profileId }) : drizzleSql`false`;
 
-    const result = await db.execute(drizzleSql`
+    const result = await dbClient.execute(drizzleSql`
       SELECT
         id,
         ${ContentType.Section}::text AS type,

--- a/packages/db/src/queries/course/course.ts
+++ b/packages/db/src/queries/course/course.ts
@@ -312,9 +312,9 @@ export const getCoursesBySiteNameForSetup = async (siteName: string) => {
     ...row.course
   }));
 };
-export async function getCourseById(courseId: string) {
+export async function getCourseById(courseId: string, dbClient: DbOrTxClient = db) {
   try {
-    return await db.select().from(schema.course).where(eq(schema.course.id, courseId)).limit(1);
+    return await dbClient.select().from(schema.course).where(eq(schema.course.id, courseId)).limit(1);
   } catch (error) {
     console.error('getCourseById error:', error);
     throw new Error(
@@ -504,9 +504,9 @@ export async function createCourseNewsfeed(newsfeed: TNewCourseNewsfeed, dbClien
  * @param data Partial course data to update
  * @returns Updated course
  */
-export async function updateCourse(courseId: string, data: Partial<TCourse>) {
+export async function updateCourse(courseId: string, data: Partial<TCourse>, dbClient: DbOrTxClient = db) {
   try {
-    const [updated] = await db
+    const [updated] = await dbClient
       .update(schema.course)
       .set({ ...data, updatedAt: new Date().toISOString() })
       .where(eq(schema.course.id, courseId))
@@ -1170,9 +1170,9 @@ export const getExploreCourses = async ({
 /**
  * Resolves the organization ID for a course via its group.
  */
-export async function getOrgIdByCourseId(courseId: string): Promise<string | null> {
+export async function getOrgIdByCourseId(courseId: string, dbClient: DbOrTxClient = db): Promise<string | null> {
   try {
-    const [row] = await db
+    const [row] = await dbClient
       .select({ orgId: schema.group.organizationId })
       .from(schema.course)
       .innerJoin(schema.group, eq(schema.course.groupId, schema.group.id))
@@ -1280,10 +1280,10 @@ export async function getOrganizationByCourseId(courseId: string): Promise<{ org
 export async function updateLessonsSectionId(
   courseId: string,
   sectionId: string,
-  tx?: Parameters<Parameters<typeof db.transaction>[0]>[0]
+  dbClient?: DbOrTxClient
 ): Promise<number> {
   try {
-    const dbInstance = tx || db;
+    const dbInstance = dbClient || db;
     const updated = await dbInstance
       .update(schema.lesson)
       .set({ sectionId })

--- a/packages/db/src/queries/course/public-course.ts
+++ b/packages/db/src/queries/course/public-course.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq } from 'drizzle-orm';
 
 import * as schema from '@db/schema';
-import { db } from '@db/drizzle';
+import { db, type DbOrTxClient } from '@db/drizzle';
 
 /**
  * Queries backing the anonymous public-course surface under
@@ -521,7 +521,8 @@ export async function getTakenItemSlugs(courseId: string): Promise<Set<string>> 
  */
 export async function findNonAutoGradableQuestionsInCourse(
   courseId: string,
-  autoGradableTypeIds: readonly number[]
+  autoGradableTypeIds: readonly number[],
+  dbClient: DbOrTxClient = db
 ): Promise<
   Array<{
     questionId: number;
@@ -532,7 +533,7 @@ export async function findNonAutoGradableQuestionsInCourse(
   }>
 > {
   try {
-    const rows = await db
+    const rows = await dbClient
       .select({
         questionId: schema.question.id,
         questionTitle: schema.question.title,

--- a/packages/db/src/queries/organization/organization.ts
+++ b/packages/db/src/queries/organization/organization.ts
@@ -530,8 +530,12 @@ export const updateOrganizationAudienceMember = async (
  * @param profileId Profile ID to check
  * @returns True if user is admin, false otherwise
  */
-export const isUserOrgAdmin = async (orgId: string, profileId: string): Promise<boolean> => {
-  const result = await db
+export const isUserOrgAdmin = async (
+  orgId: string,
+  profileId: string,
+  dbClient: DbOrTxClient = db
+): Promise<boolean> => {
+  const result = await dbClient
     .select({ roleId: schema.organizationmember.roleId })
     .from(schema.organizationmember)
     .where(

--- a/packages/db/src/queries/tag/tag.ts
+++ b/packages/db/src/queries/tag/tag.ts
@@ -2,7 +2,7 @@ import type { TNewTag, TNewTagGroup, TTag, TTagAssignment, TTagGroup } from '@db
 import { and, asc, eq, ilike, inArray, sql } from 'drizzle-orm';
 
 import * as schema from '@db/schema';
-import { db } from '@db/drizzle';
+import { db, type DbOrTxClient } from '@db/drizzle';
 
 export interface TTagWithCourseCount extends TTag {
   courseCount: number;
@@ -155,13 +155,13 @@ export async function getTagById(orgId: string, tagId: string): Promise<TTag | n
   }
 }
 
-export async function getTagsByIds(orgId: string, tagIds: string[]): Promise<TTag[]> {
+export async function getTagsByIds(orgId: string, tagIds: string[], dbClient: DbOrTxClient = db): Promise<TTag[]> {
   try {
     if (tagIds.length === 0) {
       return [];
     }
 
-    return db
+    return dbClient
       .select()
       .from(schema.tag)
       .where(and(eq(schema.tag.organizationId, orgId), inArray(schema.tag.id, tagIds)));
@@ -357,9 +357,9 @@ export async function getCourseIdsByTagSlugs(orgId: string, tagSlugs: string[]):
   }
 }
 
-export async function getCourseOrganizationId(courseId: string): Promise<string | null> {
+export async function getCourseOrganizationId(courseId: string, dbClient: DbOrTxClient = db): Promise<string | null> {
   try {
-    const [row] = await db
+    const [row] = await dbClient
       .select({
         organizationId: schema.group.organizationId
       })
@@ -375,9 +375,13 @@ export async function getCourseOrganizationId(courseId: string): Promise<string 
   }
 }
 
-export async function getCourseTagsForOrganization(orgId: string, courseId: string): Promise<TTag[]> {
+export async function getCourseTagsForOrganization(
+  orgId: string,
+  courseId: string,
+  dbClient: DbOrTxClient = db
+): Promise<TTag[]> {
   try {
-    const rows = await db
+    const rows = await dbClient
       .select({ tag: schema.tag })
       .from(schema.tagAssignment)
       .innerJoin(schema.tag, eq(schema.tagAssignment.tagId, schema.tag.id))
@@ -432,18 +436,22 @@ export async function getCourseTagsByCourseIdsForOrganization(
   }
 }
 
-export async function replaceCourseTagAssignments(courseId: string, tagIds: string[]): Promise<TTagAssignment[]> {
+export async function replaceCourseTagAssignments(
+  courseId: string,
+  tagIds: string[],
+  dbClient: DbOrTxClient = db
+): Promise<TTagAssignment[]> {
   try {
     const normalizedTagIds = Array.from(new Set(tagIds));
 
-    return db.transaction(async (tx) => {
-      await tx.delete(schema.tagAssignment).where(eq(schema.tagAssignment.courseId, courseId));
+    const replaceAssignments = async (transactionClient: DbOrTxClient) => {
+      await transactionClient.delete(schema.tagAssignment).where(eq(schema.tagAssignment.courseId, courseId));
 
       if (normalizedTagIds.length === 0) {
         return [];
       }
 
-      return tx
+      return transactionClient
         .insert(schema.tagAssignment)
         .values(
           normalizedTagIds.map((tagId) => ({
@@ -452,7 +460,13 @@ export async function replaceCourseTagAssignments(courseId: string, tagIds: stri
           }))
         )
         .returning();
-    });
+    };
+
+    if (dbClient === db) {
+      return db.transaction((tx) => replaceAssignments(tx));
+    }
+
+    return replaceAssignments(dbClient);
   } catch (error) {
     console.error('replaceCourseTagAssignments error:', error);
     throw new Error('Failed to replace course tag assignments');


### PR DESCRIPTION
## What does this PR do?

Makes course data and tag assignments update atomically for `PUT /course/:courseId`. The route now delegates tagged updates to a service-level transaction, and the course/tag query functions share the transaction client. Invalid tag IDs or tag-write failures therefore roll back the course update instead of leaving a partial update.

No issue number was provided.

## Demo

Not applicable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- `export PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH" && pnpm --filter @cio/api^... build && pnpm --filter @cio/api build`
- `export PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH" && pnpm --filter @cio/api exec vitest run src/services/course/__tests__/update-course.test.ts`
- `export PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH" && pnpm format:check`
- Send `PUT /course/:courseId` with a valid course field change and a nonexistent UUID in `tagIds`; verify the request fails and the course field remains unchanged.
- Send the same request with valid tag IDs; verify both the course field and tag assignments persist.

The full API test suite was also run. It produced 97 passing tests and 7 pre-existing module-resolution failures involving `@cio/core` and `@cio/db` subpath imports.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary (no documentation update was necessary)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Course updates now support changing tags in the same operation.
  * Updated courses return both course details and associated tags.
* **Bug Fixes**
  * Course and tag changes are applied atomically, preventing partial updates if tag assignment fails.
* **Tests**
  * Added coverage for successful combined updates and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes combined course and tag updates atomic by executing both operations with a shared database transaction client.
- Delegates tagged course updates to a transactional API service.
- Adds transaction-client support throughout affected course, organization, and tag queries.
- Adds tests covering successful combined updates and rollback when tag assignment fails.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no eligible blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/course/course.ts | Routes tagged updates through the new transactional service while preserving the direct course-only update path. |
| apps/api/src/services/course/update-course.ts | Coordinates course and tag writes in one database transaction. |
| apps/api/src/services/tag.ts | Propagates an optional database or transaction client through tag authorization, validation, assignment, and retrieval. |
| packages/core/src/services/course/course.ts | Allows course updates and their nested reads and writes to participate in a caller-owned transaction. |
| apps/api/src/services/course/__tests__/update-course.test.ts | Verifies shared transaction-client usage and propagation of tag failures for rollback. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Route as PUT /course/:courseId
  participant Service as updateCourseWithTags
  participant DB as Database transaction
  Route->>Service: courseData, tagIds, orgId, userId
  Service->>DB: Begin transaction
  Service->>DB: Update course using tx
  Service->>DB: Validate and replace tags using tx
  alt Both operations succeed
    DB-->>Service: Commit
    Service-->>Route: Updated course and tags
  else Either operation fails
    DB-->>Service: Roll back
    Service-->>Route: Error
  end
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/course-upda..."](https://github.com/classroomio/classroomio/commit/4b42c4dec3deba258f189994a80ea8223bf0086b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58996627)</sub>

<!-- /greptile_comment -->