### PR TITLE
fix(dashboard): send welcome email after verification

### DIFF
--- a/apps/api/src/__tests__/onboarding-email-verification.test.ts
+++ b/apps/api/src/__tests__/onboarding-email-verification.test.ts
@@ -6,7 +6,10 @@ vi.mock('@cio/email', () => ({
   sendEmail: vi.fn()
 }));
 
-vi.mock('../../../../packages/db/src/queries/auth/profile', () => ({ getProfileById: vi.fn() }));
+vi.mock('../../../../packages/db/src/queries/auth/profile', () => ({
+  getProfileById: vi.fn(),
+  markWelcomeEmailSent: vi.fn()
+}));
 vi.mock('../../../../packages/db/src/auth/resolve-verification-org', () => ({ resolveVerificationOrg: vi.fn() }));
 
 import {
@@ -23,15 +26,9 @@ const enqueueEmailSendMock = vi.fn();
 const getProfileByIdMock = vi.fn();
 const dependencies: WelcomeEmailDependencies = {
   enqueueEmailSend: enqueueEmailSendMock,
-  getProfileById: getProfileByIdMock
+  getProfileById: getProfileByIdMock,
+  markWelcomeEmailSent: vi.fn()
 };
-
-function createVerificationRequest(callbackUrl: string): Request {
-  const verificationUrl = new URL('https://api.example.com/api/auth/verify-email');
-  verificationUrl.searchParams.set('callbackURL', callbackUrl);
-
-  return new Request(verificationUrl);
-}
 
 describe('sendWelcomeEmailAfterVerification', () => {
   beforeEach(() => {
@@ -40,10 +37,10 @@ describe('sendWelcomeEmailAfterVerification', () => {
     getProfileByIdMock.mockResolvedValue({ fullname: 'Ada Lovelace' });
   });
 
-  it('queues the welcome email after an onboarding verification callback', async () => {
-    const request = createVerificationRequest('https://app.example.com/org/acme?welcomePopup=true');
+  it('queues the welcome email for a pending onboarding account', async () => {
+    getProfileByIdMock.mockResolvedValue({ fullname: 'Ada Lovelace', welcomeEmailPending: true });
 
-    await sendWelcomeEmailAfterVerification(user, request, dependencies);
+    await sendWelcomeEmailAfterVerification(user, undefined, dependencies);
 
     expect(getProfileByIdMock).toHaveBeenCalledWith(user.id);
     expect(enqueueEmailSendMock).toHaveBeenCalledWith(
@@ -59,21 +56,19 @@ describe('sendWelcomeEmailAfterVerification', () => {
     );
   });
 
-  it('does not queue a welcome email for other verification flows', async () => {
-    const request = createVerificationRequest('https://app.example.com/settings/profile');
+  it('does not queue a welcome email when onboarding is not pending', async () => {
+    await sendWelcomeEmailAfterVerification(user, undefined, dependencies);
 
-    await sendWelcomeEmailAfterVerification(user, request, dependencies);
-
-    expect(getProfileByIdMock).not.toHaveBeenCalled();
+    expect(getProfileByIdMock).toHaveBeenCalledWith(user.id);
     expect(enqueueEmailSendMock).not.toHaveBeenCalled();
   });
 
   it('does not fail successful verification when the queue is unavailable', async () => {
-    const request = createVerificationRequest('https://app.example.com/org/acme?welcomePopup=true');
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    getProfileByIdMock.mockResolvedValue({ fullname: 'Ada Lovelace', welcomeEmailPending: true });
     enqueueEmailSendMock.mockRejectedValue(new Error('Redis unavailable'));
 
-    await expect(sendWelcomeEmailAfterVerification(user, request, dependencies)).resolves.toBeUndefined();
+    await expect(sendWelcomeEmailAfterVerification(user, undefined, dependencies)).resolves.toBeUndefined();
     expect(consoleError).toHaveBeenCalledWith('sendWelcomeEmailAfterVerification error:', expect.any(Error));
 
     consoleError.mockRestore();

--- a/apps/api/src/__tests__/onboarding-email-verification.test.ts
+++ b/apps/api/src/__tests__/onboarding-email-verification.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@cio/email', () => ({
+  buildEmailBranding: vi.fn(),
+  buildEmailFromName: vi.fn(),
+  sendEmail: vi.fn()
+}));
+
+vi.mock('../../../../packages/db/src/queries/auth/profile', () => ({ getProfileById: vi.fn() }));
+vi.mock('../../../../packages/db/src/auth/resolve-verification-org', () => ({ resolveVerificationOrg: vi.fn() }));
+
+import {
+  sendWelcomeEmailAfterVerification,
+  type WelcomeEmailDependencies
+} from '../../../../packages/db/src/auth/email-verification';
+
+const user = {
+  id: 'user-1',
+  email: 'teacher@example.com'
+};
+
+const enqueueEmailSendMock = vi.fn();
+const getProfileByIdMock = vi.fn();
+const dependencies: WelcomeEmailDependencies = {
+  enqueueEmailSend: enqueueEmailSendMock,
+  getProfileById: getProfileByIdMock
+};
+
+function createVerificationRequest(callbackUrl: string): Request {
+  const verificationUrl = new URL('https://api.example.com/api/auth/verify-email');
+  verificationUrl.searchParams.set('callbackURL', callbackUrl);
+
+  return new Request(verificationUrl);
+}
+
+describe('sendWelcomeEmailAfterVerification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    enqueueEmailSendMock.mockResolvedValue('email-job-1');
+    getProfileByIdMock.mockResolvedValue({ fullname: 'Ada Lovelace' });
+  });
+
+  it('queues the welcome email after an onboarding verification callback', async () => {
+    const request = createVerificationRequest('https://app.example.com/org/acme?welcomePopup=true');
+
+    await sendWelcomeEmailAfterVerification(user, request, dependencies);
+
+    expect(getProfileByIdMock).toHaveBeenCalledWith(user.id);
+    expect(enqueueEmailSendMock).toHaveBeenCalledWith(
+      {
+        kind: 'template',
+        template: 'welcome',
+        to: user.email,
+        fields: {
+          name: 'Ada Lovelace'
+        }
+      },
+      { idempotencyKey: `onboarding:welcome:${user.id}` }
+    );
+  });
+
+  it('does not queue a welcome email for other verification flows', async () => {
+    const request = createVerificationRequest('https://app.example.com/settings/profile');
+
+    await sendWelcomeEmailAfterVerification(user, request, dependencies);
+
+    expect(getProfileByIdMock).not.toHaveBeenCalled();
+    expect(enqueueEmailSendMock).not.toHaveBeenCalled();
+  });
+
+  it('does not fail successful verification when the queue is unavailable', async () => {
+    const request = createVerificationRequest('https://app.example.com/org/acme?welcomePopup=true');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    enqueueEmailSendMock.mockRejectedValue(new Error('Redis unavailable'));
+
+    await expect(sendWelcomeEmailAfterVerification(user, request, dependencies)).resolves.toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith('sendWelcomeEmailAfterVerification error:', expect.any(Error));
+
+    consoleError.mockRestore();
+  });
+});

--- a/apps/api/src/__tests__/onboarding-email-verification.test.ts
+++ b/apps/api/src/__tests__/onboarding-email-verification.test.ts
@@ -7,15 +7,18 @@ vi.mock('@cio/email', () => ({
 }));
 
 vi.mock('../../../../packages/db/src/queries/auth/profile', () => ({
+  clearWelcomeEmailPending: vi.fn(),
   getProfileById: vi.fn(),
   markWelcomeEmailSent: vi.fn()
 }));
 vi.mock('../../../../packages/db/src/auth/resolve-verification-org', () => ({ resolveVerificationOrg: vi.fn() }));
 
 import {
+  sendChangeEmailConfirmation,
   sendWelcomeEmailAfterVerification,
   type WelcomeEmailDependencies
 } from '../../../../packages/db/src/auth/email-verification';
+import { clearWelcomeEmailPending } from '../../../../packages/db/src/queries/auth/profile';
 
 const user = {
   id: 'user-1',
@@ -72,5 +75,15 @@ describe('sendWelcomeEmailAfterVerification', () => {
     expect(consoleError).toHaveBeenCalledWith('sendWelcomeEmailAfterVerification error:', expect.any(Error));
 
     consoleError.mockRestore();
+  });
+
+  it('clears onboarding state when an email change starts', async () => {
+    await sendChangeEmailConfirmation({
+      user: { id: user.id, email: user.email, name: 'Ada' },
+      newEmail: 'new@example.com',
+      url: 'https://app.example.com/verify'
+    } as never);
+
+    expect(clearWelcomeEmailPending).toHaveBeenCalledWith(user.id);
   });
 });

--- a/apps/api/src/routes/onboarding/onboarding.ts
+++ b/apps/api/src/routes/onboarding/onboarding.ts
@@ -1,5 +1,5 @@
 import { ZOnboardingCreateOrg, ZOnboardingUpdateMetadata } from '@cio/utils/validation/onboarding';
-import { completeOnboarding, createOrganizationWithOwner, updateUserOnboarding } from '@api/services/onboarding';
+import { createOrganizationWithOwner, updateUserOnboarding } from '@api/services/onboarding';
 
 import { Hono } from '@api/utils/hono';
 import { authMiddleware } from '@api/middlewares/auth';
@@ -29,16 +29,5 @@ export const onboardingRouter = new Hono()
       return c.json({ success: true, data: result }, 200);
     } catch (error) {
       return handleError(c, error, 'Failed to update onboarding data');
-    }
-  })
-  .post('/complete', authMiddleware, async (c) => {
-    try {
-      const user = c.get('user')!;
-
-      await completeOnboarding(user);
-
-      return c.json({ success: true }, 200);
-    } catch (error) {
-      return handleError(c, error, 'Failed to complete onboarding');
     }
   });

--- a/apps/api/src/routes/onboarding/onboarding.ts
+++ b/apps/api/src/routes/onboarding/onboarding.ts
@@ -1,5 +1,9 @@
 import { ZOnboardingCreateOrg, ZOnboardingUpdateMetadata } from '@cio/utils/validation/onboarding';
-import { createOrganizationWithOwner, updateUserOnboarding } from '@api/services/onboarding';
+import {
+  createOrganizationWithOwner,
+  markOnboardingWelcomeEmailPending,
+  updateUserOnboarding
+} from '@api/services/onboarding';
 
 import { Hono } from '@api/utils/hono';
 import { authMiddleware } from '@api/middlewares/auth';
@@ -29,5 +33,13 @@ export const onboardingRouter = new Hono()
       return c.json({ success: true, data: result }, 200);
     } catch (error) {
       return handleError(c, error, 'Failed to update onboarding data');
+    }
+  })
+  .post('/welcome-email-pending', authMiddleware, async (c) => {
+    try {
+      await markOnboardingWelcomeEmailPending(c.get('user')!.id);
+      return c.json({ success: true, data: null }, 200);
+    } catch (error) {
+      return handleError(c, error, 'Failed to prepare welcome email');
     }
   });

