### PR TITLE
fix(dashboard): keep redirects working on BYOD custom domains

### DIFF
--- a/apps/dashboard/src/hooks.server.ts
+++ b/apps/dashboard/src/hooks.server.ts
@@ -2,9 +2,10 @@ import { getSessionData } from '$lib/utils/services/auth/session';
 import { getHasCioCookies } from '$lib/utils/functions/cookies';
 import { applyCspExtensions } from '$lib/utils/csp';
 import { proxyRequestToApi, shouldForwardToApi } from '$lib/utils/proxy-api-request';
-import { type Handle, type HandleServerError, redirect } from '@sveltejs/kit';
+import { type Handle, type HandleServerError, isRedirect, redirect } from '@sveltejs/kit';
 import { isPublicApiRoute, isPublicRoute } from '$lib/utils/functions/routes/isPublicRoute';
 import { ROUTE } from '$lib/utils/constants/routes';
+import { isCustomDomainHost } from '$lib/utils/functions/custom-domain';
 
 export const handleError: HandleServerError = ({ error, event, status, message }) => {
   const err = error as Error;
@@ -22,16 +23,87 @@ export const handleError: HandleServerError = ({ error, event, status, message }
 const ANALYTICS_SESSION_COOKIE = 'cio_aid';
 const ANALYTICS_SESSION_MAX_AGE = 60 * 60 * 24 * 90;
 
-function ensureAnalyticsSessionCookie(cookies: Parameters<Handle>[0]['event']['cookies']) {
-  if (cookies.get(ANALYTICS_SESSION_COOKIE)) return;
+/**
+ * Returns the serialized `Set-Cookie` when a new session id was minted, so
+ * redirect responses built outside `resolve` can carry it. SvelteKit only
+ * applies `cookies.set` to responses that pass through `resolve`.
+ */
+function ensureAnalyticsSessionCookie(cookies: Parameters<Handle>[0]['event']['cookies']): string | null {
+  if (cookies.get(ANALYTICS_SESSION_COOKIE)) return null;
 
-  cookies.set(ANALYTICS_SESSION_COOKIE, crypto.randomUUID(), {
+  const sessionId = crypto.randomUUID();
+  const options = {
     path: '/',
     httpOnly: false,
     sameSite: 'lax',
     secure: true,
     maxAge: ANALYTICS_SESSION_MAX_AGE
-  });
+  } as const;
+
+  cookies.set(ANALYTICS_SESSION_COOKIE, sessionId, options);
+
+  return cookies.serialize(ANALYTICS_SESSION_COOKIE, sessionId, options);
+}
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+function isDocumentRequest(request: Request): boolean {
+  const destination = request.headers.get('sec-fetch-dest');
+  if (destination) return destination === 'document';
+
+  return request.headers.get('accept')?.includes('text/html') ?? false;
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+/** Copy headers without collapsing repeated `Set-Cookie` values into one. */
+function cloneResponseHeaders(source: Headers): Headers {
+  const headers = new Headers();
+
+  for (const [name, value] of source.entries()) {
+    if (name === 'set-cookie') continue;
+
+    headers.set(name, value);
+  }
+
+  const setCookies = typeof source.getSetCookie === 'function' ? source.getSetCookie() : [];
+  for (const cookie of setCookies) {
+    headers.append('set-cookie', cookie);
+  }
+
+  return headers;
+}
+
+/**
+ * BYOD custom domains sit behind Approximated's edge, which replays a cached
+ * `103 Early Hints` for any URL it has previously seen return HTML. When the
+ * origin then answers that URL with a redirect, the status is flattened to
+ * `200` and only the `Location` header survives. Browsers ignore `Location` on
+ * a 2xx, so an empty-bodied redirect renders as a blank page.
+ *
+ * Give document redirects a meta-refresh body so navigation still happens if a
+ * proxy rewrites the status. Meta refresh only, no inline script, so the CSP
+ * applied in `applyCspExtensions` needs no nonce.
+ */
+function withRedirectFallbackBody(response: Response, request: Request): Response {
+  if (!REDIRECT_STATUSES.has(response.status)) return response;
+
+  const location = response.headers.get('location');
+  if (!location || !isDocumentRequest(request)) return response;
+
+  const escapedLocation = escapeHtmlAttribute(location);
+  const body =
+    `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
+    `<meta http-equiv="refresh" content="0; url=${escapedLocation}"></head>` +
+    `<body><a href="${escapedLocation}">Continue</a></body></html>`;
+
+  const headers = cloneResponseHeaders(response.headers);
+  headers.set('content-type', 'text/html; charset=utf-8');
+  headers.delete('content-length');
+
+  return new Response(body, { status: response.status, statusText: response.statusText, headers });
 }
 
 export const handle: Handle = async (args) => {
@@ -50,23 +122,46 @@ export const handle: Handle = async (args) => {
     event.locals = sessionData;
   }
 
-  if (!event.url.pathname.includes('/api')) {
-    ensureAnalyticsSessionCookie(event.cookies);
+  const isApiRequest = event.url.pathname.includes('/api');
+  let analyticsSetCookie: string | null = null;
+
+  if (!isApiRequest) {
+    analyticsSetCookie = ensureAnalyticsSessionCookie(event.cookies);
   }
 
   let response: Response;
 
-  if (event.url.pathname.includes('/api')) {
-    response = await handleAPIRoutes(args);
-  } else {
-    response = await handlePagesRoutes(args);
+  try {
+    response = isApiRequest ? await handleAPIRoutes(args) : await handlePagesRoutes(args);
+  } catch (error) {
+    if (!isRedirect(error)) throw error;
+
+    response = new Response(null, {
+      status: error.status,
+      headers: { location: error.location }
+    });
+
+    if (analyticsSetCookie) {
+      response.headers.append('set-cookie', analyticsSetCookie);
+    }
   }
+
+  response = withRedirectFallbackBody(response, event.request);
 
   // Prevent Cloudflare/CDN from caching HTML pages — stale HTML references old
   // hashed JS/CSS bundles after a deploy, causing the app to hang on deep links.
   const contentType = response.headers.get('content-type') ?? '';
   if (contentType.includes('text/html')) {
     response.headers.set('Cache-Control', 'private, no-cache, must-revalidate');
+
+    // SvelteKit emits `Link: rel=preload` headers for every HTML page. On BYOD
+    // domains Approximated caches those per URL and replays them as `103 Early
+    // Hints`, which is what breaks a later redirect on the same URL. Dropping
+    // the header stops new URLs from being poisoned; the `<head>` link tags are
+    // untouched, so app-owned hosts keep header preloads.
+    if (isCustomDomainHost(event.url)) {
+      response.headers.delete('link');
+    }
   }
 
   return applyCspExtensions(response);

--- a/apps/dashboard/src/lib/features/app/layout-setup.ts
+++ b/apps/dashboard/src/lib/features/app/layout-setup.ts
@@ -6,6 +6,7 @@ import { PUBLIC_IS_SELFHOSTED } from '$env/static/public';
 import { blockedSubdomain } from '$lib/utils/constants/app';
 import { env } from '$env/dynamic/private';
 import { getApiKeyHeaders } from '$lib/utils/services/api/server';
+import { isCustomDomainHost } from '$lib/utils/functions/custom-domain';
 
 export interface OrgSiteInfo {
   isOrgSite: boolean;
@@ -51,7 +52,7 @@ export async function getOrgSiteInfo(url: URL, cookies: Cookies): Promise<OrgSit
   const subdomain = getSubdomain(url) || '';
 
   // Custom domain
-  if (isURLCustomDomain(url)) {
+  if (isCustomDomainHost(url)) {
     console.log('it is custom domain');
     const apiKeyHeaders = getApiKeyHeaders();
     const orgs = await getOrgsByCustomDomain(url.hostname, true, apiKeyHeaders);
@@ -93,16 +94,6 @@ export async function getOrgSiteInfo(url: URL, cookies: Cookies): Promise<OrgSit
   }
 
   return response;
-}
-
-function isURLCustomDomain(url: URL) {
-  if (url.host.includes('localhost')) {
-    return false;
-  }
-
-  const notCustomDomainHosts = [env.PRIVATE_APP_HOST || '', 'classroomio.com', 'myclassroomio.com'].filter(Boolean);
-
-  return !notCustomDomainHosts.some((host) => url.host.endsWith(host));
 }
 
 export function getSubdomain(url: URL) {

--- a/apps/dashboard/src/lib/utils/functions/custom-domain.ts
+++ b/apps/dashboard/src/lib/utils/functions/custom-domain.ts
@@ -1,0 +1,16 @@
+import { env } from '$env/dynamic/private';
+
+/**
+ * True when a request arrived on a customer's BYOD domain rather than a host we
+ * own. BYOD domains are fronted by Approximated's edge instead of the tenant
+ * Worker, so they need proxy-specific response handling.
+ */
+export function isCustomDomainHost(url: URL): boolean {
+  if (url.host.includes('localhost')) {
+    return false;
+  }
+
+  const appHosts = [env.PRIVATE_APP_HOST || '', 'classroomio.com', 'myclassroomio.com'].filter(Boolean);
+
+  return !appHosts.some((host) => url.host.endsWith(host));
+}


### PR DESCRIPTION
## Problem

A logged-out visitor hitting a protected page on a customer's custom domain got a **blank page** — no console error, no server-side trace, nothing in the logs.

`my.fastlearner.io/lms`:

```
HTTP/1.1 103 Early Hints
Link: <./_app/immutable/assets/hero.Dn8iW_4X.css>; rel=preload, ...
Server: Caddy

HTTP/1.1 200 OK                     <- status rewritten
Location: /login?redirect=%2Flms    <- redirect header survives
Apx-Hit: true
Content-Length: 0
```

`ciodevs.myclassroomio.com/lms`, same origin, same moment: a correct `303 See Other`.

## Cause

BYOD domains are fronted by Approximated's edge instead of the tenant Worker. It caches the `Link: rel=preload` headers SvelteKit emits for HTML pages (`render.js:298`) and replays them as a `103 Early Hints` on later requests to that URL. Once the informational response is committed and the origin then answers with a redirect, the status is flattened to `200` and only `Location` survives. Browsers ignore `Location` on a 2xx, so the empty body renders as a blank document.

Evidence that isolated it:

| | `/lms` | `/lms/` | `/LMS` | `/home` |
|---|---|---|---|---|
| custom domain | **103+200** | 308 | 303 | 303 |
| tenant subdomain | 303 | 308 | — | 303 |

Redirects pass through the proxy fine in general — `/lms/` returns a clean 308 through the same edge. It is keyed to the exact path that had previously been hinted. `?cb=<random>`, `Cache-Control: no-cache` and `HEAD` all failed to bust it.

This is not specific to one domain or one path. Any URL that serves HTML to a logged-in user and later redirects a logged-out one will do it, on any custom domain. There is no cache or Early Hints control in the Approximated dashboard (vhost advanced settings are only *Exact match*, *Host header*, *Rate limit*), and the entry expires and re-forms on its own, so the failure appears intermittent.

## Fix

Two independent layers, both in `hooks.server.ts`:

1. **Stop seeding the hints.** Drop the `Link` header on custom-domain HTML responses so the edge has nothing to cache. App-owned hosts (`app.classroomio.com`, `*.myclassroomio.com`) keep it, and `<head>` link tags are untouched, so preload behaviour is unchanged where the Worker serves the request.
2. **Survive the rewrite anyway.** Document redirects carry a `<meta http-equiv="refresh">` body, so navigation still happens if a proxy flattens the status. Layer 2 matters because layer 1 cannot clear hints already cached at the edge. Data requests keep bare redirects; no inline script, so CSP needs no nonce.

Returning a redirect `Response` from `handle` skips SvelteKit's `add_cookies_to_headers`, so `ensureAnalyticsSessionCookie` now returns the serialized cookie for that path and it is appended explicitly.

`isURLCustomDomain` moves out of `layout-setup.ts` into a shared `custom-domain.ts` so hooks and layout setup agree on one host list.

## Verification

Against the production build (`node build/index.js`), not just a typecheck:

```
GET /lms, sec-fetch-dest: document
  303 See Other
  location: /login?redirect=%2Flms
  set-cookie: cio_aid=...          <- analytics cookie preserved
  <meta http-equiv="refresh" content="0; url=/login?redirect=%2Flms">

GET /lms, sec-fetch-dest: empty    -> 303, no body (unchanged)
Host: my.fastlearner.io   /login   -> no link header
Host: app.classroomio.com /login   -> link header intact
```

The cookie assertion is the one that mattered: bypassing `resolve` drops `cookies.set`, and `cio_aid` is confirmed present on the redirect.

- `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build` pass
- `pnpm format:check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved redirect handling to preserve analytics cookies and repeated cookies set during navigation.
  - Added a fallback for document redirects to improve compatibility in browsers and environments that do not follow standard redirects.
  - Improved custom-domain responses by removing unnecessary preload headers.
  - Improved detection of customer-hosted domains, including appropriate handling for local development URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hardens redirects on BYOD custom domains against an edge-proxy interaction that can flatten redirects after cached Early Hints.
- Removes SvelteKit preload `Link` headers from custom-domain HTML responses.
- Adds an HTML meta-refresh fallback to document redirects while retaining bare redirects for data requests.
- Explicitly preserves the analytics cookie when handling redirects outside `resolve`.
- Centralizes custom-domain host classification for hooks and organization layout setup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed paths.

The redirect fallback remains limited to document redirects, preserves response status and supported-runtime cookie headers, and applies BYOD-specific preload suppression consistently with existing host resolution.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/hooks.server.ts | Adds redirect-response recovery, cookie preservation, and custom-domain preload-header suppression without an identified actionable defect. |
| apps/dashboard/src/lib/features/app/layout-setup.ts | Replaces the local custom-domain classifier with the shared helper while preserving existing behavior. |
| apps/dashboard/src/lib/utils/functions/custom-domain.ts | Extracts the existing owned-host classification into a shared utility used consistently by request hooks and tenant resolution. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant B as Browser
  participant E as BYOD Edge
  participant H as Dashboard Hook
  participant R as SvelteKit Route
  B->>E: Request protected document
  E->>H: Forward request
  H->>R: Resolve request
  R-->>H: Redirect response
  H->>H: Add meta-refresh fallback
  H-->>E: 303 + Location + HTML body
  E-->>B: Redirect response
  alt Edge preserves redirect status
    B->>B: Follow Location header
  else Edge flattens status to 200
    B->>B: Follow meta refresh
  end
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): keep redirects working o..."](https://github.com/classroomio/classroomio/commit/5e62291d8c06b338ee49d308fdad6fe83bf7e227) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59378426)</sub>

**Context used:**

- Knowledge Base — [Administration dashboard](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/administration-dashboard.md)

<!-- /greptile_comment -->