### PR TITLE
fix(dashboard): show upgrade modal fully and fix pricing toggle contrast in dark mode

### DIFF
--- a/apps/dashboard/src/lib/features/ui/upgrade-modal.svelte
+++ b/apps/dashboard/src/lib/features/ui/upgrade-modal.svelte
@@ -130,7 +130,7 @@
 
 <Dialog.Root open={$isUpgradeModalOpen} onOpenChange={handleOpenChange}>
   <Dialog.Content
-    class="top-[4dvh]! max-h-[92dvh] w-[96vw] translate-y-0! overflow-y-auto p-4 sm:top-[50%]! sm:max-h-none sm:translate-y-[-50%]! sm:p-6 {upgraded ||
+    class="top-[4dvh]! max-h-[92dvh] w-[96vw] translate-y-0! overflow-y-auto p-4 sm:top-[50%]! sm:max-h-[92dvh] sm:translate-y-[-50%]! sm:p-6 {upgraded ||
     isConfirming
       ? 'max-w-[min(600px,96vw)]!'
       : 'max-w-5xl!'}"

--- a/packages/ui/src/custom/pricing-toggle/pricing-toggle.svelte
+++ b/packages/ui/src/custom/pricing-toggle/pricing-toggle.svelte
@@ -28,7 +28,7 @@
   <button
     type="button"
     class="ui:cursor-pointer ui:rounded-full ui:px-3 ui:py-1 ui:text-sm ui:font-medium ui:transition-all ui:duration-500 ui:ease-in-out {isActive
-      ? 'ui:bg-gray-200 ui:text-secondary-foreground'
+      ? 'ui:bg-gray-200 ui:text-gray-900'
       : 'ui:text-muted-foreground ui:hover:text-accent-foreground'}"
     onclick={() => handleToggle(isMonth ? false : true)}
   >


### PR DESCRIPTION
## What does this PR do?

Fixed the upgrade plan modal on smaller laptop screens or zoomed in view of the user's laptop.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #786 

## Demo
https://www.awesomescreenshot.com/video/56099304?key=a100165788e2f94fc7a47dcc10759528

<!-- Please upload a video here or attach a link to a video player like Awesome Screenshot or Loom to show the change in action. This speeds up reviews, especially for visual changes. -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Log in to the dashboard on a small laptop screen (e.g. 1366×768), go to dark mode, click Upgrade Plan from the sidebar. Verify:
- Test A: The modal opens fully, the title and close (X) icon are visible, and when content overflows the dialog is scrollable.
- Test B: In dark mode, the active tab in the Monthly/Annually toggle shows readable text (dark text on the light active pill); switching between Monthly and Yearly keeps the active label legible.
- Test C: Repeat on a mobile-width viewport to confirm the existing top-anchored, scrollable behavior is unchanged, and confirm the toggle still reads correctly in light mode.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Constrains the upgrade dialog to the viewport on wider screens and improves the active pricing-period label’s dark-mode contrast.
- Caps the centered upgrade modal at 92dvh while retaining vertical scrolling.
- Uses dark text on the pricing toggle’s light active pill.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The modal retains scrolling while gaining a bounded height on short wider viewports, and the toggle color change corrects the active label’s dark-mode contrast.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/ui/upgrade-modal.svelte | Adds a responsive viewport-height cap so overflowing upgrade content remains accessible through scrolling. |
| packages/ui/src/custom/pricing-toggle/pricing-toggle.svelte | Changes the active pricing option to dark text, preserving contrast against its light background in both themes. |

<sub>Reviews (1): Last reviewed commit: ["adjusted upgrade plan ui"](https://github.com/classroomio/classroomio/commit/0eca18100942e15e35397eae405127c358522710) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59075591)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the upgrade modal layout on larger screens by limiting its maximum height, helping keep content accessible within the viewport.
  - Updated the active pricing period’s text color for clearer visual emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->