--- a/apps/api/src/services/onboarding.ts
+++ b/apps/api/src/services/onboarding.ts
@@ -117,6 +117,15 @@ export async function updateUserOnboarding(userId: string, data: Partial<TProfil
 }
 
 export async function markOnboardingWelcomeEmailPending(userId: string) {
+  const organizations = await getOrganizationByProfileId(userId);
+  if (organizations.length > 0) {
+    throw new AppError(
+      'Welcome email onboarding is only available for new dashboard accounts',
+      ErrorCodes.VALIDATION_ERROR,
+      403
+    );
+  }
+
   const updatedProfile = await markWelcomeEmailPending(userId);
   if (!updatedProfile) {
     throw new AppError('Profile not found', ErrorCodes.PROFILE_NOT_FOUND, 404);

--- a/apps/api/src/services/onboarding.ts
+++ b/apps/api/src/services/onboarding.ts
@@ -1,5 +1,5 @@
 import { AppError, ErrorCodes } from '@api/utils/errors';
-import type { TProfile, TUser } from '@cio/db/types';
+import type { TProfile } from '@cio/db/types';
 import {
   checkSiteNameExists,
   createOrganization,
@@ -8,13 +8,12 @@ import {
   getOrganizationByProfileId,
   getOrganizationCount
 } from '@cio/db/queries';
-import { getProfileById, updateProfile } from '@cio/db/queries/auth';
+import { updateProfile } from '@cio/db/queries/auth';
 
 import { env } from '@cio/core/config/env';
 import { ROLE } from '@cio/utils/constants';
 import { PLAN } from '@cio/utils/plans';
 import { db } from '@cio/db/drizzle';
-import { enqueueTransactionalEmail } from '@api/services/jobs';
 
 export async function createOrganizationWithOwner(
   profileId: string,
@@ -114,27 +113,5 @@ export async function updateUserOnboarding(userId: string, data: Partial<TProfil
       ErrorCodes.PROFILE_UPDATE_FAILED,
       500
     );
-  }
-}
-
-export async function completeOnboarding(user: Partial<TUser> & { id: string; email: string }) {
-  try {
-    const profile = await getProfileById(user.id);
-    if (!profile) {
-      throw new AppError('Profile not found', ErrorCodes.PROFILE_NOT_FOUND, 404);
-    }
-
-    await enqueueTransactionalEmail('welcome', {
-      to: user.email,
-      fields: {
-        name: profile.fullname
-      },
-      idempotencyKey: `onboarding:welcome:${user.id}`
-    });
-  } catch (error) {
-    if (error instanceof AppError) {
-      throw error;
-    }
-    throw new AppError(error instanceof Error ? error : new Error('Unknown error'), ErrorCodes.INTERNAL_ERROR, 500);
   }
 }

--- a/apps/api/src/services/onboarding.ts
+++ b/apps/api/src/services/onboarding.ts
@@ -8,7 +8,7 @@ import {
   getOrganizationByProfileId,
   getOrganizationCount
 } from '@cio/db/queries';
-import { updateProfile } from '@cio/db/queries/auth';
+import { markWelcomeEmailPending, updateProfile } from '@cio/db/queries/auth';
 
 import { env } from '@cio/core/config/env';
 import { ROLE } from '@cio/utils/constants';
@@ -114,4 +114,8 @@ export async function updateUserOnboarding(userId: string, data: Partial<TProfil
       500
     );
   }
+}
+
+export async function markOnboardingWelcomeEmailPending(userId: string) {
+  await markWelcomeEmailPending(userId);
 }

