### PR TITLE
fix(dashboard): refresh org state after onboarding

### DIFF
--- a/apps/dashboard/src/lib/features/onboarding/api/onboarding.svelte.ts
+++ b/apps/dashboard/src/lib/features/onboarding/api/onboarding.svelte.ts
@@ -3,12 +3,12 @@ import { currentOrg, mergeAccountOrgFromServer, orgs } from '$lib/utils/store/or
 
 import { ONBOARDING_STEPS } from '../utils/constants';
 import { BaseApiWithErrors, classroomio } from '$lib/utils/services/api';
-import { goto } from '$app/navigation';
 import { handleLocaleChange } from '$lib/utils/functions/translations';
 import { onboardingValidation } from '../utils/validations';
 import { profile } from '$lib/utils/store/user';
 import { resolve } from '$app/paths';
 import { snackbar } from '$features/ui/snackbar/store';
+import { authClient } from '$lib/utils/services/auth/client';
 
 export class OnboardingApi extends BaseApiWithErrors {
   step: OnboardingStep = $state(ONBOARDING_STEPS.ORG_SETUP);
@@ -84,13 +84,15 @@ export class OnboardingApi extends BaseApiWithErrors {
     await this.execute<(typeof classroomio.onboarding)['update-metadata']['$post']>({
       requestFn: () => classroomio.onboarding['update-metadata'].$post({ json: data }),
       logContext: 'submitting organization setup',
-      onSuccess: (result) => {
+      onSuccess: async (result) => {
         profile.set(result.data);
         handleLocaleChange(result.data.locale ?? 'en');
 
         const welcomePopup = `${result.data.isEmailVerified}`;
+        const orgPath = resolve(`/org/${data.siteName}?welcomePopup=${welcomePopup}`, {});
 
-        return goto(resolve(`/org/${data.siteName}?welcomePopup=${welcomePopup}`, {}));
+        await authClient.getSession({ query: { disableCookieCache: true } });
+        window.location.href = orgPath;
       },
       onError: (result) => {
         if (typeof result === 'string') {


### PR DESCRIPTION
## Summary

- refresh the Better Auth session after onboarding creates a new organization membership
- use a full-page navigation to clear stale app initialization state and reload the new organization
- preserve the welcome popup query parameter on the destination

## Verification

- `pnpm format:check`
- `pnpm --filter @cio/dashboard^... build`
- `pnpm --filter @cio/dashboard build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refreshes the Better Auth session after onboarding creates an organization membership, then performs a full-page navigation so application initialization reloads the new organization state.
- Preserves the welcome-popup query parameter in the organization destination.
- Replaces client-side `goto` navigation with a browser-level reload.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The changed flow refreshes the authenticated session before reloading the existing organization destination, preserving the welcome-popup parameter and ensuring application initialization sees the new membership.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/onboarding/api/onboarding.svelte.ts | Refreshes the session before a deliberate full-page organization navigation; no actionable changed-code defect was established. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): refresh org state after ..."](https://github.com/classroomio/classroomio/commit/07dd0ed2b50d305e2e1abb4217f2ddf49a17fc2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59096119)</sub>

<!-- /greptile_comment -->