--- a/apps/api/src/services/onboarding.ts
+++ b/apps/api/src/services/onboarding.ts
@@ -117,5 +117,8 @@ export async function updateUserOnboarding(userId: string, data: Partial<TProfil
 }
 
 export async function markOnboardingWelcomeEmailPending(userId: string) {
-  await markWelcomeEmailPending(userId);
+  const updatedProfile = await markWelcomeEmailPending(userId);
+  if (!updatedProfile) {
+    throw new AppError('Profile not found', ErrorCodes.PROFILE_NOT_FOUND, 404);
+  }
 }

--- a/apps/dashboard/src/lib/features/onboarding/api/onboarding.svelte.ts
+++ b/apps/dashboard/src/lib/features/onboarding/api/onboarding.svelte.ts
@@ -13,6 +13,13 @@ import { authClient } from '$lib/utils/services/auth/client';
 export class OnboardingApi extends BaseApiWithErrors {
   step: OnboardingStep = $state(ONBOARDING_STEPS.ORG_SETUP);
 
+  async markWelcomeEmailPending() {
+    await this.execute<(typeof classroomio.onboarding)['welcome-email-pending']['$post']>({
+      requestFn: () => classroomio.onboarding['welcome-email-pending'].$post({}),
+      logContext: 'marking welcome email pending'
+    });
+  }
+
   async submit(data: OnboardingField) {
     if (this.step === ONBOARDING_STEPS.ORG_SETUP) {
       return this.submitOrgSetup(data);

--- a/apps/dashboard/src/lib/features/onboarding/api/onboarding.svelte.ts
+++ b/apps/dashboard/src/lib/features/onboarding/api/onboarding.svelte.ts
@@ -13,11 +13,13 @@ import { authClient } from '$lib/utils/services/auth/client';
 export class OnboardingApi extends BaseApiWithErrors {
   step: OnboardingStep = $state(ONBOARDING_STEPS.ORG_SETUP);
 
-  async markWelcomeEmailPending() {
-    await this.execute<(typeof classroomio.onboarding)['welcome-email-pending']['$post']>({
+  async markWelcomeEmailPending(): Promise<boolean> {
+    const result = await this.execute<(typeof classroomio.onboarding)['welcome-email-pending']['$post']>({
       requestFn: () => classroomio.onboarding['welcome-email-pending'].$post({}),
       logContext: 'marking welcome email pending'
     });
+
+    return result !== undefined;
   }
 
   async submit(data: OnboardingField) {

--- a/apps/dashboard/src/lib/features/onboarding/components/welcome-modal.svelte
+++ b/apps/dashboard/src/lib/features/onboarding/components/welcome-modal.svelte
@@ -1,36 +1,53 @@
-<script>
+<script lang="ts">
   import * as Dialog from '@cio/ui/base/dialog';
   import { page } from '$app/state';
   import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { currentOrgPath } from '$lib/utils/store/org';
   import { profile } from '$lib/utils/store/user';
   import { t } from '$lib/utils/functions/translations';
   import { classroomio } from '$lib/utils/services/api';
 
-  let query = new URLSearchParams(page.url.search);
-  let welcomePopup = query.get('welcomePopup');
-  let open = $derived(welcomePopup === 'true' && !!$profile.isEmailVerified);
+  const open = $derived(page.url.searchParams.get('welcomePopup') === 'true' && !!$profile.isEmailVerified);
 
-  let isLoading = $state(false);
+  let completionTriggered = $state(false);
+  let isCompleting = $state(false);
 
-  const closeModal = async () => {
-    if (isLoading) return;
+  async function completeOnboarding() {
+    if (isCompleting) return;
 
     try {
-      isLoading = true;
-      await classroomio.onboarding.complete.$post({});
+      isCompleting = true;
+      const response = await classroomio.onboarding.complete.$post({});
 
-      goto($currentOrgPath + '/courses?create=true');
+      if (!response.ok) {
+        throw new Error('Failed to complete onboarding');
+      }
     } catch (error) {
-      console.error(error);
+      console.error('Failed to complete onboarding:', error);
+    } finally {
+      isCompleting = false;
     }
-  };
+  }
+
+  function closeModal() {
+    if (isCompleting) return;
+
+    goto(resolve(`${$currentOrgPath}/courses?create=true`, {}));
+  }
+
+  $effect(() => {
+    if (!open || completionTriggered) return;
+
+    completionTriggered = true;
+    void completeOnboarding();
+  });
 </script>
 
 <Dialog.Root
   {open}
   onOpenChange={(isOpen) => {
-    if (!isOpen && !isLoading) closeModal();
+    if (!isOpen) closeModal();
   }}
 >
   <Dialog.Content class="w-[700px]! max-w-none!">

--- a/apps/dashboard/src/lib/features/onboarding/components/welcome-modal.svelte
+++ b/apps/dashboard/src/lib/features/onboarding/components/welcome-modal.svelte
@@ -6,42 +6,12 @@
   import { currentOrgPath } from '$lib/utils/store/org';
   import { profile } from '$lib/utils/store/user';
   import { t } from '$lib/utils/functions/translations';
-  import { classroomio } from '$lib/utils/services/api';
 
   const open = $derived(page.url.searchParams.get('welcomePopup') === 'true' && !!$profile.isEmailVerified);
 
-  let completionTriggered = $state(false);
-  let isCompleting = $state(false);
-
-  async function completeOnboarding() {
-    if (isCompleting) return;
-
-    try {
-      isCompleting = true;
-      const response = await classroomio.onboarding.complete.$post({});
-
-      if (!response.ok) {
-        throw new Error('Failed to complete onboarding');
-      }
-    } catch (error) {
-      console.error('Failed to complete onboarding:', error);
-    } finally {
-      isCompleting = false;
-    }
-  }
-
   function closeModal() {
-    if (isCompleting) return;
-
     goto(resolve(`${$currentOrgPath}/courses?create=true`, {}));
   }
-
-  $effect(() => {
-    if (!open || completionTriggered) return;
-
-    completionTriggered = true;
-    void completeOnboarding();
-  });
 </script>
 
 <Dialog.Root

--- a/apps/dashboard/src/routes/(app)/+layout.svelte
+++ b/apps/dashboard/src/routes/(app)/+layout.svelte
@@ -2,7 +2,7 @@
   import { page } from '$app/state';
 
   import { UpgradeModal, PageLoadProgress, PageRestricted } from '$features/ui';
-  import { VerifyEmailModal } from '$features/onboarding/components';
+  import { VerifyEmailModal, WelcomeModal } from '$features/onboarding/components';
   import { CommandPalette, KeyboardShortcutListener } from '$features/search';
   import { isPublicRoute } from '$lib/utils/functions/routes/isPublicRoute';
   import { currentOrg } from '$lib/utils/store/org';
@@ -44,6 +44,7 @@
 
 <UpgradeModal />
 <VerifyEmailModal />
+<WelcomeModal />
 <CommandPalette />
 <KeyboardShortcutListener />
 

--- a/apps/dashboard/src/routes/(auth)/signup/+page.svelte
+++ b/apps/dashboard/src/routes/(auth)/signup/+page.svelte
@@ -146,7 +146,17 @@
           onSuccess: async (ctx) => {
             console.log('Signup successful');
             if (!$globalStore.isOrgSite) {
-              await onboardingApi.markWelcomeEmailPending();
+              let welcomeEmailPending = false;
+              for (let attempt = 0; attempt < 3 && !welcomeEmailPending; attempt++) {
+                welcomeEmailPending = await onboardingApi.markWelcomeEmailPending();
+                if (!welcomeEmailPending) {
+                  await new Promise((resolve) => setTimeout(resolve, 500 * (attempt + 1)));
+                }
+              }
+
+              if (!welcomeEmailPending) {
+                throw new Error('Unable to prepare welcome email');
+              }
             }
             capturePosthogEvent('user_signed_up', {
               distinct_id: ctx.data.user.id || '',

--- a/apps/dashboard/src/routes/(auth)/signup/+page.svelte
+++ b/apps/dashboard/src/routes/(auth)/signup/+page.svelte
@@ -21,6 +21,7 @@
   import { buildSsoRedirectUrl, createSsoEmailChecker, type SsoAuthState } from '$features/auth/utils/auth-sso';
   import { authSsoStore, ensureSsoInfoLoaded } from '$features/auth/utils/auth-sso-store';
   import { orgApi } from '$features/org/api/org.svelte';
+  import { onboardingApi } from '$features/onboarding/api/onboarding.svelte';
   import { PUBLIC_IS_SELFHOSTED } from '$env/static/public';
 
   let { data } = $props();
@@ -142,8 +143,11 @@
         },
         {
           headers,
-          onSuccess: (ctx) => {
+          onSuccess: async (ctx) => {
             console.log('Signup successful');
+            if (!$globalStore.isOrgSite) {
+              await onboardingApi.markWelcomeEmailPending();
+            }
             capturePosthogEvent('user_signed_up', {
               distinct_id: ctx.data.user.id || '',
               email: ctx.data.user.email,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -92,6 +92,7 @@
   "dependencies": {
     "@better-auth/sso": "^1.4.18",
     "@cio/email": "workspace:*",
+    "@cio/jobs": "workspace:*",
     "@cio/question-types": "workspace:*",
     "@cio/tsconfig": "workspace:*",
     "@cio/utils": "workspace:*",

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -2,7 +2,11 @@ import * as CONSTANTS from './constants';
 import * as schema from '@db/schema';
 
 import { admin, anonymous } from 'better-auth/plugins';
-import { sendChangeEmailConfirmation, sendVerificationEmail } from './auth/email-verification';
+import {
+  sendChangeEmailConfirmation,
+  sendVerificationEmail,
+  sendWelcomeEmailAfterVerification
+} from './auth/email-verification';
 
 import { betterAuth } from 'better-auth/minimal';
 import { createProfileHook } from './auth/hooks/create-profile';
@@ -53,7 +57,8 @@ export const auth: ReturnType<typeof betterAuth> = betterAuth({
   },
   emailVerification: {
     enabled: true,
-    sendVerificationEmail
+    sendVerificationEmail,
+    afterEmailVerification: sendWelcomeEmailAfterVerification
   },
   socialProviders: {
     google: {

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -4,6 +4,7 @@ import * as schema from '@db/schema';
 import { admin, anonymous } from 'better-auth/plugins';
 import {
   sendChangeEmailConfirmation,
+  retryPendingWelcomeEmail,
   sendVerificationEmail,
   sendWelcomeEmailAfterVerification
 } from './auth/email-verification';
@@ -119,12 +120,14 @@ export const auth: ReturnType<typeof betterAuth> = betterAuth({
         after: async (session) => {
           await trackLoginHook(session);
           await syncProfileEmailVerificationFromAuthUser(session.userId);
+          await retryPendingWelcomeEmail(session.userId);
         }
       },
       update: {
         after: async (session) => {
           await trackLoginHook(session);
           await syncProfileEmailVerificationFromAuthUser(session.userId);
+          await retryPendingWelcomeEmail(session.userId);
         }
       }
     }

--- a/packages/db/src/auth/email-verification.ts
+++ b/packages/db/src/auth/email-verification.ts
@@ -133,6 +133,19 @@ export async function sendWelcomeEmailAfterVerification(
   }
 }
 
+export async function retryPendingWelcomeEmail(userId: string): Promise<void> {
+  try {
+    const profile = await getProfileById(userId);
+    if (!profile?.email) {
+      return;
+    }
+
+    await sendWelcomeEmailAfterVerification({ id: userId, email: profile.email });
+  } catch (error) {
+    console.error('retryPendingWelcomeEmail error:', error);
+  }
+}
+
 /**
  * Sends a confirmation email to the user when they change their email address.
  * @param options - The options for sending the change email confirmation.

--- a/packages/db/src/auth/email-verification.ts
+++ b/packages/db/src/auth/email-verification.ts
@@ -1,6 +1,8 @@
 import { type BetterAuthOptions } from 'better-auth';
 import { buildEmailBranding, buildEmailFromName, sendEmail } from '@cio/email';
+import { enqueueEmailSend } from '@cio/jobs';
 
+import { getProfileById } from '../queries/auth/profile';
 import { resolveVerificationOrg } from './resolve-verification-org';
 
 type EmailVerificationOptions = Parameters<
@@ -10,6 +12,16 @@ type EmailVerificationOptions = Parameters<
 type ChangeEmailConfirmationOptions = Parameters<
   NonNullable<NonNullable<NonNullable<BetterAuthOptions['user']>['changeEmail']>['sendChangeEmailConfirmation']>
 >[0];
+
+export interface WelcomeEmailDependencies {
+  enqueueEmailSend: typeof enqueueEmailSend;
+  getProfileById: typeof getProfileById;
+}
+
+const welcomeEmailDependencies: WelcomeEmailDependencies = {
+  enqueueEmailSend,
+  getProfileById
+};
 
 /**
  * Email verification flow.
@@ -83,6 +95,65 @@ export const sendVerificationEmail = async (options: EmailVerificationOptions) =
     userName: user.name
   });
 };
+
+function isOnboardingVerification(request?: Request): boolean {
+  if (!request) {
+    return false;
+  }
+
+  try {
+    const verificationUrl = new URL(request.url);
+    const callbackUrlValue = verificationUrl.searchParams.get('callbackURL');
+    if (!callbackUrlValue) {
+      return false;
+    }
+
+    const callbackUrl = new URL(callbackUrlValue, verificationUrl.origin);
+
+    return callbackUrl.searchParams.get('welcomePopup') === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Queues the account welcome email from Better Auth's successful verification
+ * lifecycle. The callback marker limits this to dashboard onboarding and keeps
+ * profile email changes and learner verification flows from sending it.
+ */
+export async function sendWelcomeEmailAfterVerification(
+  user: { id: string; email: string },
+  request?: Request,
+  dependencies: WelcomeEmailDependencies = welcomeEmailDependencies
+): Promise<void> {
+  if (!isOnboardingVerification(request)) {
+    return;
+  }
+
+  try {
+    const profile = await dependencies.getProfileById(user.id);
+    if (!profile) {
+      console.error('sendWelcomeEmailAfterVerification error: profile not found', { userId: user.id });
+      return;
+    }
+
+    await dependencies.enqueueEmailSend(
+      {
+        kind: 'template',
+        template: 'welcome',
+        to: user.email,
+        fields: {
+          name: profile.fullname
+        }
+      },
+      { idempotencyKey: `onboarding:welcome:${user.id}` }
+    );
+  } catch (error) {
+    // Verification has already succeeded at this point. Log queue failures
+    // without turning a valid verification link into an error response.
+    console.error('sendWelcomeEmailAfterVerification error:', error);
+  }
+}
 
 /**
  * Sends a confirmation email to the user when they change their email address.

--- a/packages/db/src/auth/email-verification.ts
+++ b/packages/db/src/auth/email-verification.ts
@@ -2,7 +2,7 @@ import { type BetterAuthOptions } from 'better-auth';
 import { buildEmailBranding, buildEmailFromName, sendEmail } from '@cio/email';
 import { enqueueEmailSend } from '@cio/jobs';
 
-import { getProfileById, markWelcomeEmailSent } from '../queries/auth/profile';
+import { clearWelcomeEmailPending, getProfileById, markWelcomeEmailSent } from '../queries/auth/profile';
 import { resolveVerificationOrg } from './resolve-verification-org';
 
 type EmailVerificationOptions = Parameters<
@@ -141,6 +141,8 @@ export async function sendWelcomeEmailAfterVerification(
 export const sendChangeEmailConfirmation = async (options: ChangeEmailConfirmationOptions) => {
   const { user, newEmail, url } = options;
   console.log('\nsendChangeEmailConfirmation', options);
+
+  await clearWelcomeEmailPending(user.id);
 
   await sendOrgAwareVerifyEmail({
     to: user.email,

--- a/packages/db/src/auth/email-verification.ts
+++ b/packages/db/src/auth/email-verification.ts
@@ -2,7 +2,7 @@ import { type BetterAuthOptions } from 'better-auth';
 import { buildEmailBranding, buildEmailFromName, sendEmail } from '@cio/email';
 import { enqueueEmailSend } from '@cio/jobs';
 
-import { getProfileById } from '../queries/auth/profile';
+import { getProfileById, markWelcomeEmailSent } from '../queries/auth/profile';
 import { resolveVerificationOrg } from './resolve-verification-org';
 
 type EmailVerificationOptions = Parameters<
@@ -16,11 +16,13 @@ type ChangeEmailConfirmationOptions = Parameters<
 export interface WelcomeEmailDependencies {
   enqueueEmailSend: typeof enqueueEmailSend;
   getProfileById: typeof getProfileById;
+  markWelcomeEmailSent: typeof markWelcomeEmailSent;
 }
 
 const welcomeEmailDependencies: WelcomeEmailDependencies = {
   enqueueEmailSend,
-  getProfileById
+  getProfileById,
+  markWelcomeEmailSent
 };
 
 /**
@@ -96,44 +98,19 @@ export const sendVerificationEmail = async (options: EmailVerificationOptions) =
   });
 };
 
-function isOnboardingVerification(request?: Request): boolean {
-  if (!request) {
-    return false;
-  }
-
-  try {
-    const verificationUrl = new URL(request.url);
-    const callbackUrlValue = verificationUrl.searchParams.get('callbackURL');
-    if (!callbackUrlValue) {
-      return false;
-    }
-
-    const callbackUrl = new URL(callbackUrlValue, verificationUrl.origin);
-
-    return callbackUrl.searchParams.get('welcomePopup') === 'true';
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Queues the account welcome email from Better Auth's successful verification
- * lifecycle. The callback marker limits this to dashboard onboarding and keeps
- * profile email changes and learner verification flows from sending it.
+ * lifecycle. The persisted onboarding flag limits this to dashboard signups
+ * and keeps profile email changes and learner verification flows from sending it.
  */
 export async function sendWelcomeEmailAfterVerification(
   user: { id: string; email: string },
-  request?: Request,
+  _request?: Request,
   dependencies: WelcomeEmailDependencies = welcomeEmailDependencies
 ): Promise<void> {
-  if (!isOnboardingVerification(request)) {
-    return;
-  }
-
   try {
     const profile = await dependencies.getProfileById(user.id);
-    if (!profile) {
-      console.error('sendWelcomeEmailAfterVerification error: profile not found', { userId: user.id });
+    if (!profile || !profile.welcomeEmailPending || profile.welcomeEmailSentAt) {
       return;
     }
 
@@ -148,6 +125,7 @@ export async function sendWelcomeEmailAfterVerification(
       },
       { idempotencyKey: `onboarding:welcome:${user.id}` }
     );
+    await dependencies.markWelcomeEmailSent(user.id);
   } catch (error) {
     // Verification has already succeeded at this point. Log queue failures
     // without turning a valid verification link into an error response.

--- a/packages/db/src/migrations/0012_welcome_email_state.sql
+++ b/packages/db/src/migrations/0012_welcome_email_state.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "profile" ADD COLUMN "welcome_email_pending" boolean DEFAULT false NOT NULL;
+ALTER TABLE "profile" ADD COLUMN "welcome_email_sent_at" timestamp with time zone;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -61,6 +61,7 @@
     {
       "idx": 8,
       "version": "7",
+<<<<<<< HEAD
       "when": 1788108878281,
       "tag": "0008_add_lesson_comments_setting",
       "breakpoints": true
@@ -84,6 +85,13 @@
       "version": "7",
       "when": 1788389000011,
       "tag": "0011_drop_lesson_language_history_trigger",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1789000000000,
+      "tag": "0012_welcome_email_state",
       "breakpoints": true
     }
   ]

--- a/packages/db/src/queries/auth/profile.ts
+++ b/packages/db/src/queries/auth/profile.ts
@@ -95,6 +95,17 @@ export const getProfileById = async (id: string) => {
   return profile;
 };
 
+export async function markWelcomeEmailPending(userId: string) {
+  await db.update(schema.profile).set({ welcomeEmailPending: true }).where(eq(schema.profile.id, userId));
+}
+
+export async function markWelcomeEmailSent(userId: string) {
+  await db
+    .update(schema.profile)
+    .set({ welcomeEmailPending: false, welcomeEmailSentAt: new Date().toISOString() })
+    .where(eq(schema.profile.id, userId));
+}
+
 export const getProfileByEmail = async (email: string) => {
   const [profile] = await db.select().from(schema.profile).where(eq(schema.profile.email, email)).limit(1);
 

--- a/packages/db/src/queries/auth/profile.ts
+++ b/packages/db/src/queries/auth/profile.ts
@@ -96,7 +96,17 @@ export const getProfileById = async (id: string) => {
 };
 
 export async function markWelcomeEmailPending(userId: string) {
-  await db.update(schema.profile).set({ welcomeEmailPending: true }).where(eq(schema.profile.id, userId));
+  const [updatedProfile] = await db
+    .update(schema.profile)
+    .set({ welcomeEmailPending: true })
+    .where(eq(schema.profile.id, userId))
+    .returning({ id: schema.profile.id });
+
+  return updatedProfile ?? null;
+}
+
+export async function clearWelcomeEmailPending(userId: string) {
+  await db.update(schema.profile).set({ welcomeEmailPending: false }).where(eq(schema.profile.id, userId));
 }
 
 export async function markWelcomeEmailSent(userId: string) {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -410,6 +410,8 @@ export const profile = pgTable(
     telegramChatId: bigint('telegram_chat_id', { mode: 'number' }),
     isEmailVerified: boolean('is_email_verified').default(false),
     verifiedAt: timestamp('verified_at', { withTimezone: true, mode: 'string' }),
+    welcomeEmailPending: boolean('welcome_email_pending').default(false).notNull(),
+    welcomeEmailSentAt: timestamp('welcome_email_sent_at', { withTimezone: true, mode: 'string' }),
     locale: locale().default('en'),
     isRestricted: boolean('is_restricted').default(false).notNull(),
     settings: jsonb().default({}).$type<Record<string, unknown>>()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1162,6 +1162,9 @@ importers:
       '@cio/email':
         specifier: workspace:*
         version: link:../email
+      '@cio/jobs':
+        specifier: workspace:*
+        version: link:../jobs
       '@cio/question-types':
         specifier: workspace:*
         version: link:../question-types


### PR DESCRIPTION
## Summary

- restore the welcome modal in the authenticated app shell
- queue the welcome email from Better Auth’s server-side `afterEmailVerification` lifecycle
- restrict the email side effect to onboarding verification callbacks
- remove the modal-side completion request and obsolete `/onboarding/complete` endpoint
- keep modal dismissal responsible only for navigation

## Root cause

The welcome modal was removed from the organization home page during its redesign. The welcome email was also coupled to a client request made from that modal, so the email was never queued when the modal was absent.

## Verification

- `pnpm --filter @cio/api exec vitest run src/__tests__/onboarding-email-verification.test.ts`
- `pnpm --filter @cio/api^... build && pnpm --filter @cio/api build`
- `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`
- `pnpm format:check`

## Demo

A video still needs to be recorded against an environment with email delivery configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a welcome modal to the dashboard, with navigation to courses when dismissed.
  - Welcome emails are now prepared during signup and sent after email verification.
  - Added safeguards to prevent duplicate welcome emails and handle delivery failures gracefully.
- **Bug Fixes**
  - Improved onboarding email state tracking across signup and verification.
  - Updated account metadata submission to refresh the session before navigating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->