### PR TITLE
feat(e2e): add Playwright test hooks and e2e helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ node_modules
 
 # testing
 coverage
+e2e/test-results/
+e2e/playwright-report/
+.github/demo-runs/pr-*.spec.ts
 
 # next.js
 .next/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -577,6 +577,7 @@ Links embedded in transactional emails must use the correct dashboard host. Temp
 - Reset modal/form state in close/submit handlers or `onOpenChange`, not in `$effect` tied to a steady “closed” condition
 - Mutate bound `$state` object fields in place when clearing forms (don't reassign the whole object)
 - Use `ScrollToTop` (`@cio/ui/custom/scroll-to-top`) on any page whose main column can overflow the viewport (see **Scroll to top**)
+- Add `testId` on `@cio/ui` wrappers or shell surfaces when Playwright needs a stable hook (see **E2E test hooks**)
 
 ### ❌ DON'T
 - Put business logic in routes or queries
@@ -595,6 +596,23 @@ Links embedded in transactional emails must use the correct dashboard host. Temp
 - **Reassign whole bound state objects to clear forms** (e.g. `fields = {}`) — mutate properties in place
 - **Use inline type imports** (e.g. `import('Package').Type` in type positions) — use top-level `import type` instead
 - Build a one-off back-to-top button — use `ScrollToTop` (see **Scroll to top** and `prd/scroll-to-top/README.md`)
+
+## E2E test hooks
+
+Playwright specs and PR demos should use stable, locale-independent selectors. Full registry: `e2e/README.md`.
+
+**Locator priority:** `getByRole` / `getByLabel` first, then legacy `#id`, then `getByTestId`. Never select by CSS class, Tailwind utility, or translated copy in CI.
+
+**Infrastructure ids** ship in the app shell (login, org sidebar, header, settings save bar). Org nav ids are derived by `orgNavTestId()` — e.g. `/courses` → `org-nav-courses`.
+
+**Call-site ids:** pass `testId` on `@cio/ui` field wrappers and `Button` when a feature needs a hook. Naming: kebab-case, feature-scoped — `{area}-{element}` or `{area}-{element}-{action}`.
+
+```svelte
+<InputField testId="course-settings-title" label={...} bind:value={...} />
+<Button testId="course-create-submit">Create</Button>
+```
+
+Do not annotate every control — add hooks only for high-impact flows (auth, nav, save bars, primary actions).
 
 ## Checklist for New Routes
 

--- a/apps/dashboard/src/lib/features/ui/navigation/app-header.svelte
+++ b/apps/dashboard/src/lib/features/ui/navigation/app-header.svelte
@@ -26,7 +26,7 @@
   class="ui:border-border ui:bg-background sticky top-0 z-50 flex h-12 w-full shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-8"
 >
   <div class="flex w-full items-center gap-2 px-4">
-    <Sidebar.Trigger />
+    <Sidebar.Trigger testId="app-sidebar-trigger" />
 
     <div class="h-4 w-2">
       <Separator orientation="vertical" />
@@ -43,7 +43,7 @@
 
     <Popover.Root>
       <Popover.Trigger>
-        <Button variant="outline" size="icon">
+        <Button variant="outline" size="icon" testId="app-notifications-trigger">
           <BellIcon class="custom rounded-full" />
         </Button>
       </Popover.Trigger>

--- a/apps/dashboard/src/lib/features/ui/navigation/org-navigation.ts
+++ b/apps/dashboard/src/lib/features/ui/navigation/org-navigation.ts
@@ -26,6 +26,8 @@ export interface NavItem {
   title: string;
   url: string;
   path: string; // Actual path (e.g., '/settings') for breadcrumb generation
+  /** Stable Playwright hook, e.g. org-nav-courses */
+  testId: string;
   icon?: Component;
   isActive?: boolean;
   isExpanded?: boolean;
@@ -56,6 +58,8 @@ export interface NavItemConfig {
   isPaid?: boolean; // Show upgrade indicator for free plan users
   /** Plan-limited resource this item represents; when that resource is at its cap, `upgrade` is set. */
   upgradeResource?: PlanLimitResource;
+  /** Override the default org-nav-* test id derived from `path`. */
+  testId?: string;
   group?: string | null; // Group label key for sidebar grouping
 }
 
@@ -67,6 +71,20 @@ export interface NavGroup {
 export interface NestedRouteConfig {
   path: string; // Relative to parent (e.g., 'ask', 'customize-lms')
   titleKey: string; // Translation key or plain text
+}
+
+/** Stable sidebar nav hook from a route path segment (locale-independent). */
+export function orgNavTestId(path: string): string {
+  if (!path) {
+    return 'org-nav-home';
+  }
+
+  const slug = path.replace(/^\//, '').replace(/\//g, '-');
+  return `org-nav-${slug}`;
+}
+
+function resolveNavTestId(path: string, testId?: string): string {
+  return testId ?? orgNavTestId(path);
 }
 
 // Base navigation configuration structure
@@ -361,6 +379,7 @@ export function getOrgNavigationItems(
       title: t(config.titleKey),
       url: config.useHashUrl ? '#' : url,
       path: config.path, // Store actual path for breadcrumb generation
+      testId: resolveNavTestId(config.path, config.testId),
       icon: config.icon,
       matchPattern,
       isActive: isActive(pagePathname, fullPath, matchPattern),
@@ -386,6 +405,7 @@ export function getOrgNavigationItems(
           isActive: isActive(pagePathname, subUrl, subMatchPattern, true),
           url: subUrl,
           path: subConfig.path,
+          testId: resolveNavTestId(subConfig.path, subConfig.testId),
           matchPattern: subMatchPattern,
           isPaid: subConfig.isPaid,
           nestedRoutes: subConfig.nestedRoutes
@@ -445,6 +465,7 @@ export function getOrgNavigationGroups(
       title: t(config.titleKey),
       url: config.useHashUrl ? '#' : url,
       path: config.path,
+      testId: resolveNavTestId(config.path, config.testId),
       icon: config.icon,
       matchPattern,
       isActive: isActive(pathnameOnly, fullPath, matchPattern),
@@ -469,6 +490,7 @@ export function getOrgNavigationGroups(
           isActive: isActive(pathnameOnly, subUrl, subMatchPattern, true),
           url: subUrl,
           path: subConfig.path,
+          testId: resolveNavTestId(subConfig.path, subConfig.testId),
           matchPattern: subMatchPattern,
           isPaid: subConfig.isPaid,
           nestedRoutes: subConfig.nestedRoutes

--- a/apps/dashboard/src/lib/features/ui/sidebar/footer/menu.svelte
+++ b/apps/dashboard/src/lib/features/ui/sidebar/footer/menu.svelte
@@ -85,6 +85,7 @@
         {#snippet child({ props })}
           <Sidebar.MenuButton
             size="lg"
+            data-testid="app-user-menu-trigger"
             class="ui:data-[state=open]:bg-sidebar-accent ui:data-[state=open]:text-sidebar-accent-foreground"
             {...props}
           >

--- a/apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/nav-main.svelte
+++ b/apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/nav-main.svelte
@@ -21,7 +21,7 @@
       <Sidebar.GroupLabel>{$t(group.labelKey)}</Sidebar.GroupLabel>
     {/if}
     <Sidebar.Menu>
-      {#each group.items as item (item.title)}
+      {#each group.items as item (item.testId)}
         <Collapsible.Root open={item.isActive || item.isExpanded} class="group/collapsible">
           {#snippet child({ props })}
             <Sidebar.MenuItem {...props}>
@@ -43,7 +43,7 @@
                                 {/if}
                               </span>
                             {:else}
-                              <a href={item.url} {...props}>
+                              <a href={item.url} {...props} data-testid={item.testId}>
                                 {#if item.icon}
                                   {@const Icon = item.icon}
                                   <Icon {isHovered} size={16} class="custom" />
@@ -78,7 +78,7 @@
                             {/if}
                           </span>
                         {:else}
-                          <a href={item.url} {...props}>
+                          <a href={item.url} {...props} data-testid={item.testId}>
                             {#if item.icon}
                               {@const Icon = item.icon}
                               <Icon {isHovered} size={16} class="custom" />
@@ -99,11 +99,11 @@
               {#if item.items}
                 <Collapsible.Content>
                   <Sidebar.MenuSub>
-                    {#each item.items ?? [] as subItem (subItem.title)}
+                    {#each item.items ?? [] as subItem (subItem.testId)}
                       <Sidebar.MenuSubItem>
                         <Sidebar.MenuSubButton isActive={subItem.isActive}>
                           {#snippet child({ props })}
-                            <a href={subItem.url} {...props}>
+                            <a href={subItem.url} {...props} data-testid={subItem.testId}>
                               <span>{subItem.title}</span>
                               {#if subItem.isPaid && $isFreePlan}
                                 <PremiumIcon size={16} class="ui:text-primary ml-auto" />

--- a/apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/org-switcher.svelte
+++ b/apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/org-switcher.svelte
@@ -94,7 +94,7 @@
   <DropdownMenu.Root>
     <DropdownMenu.Trigger>
       {#snippet child({ props })}
-        <Breadcrumb.Link {...props} href="##" class="flex items-center gap-2">
+        <Breadcrumb.Link {...props} href="##" class="flex items-center gap-2" data-testid="org-switcher-trigger">
           {#if $currentOrg.name}
             <Avatar.Root class="flex size-6! items-center justify-center rounded-md!">
               <Avatar.Image src={$currentOrg.avatarUrl} alt={$currentOrg.name} />
@@ -168,6 +168,7 @@
             <Sidebar.MenuButton
               {...props}
               size="lg"
+              data-testid="org-switcher-trigger"
               class="ui:data-[state=open]:bg-sidebar-accent ui:data-[state=open]:text-sidebar-accent-foreground"
             >
               {#if $currentOrg.name}

--- a/apps/dashboard/src/routes/(auth)/login/+page.svelte
+++ b/apps/dashboard/src/routes/(auth)/login/+page.svelte
@@ -161,6 +161,7 @@
           id="email"
           type="email"
           bind:value={fields.email}
+          data-testid="auth-login-email"
           oninput={handleEmailChange}
           placeholder="you@domain.com"
           disabled={loading || isEmailPrefilled}
@@ -188,6 +189,7 @@
           <Password
             id="password"
             bind:value={fields.password}
+            data-testid="auth-login-password"
             placeholder="************"
             disabled={loading}
             aria-invalid={errors.password ? 'true' : undefined}
@@ -203,7 +205,7 @@
         <p class="ui:text-destructive text-sm">{submitError}</p>
       {/if}
 
-      <Button type="submit" disabled={loading} {loading} class="w-full">
+      <Button type="submit" disabled={loading} {loading} class="w-full" testId="auth-login-submit">
         {$t('login.login')}
       </Button>
     {:else if $globalStore.isOrgSite && $currentOrg.disableEmailPassword && !ssoState.available}

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,56 @@
+# E2E test hooks
+
+Playwright specs and helpers for PR demos and future end-to-end tests.
+
+## Locator priority
+
+1. `getByRole` / `getByLabel` when the control is accessible
+2. Existing `#id` attributes (e.g. legacy login fields)
+3. `getByTestId` for stable, locale-independent hooks
+
+Do not select by CSS class, Tailwind utility, or translated copy in CI.
+
+## Fixed test ids (infrastructure)
+
+These ship in the app shell or shared UI and do not require call-site props.
+
+| Test id | Surface |
+|---|---|
+| `auth-login-email` | Login email input |
+| `auth-login-password` | Login password input |
+| `auth-login-submit` | Login submit button |
+| `org-nav-{path}` | Org sidebar links (derived from route path, e.g. `org-nav-courses`) |
+| `org-switcher-trigger` | Org / workspace switcher |
+| `app-sidebar-trigger` | Collapse sidebar |
+| `app-notifications-trigger` | Header notifications |
+| `app-user-menu-trigger` | Footer profile menu |
+| `page-settings-actions` | Sticky settings save bar container |
+| `page-settings-save` | Settings save button |
+| `page-settings-discard` | Settings discard button |
+
+Org nav ids are built by `orgNavTestId()` in `apps/dashboard/src/lib/features/ui/navigation/org-navigation.ts`.
+
+## Call-site test ids
+
+Pass `testId` on `@cio/ui` field wrappers and buttons when a feature needs a stable hook:
+
+```svelte
+<InputField testId="course-settings-title" label={...} bind:value={...} />
+<Button testId="course-create-submit">Create</Button>
+```
+
+Naming: kebab-case, feature-scoped — `{area}-{element}` or `{area}-{element}-{action}`.
+
+## Helpers
+
+- `e2e/helpers/login.ts` — `loginAsAdmin`, `openOrgCatalog`
+- `e2e/helpers/nav.ts` — `clickOrgNav`, `goToOrgCourses`
+
+## Running locally
+
+Requires dashboard preview + API (see root `README.md`). Then:
+
+```bash
+pnpm exec playwright install chromium
+DEMO_BASE_URL=http://localhost:4173 pnpm demo:playwright
+```

--- a/e2e/demos/example.spec.ts
+++ b/e2e/demos/example.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+import { loginAsAdmin } from '../helpers/login';
+
+test('admin can sign in with test hooks', async ({ page }) => {
+  await loginAsAdmin(page);
+  await expect(page).not.toHaveURL(/\/login/);
+});

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -1,0 +1,22 @@
+import type { Page } from '@playwright/test';
+
+export const DEMO_ADMIN = {
+  email: 'admin@test.com',
+  password: '123456'
+} as const;
+
+export const DEFAULT_ORG_SITE_NAME = 'udemy-test';
+
+/** Admin app login (cloud mode, localhost preview). */
+export async function loginAsAdmin(page: Page) {
+  await page.goto('/login');
+  await page.getByTestId('auth-login-email').fill(DEMO_ADMIN.email);
+  await page.getByTestId('auth-login-password').fill(DEMO_ADMIN.password);
+  await page.getByTestId('auth-login-submit').click();
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 60_000 });
+}
+
+/** Org public site (simulates tenant subdomain via ?org= locally). */
+export async function openOrgCatalog(page: Page, siteName = DEFAULT_ORG_SITE_NAME) {
+  await page.goto(`/?org=${siteName}`);
+}

--- a/e2e/helpers/nav.ts
+++ b/e2e/helpers/nav.ts
@@ -1,0 +1,11 @@
+import type { Page } from '@playwright/test';
+
+/** Click a top-level org sidebar link by its stable test id (see e2e/README.md). */
+export async function clickOrgNav(page: Page, testId: string) {
+  await page.getByTestId(testId).click();
+}
+
+/** Navigate to org courses list from the admin sidebar. */
+export async function goToOrgCourses(page: Page) {
+  await clickOrgNav(page, 'org-nav-courses');
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '..',
+  testMatch: ['.github/demo-runs/pr-*.spec.ts', 'e2e/demos/**/*.spec.ts'],
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
+  outputDir: 'test-results',
+  use: {
+    baseURL: process.env.DEMO_BASE_URL ?? 'http://localhost:4173',
+    video: 'on',
+    screenshot: 'on',
+    trace: 'retain-on-failure',
+    ...devices['Desktop Chrome']
+  }
+});

--- a/package.json
+++ b/package.json
@@ -33,13 +33,15 @@
     "embeds:dev": "pnpm --filter=@cio/embeds --filter=@cio/ui run dev",
     "storybook:dev": "pnpm --filter=@cio/storybook --filter=@cio/ui --filter=@cio/question-types run dev",
     "mcp:build": "pnpm --filter @cio/question-types build && pnpm --filter @cio/utils build && pnpm --filter @classroomio/mcp build",
-    "db:push": "pnpm --filter @cio/db db push"
+    "db:push": "pnpm --filter @cio/db db push",
+    "demo:playwright": "playwright test --config e2e/playwright.config.ts"
   },
   "license": "MIT",
   "dependencies": {
     "turbo": "^1.10.16"
   },
   "devDependencies": {
+    "@playwright/test": "^1.48.2",
     "@babel/plugin-syntax-jsx": "^7.28.6",
     "@babel/preset-typescript": "^7.28.5",
     "@cio/tsconfig": "workspace:*",

--- a/packages/storybook/src/atoms/button/button.stories.svelte
+++ b/packages/storybook/src/atoms/button/button.stories.svelte
@@ -82,6 +82,12 @@
   {/snippet}
 </Story>
 
+<Story name="With testId">
+  {#snippet template(args)}
+    <Button {...args} testId="storybook-submit-button">Submit</Button>
+  {/snippet}
+</Story>
+
 <Story name="All Variants">
   {#snippet template()}
     <div class="flex flex-wrap gap-4">

--- a/packages/storybook/src/atoms/button/fields.ts
+++ b/packages/storybook/src/atoms/button/fields.ts
@@ -1,1 +1,1 @@
-export const FIELDS = ['variant', 'size', 'disabled', 'class', 'type', 'href', 'loading'] as string[];
+export const FIELDS = ['variant', 'size', 'disabled', 'class', 'type', 'href', 'loading', 'testId'] as string[];

--- a/packages/storybook/src/molecules/input-field/fields.ts
+++ b/packages/storybook/src/molecules/input-field/fields.ts
@@ -14,5 +14,6 @@ export const FIELDS = [
   'labelClassName',
   'min',
   'max',
-  'autoComplete'
+  'autoComplete',
+  'testId'
 ] as string[];

--- a/packages/storybook/src/molecules/input-field/input-field.stories.svelte
+++ b/packages/storybook/src/molecules/input-field/input-field.stories.svelte
@@ -178,6 +178,22 @@
   {/snippet}
 </Story>
 
+<Story name="With testId">
+  {#snippet template()}
+    <div class="ui:flex ui:flex-col ui:gap-4 ui:w-96">
+      <InputField
+        label="Student Email"
+        placeholder="student@example.com"
+        bind:value={studentEmail}
+        name="student-email-testid"
+        type="email"
+        testId="storybook-input-email"
+      />
+      <p class="ui:text-sm ui:text-muted-foreground">Playwright: page.getByTestId('storybook-input-email')</p>
+    </div>
+  {/snippet}
+</Story>
+
 <Story name="Form Example">
   {#snippet template()}
     <form class="ui:flex ui:flex-col ui:gap-4 ui:w-96" onsubmit={(e) => e.preventDefault()}>

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -244,6 +244,19 @@ This ensures that styles don't conflict with other Tailwind configurations in co
 
 **Note:** When adding new components or styles, always use the `ui:` prefix for all Tailwind classes.
 
+## Test hooks (`testId`)
+
+Optional `testId` props on form wrappers and buttons render `data-testid` for Playwright. Prefer roles/labels first; use `testId` when a flow needs a stable, locale-independent hook.
+
+Supported today: `InputField`, `TextareaField`, `CheckboxField`, `Button`. Fixed ids on `Page.SettingsActions` (`page-settings-save`, `page-settings-discard`).
+
+```svelte
+<InputField testId="course-settings-title" label="Title" bind:value={title} />
+<Button testId="course-create-submit">Create</Button>
+```
+
+Registry and naming rules: `e2e/README.md` and AGENTS.md § E2E test hooks.
+
 ## Component Exports
 
 Components are exported from the main `src/index.ts` file in an alphabetical order. There are two main export patterns:

--- a/packages/ui/src/base/button/button.svelte
+++ b/packages/ui/src/base/button/button.svelte
@@ -49,6 +49,8 @@
     size?: ButtonSize;
     animate?: ButtonAnimate;
     loading?: boolean;
+    /** Stable hook for Playwright (`data-testid`). Also accepts `data-testid` via HTML attributes. */
+    testId?: string;
     onClickPromise?: (
       e: MouseEvent & {
         currentTarget: EventTarget & HTMLButtonElement;
@@ -86,6 +88,7 @@
     type = 'button',
     loading = false,
     disabled = false,
+    testId,
     tabindex = 0,
     onclick,
     onClickPromise,
@@ -106,6 +109,7 @@
   this={href ? 'a' : 'button'}
   {...rest}
   data-slot="button"
+  data-testid={testId}
   type={href ? undefined : type}
   href={href && !disabled ? href : undefined}
   disabled={href ? undefined : disabled || loading}

--- a/packages/ui/src/base/page/page-settings-actions.svelte
+++ b/packages/ui/src/base/page/page-settings-actions.svelte
@@ -37,6 +37,7 @@
   <div
     bind:this={ref}
     data-slot="page-settings-actions"
+    data-testid="page-settings-actions"
     class={cn(
       'ui:pointer-events-none ui:sticky ui:bottom-0 ui:z-50 ui:flex ui:shrink-0 ui:justify-center ui:px-2 ui:pb-4',
       className
@@ -64,13 +65,22 @@
           variant="secondary"
           size="sm"
           type="button"
+          testId="page-settings-discard"
           class="ui:bg-background ui:text-foreground ui:hover:bg-background/80"
           disabled={loading}
           onclick={onDiscard}
         >
           {discardLabel}
         </Button>
-        <Button variant="default" size="sm" type="button" {loading} disabled={loading || disabled} onclick={onSave}>
+        <Button
+          variant="default"
+          size="sm"
+          type="button"
+          testId="page-settings-save"
+          {loading}
+          disabled={loading || disabled}
+          onclick={onSave}
+        >
           {saveLabel}
         </Button>
       </div>

--- a/packages/ui/src/custom/checkbox-field/checkbox-field.svelte
+++ b/packages/ui/src/custom/checkbox-field/checkbox-field.svelte
@@ -10,6 +10,8 @@
     name?: string;
     isEditable?: boolean;
     disabled?: boolean;
+    /** Stable hook for Playwright (`data-testid`) on the checkbox control. */
+    testId?: string;
     className?: string;
     onchange?: (e: Event) => void;
     /** When set, the whole row handles the click (e.g. multi-select). Avoids nesting a native button inside the checkbox control. */
@@ -24,6 +26,7 @@
     name = '',
     isEditable = false,
     disabled = false,
+    testId,
     className = '',
     onchange = () => {},
     onclick,
@@ -62,7 +65,14 @@
     onclick={handleRowClick}
     onkeydown={handleRowKeydown}
   >
-    <Checkbox class="ui:pointer-events-none" {name} {value} disabled={disabled || isEditable} bind:checked />
+    <Checkbox
+      class="ui:pointer-events-none"
+      {name}
+      {value}
+      disabled={disabled || isEditable}
+      bind:checked
+      data-testid={testId}
+    />
     {#if isEditable}
       <!-- Isolate text field from the row button (rare: onclick + isEditable) -->
       <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -78,7 +88,7 @@
   </div>
 {:else if isEditable}
   <div class={rowClass}>
-    <Checkbox {name} {value} disabled={disabled || isEditable} bind:checked />
+    <Checkbox {name} {value} disabled={disabled || isEditable} bind:checked data-testid={testId} />
     <div class="ui:w-2/4">
       <InputField bind:value={label} placeholder="Your option" className="ui:ml-1" type="text" {onchange} />
     </div>
@@ -87,7 +97,7 @@
   </div>
 {:else}
   <label class={rowClass}>
-    <Checkbox {name} {value} {disabled} bind:checked />
+    <Checkbox {name} {value} {disabled} bind:checked data-testid={testId} />
     <span class="ui:ml-2 ui:dark:text-white ui:text-sm">{label}</span>
 
     {@render children?.()}

--- a/packages/ui/src/custom/input-field/input-field.svelte
+++ b/packages/ui/src/custom/input-field/input-field.svelte
@@ -25,6 +25,8 @@
     errorMessage?: string;
     helperMessage?: string;
     autoComplete?: boolean;
+    /** Stable hook for Playwright (`data-testid`). Prefer over CSS classes or translated labels. */
+    testId?: string;
     onchange?: (e: InputOnChangeEvent) => void;
     onInputChange?: (e: InputOnChangeEvent) => void;
     labelAction?: import('svelte').Snippet;
@@ -50,6 +52,7 @@
     errorMessage = '',
     helperMessage = '',
     autoComplete = true,
+    testId,
     onchange = () => {},
     onInputChange = () => {},
     labelAction
@@ -88,6 +91,7 @@
     class={inputClassName}
     bind:ref={inputRef}
     id={name || 'input-field'}
+    data-testid={testId}
     {type}
     {placeholder}
     bind:value

--- a/packages/ui/src/custom/textarea-field/textarea-field.svelte
+++ b/packages/ui/src/custom/textarea-field/textarea-field.svelte
@@ -12,6 +12,8 @@
     isRequired?: boolean;
     className?: string;
     bgColor?: string;
+    /** Stable hook for Playwright (`data-testid`). */
+    testId?: string;
     labelAction?: import('svelte').Snippet;
     iconbutton?: import('svelte').Snippet;
   }
@@ -24,6 +26,7 @@
     isRequired = false,
     className = '',
     bgColor = '',
+    testId,
     labelAction,
     iconbutton,
     value = $bindable(),
@@ -48,6 +51,7 @@
     bind:value
     class={cn(bgColor, errorMessage ? 'ui:border-red-500' : '')}
     aria-invalid={errorMessage ? 'true' : undefined}
+    data-testid={testId}
     {...textareaProps}
   />
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@evilmartians/lefthook':
         specifier: ^1.13.6
         version: 1.13.6
+      '@playwright/test':
+        specifier: ^1.48.2
+        version: 1.57.0
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -619,7 +622,7 @@ importers:
         version: 0.4.9(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.4)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.958.0)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(ioredis@5.10.1)(jiti@2.6.1)(rollup@4.54.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
       '@shikijs/twoslash':
         specifier: 4.3.1
-        version: 4.3.1(typescript@5.9.3)
+        version: 4.3.1(typescript@6.0.3)
       '@tailwindcss/typography':
         specifier: 0.5.19
         version: 0.5.19(tailwindcss@4.1.18)
@@ -631,7 +634,7 @@ importers:
         version: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.4)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.958.0)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(ioredis@5.10.1)(jiti@2.6.1)(rollup@4.54.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)
       blume:
         specifier: 1.2.0
-        version: 1.2.0(f342977323bd7a6c7016cdf6ded9eb09)
+        version: 1.2.0(d3f8375b6e3f03057eb24d94660d2dc0)
       mermaid:
         specifier: ^11.16.0
         version: 11.16.0
@@ -1377,7 +1380,7 @@ importers:
         version: 10.1.10(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(esbuild@0.25.12)(rollup@4.54.0)(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
       '@storybook/sveltekit':
         specifier: ^8.4.2
-        version: 8.6.15(@babel/core@7.29.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.9.3)))(postcss@8.5.19)(sass@1.97.1)(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 8.6.15(@babel/core@7.29.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@6.0.3)))(postcss@8.5.19)(sass@1.97.1)(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
       '@storybook/test':
         specifier: ^8.4.2
         version: 8.6.14(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))
@@ -1416,7 +1419,7 @@ importers:
         version: 4.21.0
       typescript-svelte-plugin:
         specifier: ^0.3.50
-        version: 0.3.50(svelte@5.56.9(@typescript-eslint/types@8.50.1))(typescript@5.9.3)
+        version: 0.3.50(svelte@5.56.9(@typescript-eslint/types@8.50.1))(typescript@6.0.3)
       vite:
         specifier: ^7.1.4
         version: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)
@@ -16167,30 +16170,6 @@ snapshots:
       is-docker: 4.0.0
       package-manager-detector: 1.7.0
 
-  '@astrojs/vercel@11.0.3(@aws-sdk/credential-provider-web-identity@3.958.0)(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.4)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.958.0)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(ioredis@5.10.1)(jiti@2.6.1)(rollup@4.54.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))(encoding@0.1.13)(react@19.2.3)(rollup@4.54.0)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vue@3.5.26(typescript@5.9.3))(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
-    dependencies:
-      '@astrojs/internal-helpers': 0.10.1
-      '@vercel/analytics': 1.6.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(react@19.2.3)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vue@3.5.26(typescript@5.9.3))
-      '@vercel/functions': 3.7.5(@aws-sdk/credential-provider-web-identity@3.958.0)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@vercel/nft': 1.10.2(encoding@0.1.13)(rollup@4.54.0)
-      '@vercel/routing-utils': 5.3.3
-      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.4)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.958.0)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(ioredis@5.10.1)(jiti@2.6.1)(rollup@4.54.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)
-      esbuild: 0.28.1
-      tinyglobby: 0.2.17
-    transitivePeerDependencies:
-      - '@aws-sdk/credential-provider-web-identity'
-      - '@remix-run/react'
-      - '@sveltejs/kit'
-      - encoding
-      - next
-      - react
-      - rollup
-      - supports-color
-      - svelte
-      - vue
-      - vue-router
-      - ws
-
   '@astrojs/vercel@11.0.3(@aws-sdk/credential-provider-web-identity@3.958.0)(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.4)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.958.0)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(ioredis@5.10.1)(jiti@2.6.1)(rollup@4.54.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))(encoding@0.1.13)(react@19.2.3)(rollup@4.54.0)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vue@3.5.26(typescript@6.0.3))(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.1
@@ -20748,15 +20727,6 @@ snapshots:
       '@shikijs/core': 4.3.1
       '@shikijs/types': 4.3.1
 
-  '@shikijs/twoslash@4.3.1(typescript@5.9.3)':
-    dependencies:
-      '@shikijs/core': 4.3.1
-      '@shikijs/types': 4.3.1
-      twoslash: 0.3.9(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@shikijs/twoslash@4.3.1(typescript@6.0.3)':
     dependencies:
       '@shikijs/core': 4.3.1
@@ -21416,7 +21386,7 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/svelte-vite@8.6.15(@babel/core@7.29.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.9.3)))(postcss@8.5.19)(sass@1.97.1)(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@storybook/svelte-vite@8.6.15(@babel/core@7.29.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@6.0.3)))(postcss@8.5.19)(sass@1.97.1)(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@storybook/builder-vite': 8.6.15(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
       '@storybook/svelte': 8.6.15(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))(svelte@5.56.9(@typescript-eslint/types@8.50.1))
@@ -21424,7 +21394,7 @@ snapshots:
       magic-string: 0.30.21
       storybook: 8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6)
       svelte: 5.56.9(@typescript-eslint/types@8.50.1)
-      svelte-preprocess: 5.1.4(@babel/core@7.29.0)(postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.9.3)))(postcss@8.5.19)(sass@1.97.1)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(typescript@5.9.3)
+      svelte-preprocess: 5.1.4(@babel/core@7.29.0)(postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@6.0.3)))(postcss@8.5.19)(sass@1.97.1)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(typescript@5.9.3)
       svelte2tsx: 0.7.46(svelte@5.56.9(@typescript-eslint/types@8.50.1))(typescript@5.9.3)
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
@@ -21465,12 +21435,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/sveltekit@8.6.15(@babel/core@7.29.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.9.3)))(postcss@8.5.19)(sass@1.97.1)(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@storybook/sveltekit@8.6.15(@babel/core@7.29.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@6.0.3)))(postcss@8.5.19)(sass@1.97.1)(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@storybook/addon-actions': 8.6.15(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))
       '@storybook/builder-vite': 8.6.15(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
       '@storybook/svelte': 8.6.15(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))(svelte@5.56.9(@typescript-eslint/types@8.50.1))
-      '@storybook/svelte-vite': 8.6.15(@babel/core@7.29.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.9.3)))(postcss@8.5.19)(sass@1.97.1)(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@storybook/svelte-vite': 8.6.15(@babel/core@7.29.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@6.0.3)))(postcss@8.5.19)(sass@1.97.1)(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
       storybook: 8.6.15(bufferutil@4.1.0)(prettier@3.8.2)(utf-8-validate@6.0.6)
       svelte: 5.56.9(@typescript-eslint/types@8.50.1)
       vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)
@@ -23330,13 +23300,6 @@ snapshots:
       '@typescript-eslint/types': 8.50.1
       eslint-visitor-keys: 4.2.1
 
-  '@typescript/vfs@1.6.4(typescript@5.9.3)':
-    dependencies:
-      debug: 4.4.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript/vfs@1.6.4(typescript@6.0.3)':
     dependencies:
       debug: 4.4.3
@@ -23351,26 +23314,12 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@1.6.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(react@19.2.3)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vue@3.5.26(typescript@5.9.3))':
-    optionalDependencies:
-      '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
-      react: 19.2.3
-      svelte: 5.56.9(@typescript-eslint/types@8.50.1)
-      vue: 3.5.26(typescript@5.9.3)
-
   '@vercel/analytics@1.6.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(react@19.2.3)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vue@3.5.26(typescript@6.0.3))':
     optionalDependencies:
       '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
       react: 19.2.3
       svelte: 5.56.9(@typescript-eslint/types@8.50.1)
       vue: 3.5.26(typescript@6.0.3)
-
-  '@vercel/analytics@2.0.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(react@19.2.3)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vue@3.5.26(typescript@5.9.3))':
-    optionalDependencies:
-      '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
-      react: 19.2.3
-      svelte: 5.56.9(@typescript-eslint/types@8.50.1)
-      vue: 3.5.26(typescript@5.9.3)
 
   '@vercel/analytics@2.0.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(react@19.2.3)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vue@3.5.26(typescript@6.0.3))':
     optionalDependencies:
@@ -24361,114 +24310,6 @@ snapshots:
       '@tailwindcss/typography': 0.5.20(tailwindcss@4.2.2)
       '@tailwindcss/vite': 4.1.18(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
       '@vercel/analytics': 2.0.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(react@19.2.3)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vue@3.5.26(typescript@6.0.3))
-      ai: 5.0.212(zod@3.25.76)
-      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.4)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.958.0)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(ioredis@5.10.1)(jiti@2.6.1)(rollup@4.54.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)
-      babel-plugin-react-compiler: 1.0.0
-      citty: 0.1.6
-      consola: 3.4.2
-      dompurify: 3.4.12
-      epub-gen-memory: 1.1.2(encoding@0.1.13)
-      github-slugger: 2.0.0
-      gray-matter: 4.0.3
-      jiti: 2.6.1
-      js-yaml: 4.1.1
-      katex: 0.17.0
-      marked: 18.0.6
-      mermaid: 11.16.0
-      node-html-parser: 9.0.0
-      pagefind: 1.5.2
-      pathe: 2.0.3
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      satteri: 0.9.5
-      shiki: 4.3.1
-      simple-icons: 13.21.0
-      tailwindcss: 4.2.2
-      takumi-js: 2.4.0(csstype@3.2.3)(preact@10.28.1)(react@19.2.3)
-      tinyglobby: 0.2.17
-      twoslash: 0.3.9(typescript@6.0.3)
-      typescript: 6.0.3
-      undici: 8.7.0
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@astrojs/markdown-remark'
-      - '@aws-sdk/credential-provider-web-identity'
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@cfworker/json-schema'
-      - '@deno/kv'
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@remix-run/react'
-      - '@shikijs/themes'
-      - '@sveltejs/kit'
-      - '@types/node'
-      - '@types/react'
-      - '@types/react-dom'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - aws4fetch
-      - csstype
-      - db0
-      - encoding
-      - esbuild
-      - idb-keyval
-      - ioredis
-      - less
-      - next
-      - nuxt
-      - preact
-      - prettier
-      - prettier-plugin-astro
-      - rollup
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - svelte
-      - terser
-      - tsx
-      - uploadthing
-      - vite
-      - vue
-      - vue-router
-      - ws
-      - yaml
-
-  blume@1.2.0(f342977323bd7a6c7016cdf6ded9eb09):
-    dependencies:
-      '@astrojs/check': 0.9.9(prettier@3.8.2)(typescript@6.0.3)
-      '@astrojs/markdown-satteri': 0.3.4
-      '@astrojs/mdx': 7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.4)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.958.0)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(ioredis@5.10.1)(jiti@2.6.1)(rollup@4.54.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
-      '@astrojs/node': 11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.4)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.958.0)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(ioredis@5.10.1)(jiti@2.6.1)(rollup@4.54.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
-      '@astrojs/react': 6.0.1(@types/node@24.10.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(esbuild@0.28.1)(jiti@2.6.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)
-      '@astrojs/vercel': 11.0.3(@aws-sdk/credential-provider-web-identity@3.958.0)(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.4)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.958.0)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(ioredis@5.10.1)(jiti@2.6.1)(rollup@4.54.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))(encoding@0.1.13)(react@19.2.3)(rollup@4.54.0)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vue@3.5.26(typescript@5.9.3))(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@clack/prompts': 1.7.0
-      '@iconify-json/lucide': 1.2.117
-      '@iconify/types': 2.0.0
-      '@iconify/utils': 3.1.4
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
-      '@orama/orama': 3.1.18
-      '@pierre/diffs': 1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@scalar/astro': 0.4.9(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.4)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.958.0)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(ioredis@5.10.1)(jiti@2.6.1)(rollup@4.54.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
-      '@scalar/openapi-parser': 0.28.8
-      '@scalar/openapi-types': 0.9.1
-      '@shikijs/transformers': 4.3.1
-      '@shikijs/twoslash': 4.3.1(typescript@6.0.3)
-      '@tailwindcss/typography': 0.5.20(tailwindcss@4.2.2)
-      '@tailwindcss/vite': 4.1.18(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0))
-      '@vercel/analytics': 2.0.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vite@8.1.4(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)))(react@19.2.3)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(vue@3.5.26(typescript@5.9.3))
       ai: 5.0.212(zod@3.25.76)
       astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.4)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.958.0)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(ioredis@5.10.1)(jiti@2.6.1)(rollup@4.54.0)(sass@1.97.1)(tsx@4.21.0)(yaml@2.9.0)
       babel-plugin-react-compiler: 1.0.0
@@ -29543,13 +29384,13 @@ snapshots:
       postcss: 8.5.6
       ts-node: 10.9.2(@types/node@20.19.27)(typescript@5.9.3)
 
-  postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@6.0.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.2
     optionalDependencies:
       postcss: 8.5.19
-      ts-node: 10.9.2(@types/node@24.10.4)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@24.10.4)(typescript@6.0.3)
     optional: true
 
   postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)):
@@ -31027,7 +30868,7 @@ snapshots:
       svelte: 5.56.9(@typescript-eslint/types@8.50.1)
       tslib: 2.8.1
 
-  svelte-preprocess@5.1.4(@babel/core@7.29.0)(postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.9.3)))(postcss@8.5.19)(sass@1.97.1)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(typescript@5.9.3):
+  svelte-preprocess@5.1.4(@babel/core@7.29.0)(postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@6.0.3)))(postcss@8.5.19)(sass@1.97.1)(svelte@5.56.9(@typescript-eslint/types@8.50.1))(typescript@5.9.3):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
@@ -31038,7 +30879,7 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
       postcss: 8.5.19
-      postcss-load-config: 4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.9.3))
+      postcss-load-config: 4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.10.4)(typescript@6.0.3))
       sass: 1.97.1
       typescript: 5.9.3
 
@@ -31113,6 +30954,13 @@ snapshots:
       scule: 1.3.0
       svelte: 5.56.9(@typescript-eslint/types@8.50.1)
       typescript: 5.9.3
+
+  svelte2tsx@0.7.46(svelte@5.56.9(@typescript-eslint/types@8.50.1))(typescript@6.0.3):
+    dependencies:
+      dedent-js: 1.0.1
+      scule: 1.3.0
+      svelte: 5.56.9(@typescript-eslint/types@8.50.1)
+      typescript: 6.0.3
 
   svelte@5.56.9(@typescript-eslint/types@8.50.1):
     dependencies:
@@ -31482,6 +31330,25 @@ snapshots:
       yn: 3.1.1
     optional: true
 
+  ts-node@10.9.2(@types/node@24.10.4)(typescript@6.0.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 24.10.4
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 6.0.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
   tsc-alias@1.8.16:
     dependencies:
       chokidar: 3.6.0
@@ -31533,14 +31400,6 @@ snapshots:
   tw-animate-css@1.4.0: {}
 
   twoslash-protocol@0.3.9: {}
-
-  twoslash@0.3.9(typescript@5.9.3):
-    dependencies:
-      '@typescript/vfs': 1.6.4(typescript@5.9.3)
-      twoslash-protocol: 0.3.9
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
 
   twoslash@0.3.9(typescript@6.0.3):
     dependencies:
@@ -31610,10 +31469,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript-svelte-plugin@0.3.50(svelte@5.56.9(@typescript-eslint/types@8.50.1))(typescript@5.9.3):
+  typescript-svelte-plugin@0.3.50(svelte@5.56.9(@typescript-eslint/types@8.50.1))(typescript@6.0.3):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-      svelte2tsx: 0.7.46(svelte@5.56.9(@typescript-eslint/types@8.50.1))(typescript@5.9.3)
+      svelte2tsx: 0.7.46(svelte@5.56.9(@typescript-eslint/types@8.50.1))(typescript@6.0.3)
     transitivePeerDependencies:
       - svelte
       - typescript


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds a first pass of stable Playwright hooks so PR demos and future e2e tests can target locale-independent selectors without annotating every UI control.

**`@cio/ui`**
- Optional `testId` prop on `InputField`, `TextareaField`, `CheckboxField`, and `Button`
- Fixed ids on `Page.SettingsActions` (`page-settings-actions`, `page-settings-save`, `page-settings-discard`)

**Dashboard shell**
- Login: `auth-login-email`, `auth-login-password`, `auth-login-submit`
- Org sidebar: `org-nav-{path}` via `orgNavTestId()` in `org-navigation.ts`
- Header/footer: `app-sidebar-trigger`, `app-notifications-trigger`, `app-user-menu-trigger`, `org-switcher-trigger`

**E2E scaffolding**
- `e2e/README.md` registry and locator priority
- `e2e/helpers/login.ts`, `e2e/helpers/nav.ts`
- `e2e/playwright.config.ts`, example spec, root `demo:playwright` script

**Docs**
- AGENTS.md § E2E test hooks
- `packages/ui/README.md` § Test hooks

Independent of the PR demo workflow PR (#1024) — merges cleanly into `main` on its own.

## Demo

https://shots.classai.work/zmfW4DPq

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How should this be tested?

- `pnpm --filter @cio/dashboard build` passes
- Inspect login page / org sidebar in devtools for `data-testid` attributes listed in `e2e/README.md`
- With preview + API running: `pnpm exec playwright install chromium && DEMO_BASE_URL=http://localhost:4173 pnpm demo:playwright`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Ran dashboard build
- [x] If this PR changes `pnpm-lock.yaml`: call that out in the PR description (adds `@playwright/test` dev dep)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a060c4-6561-713c-83d2-6aeabce8b10d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a060c4-6561-713c-83d2-6aeabce8b10d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds stable Playwright selectors across shared UI controls and the dashboard shell, plus Playwright configuration, helpers, documentation, and an example login test.
- Extends shared fields and buttons with optional `testId` support.
- Adds fixed hooks for login, organization navigation, shell menus, and settings actions.
- Introduces root-level Playwright tooling and reusable login/navigation helpers.

<h3>Confidence Score: 4/5</h3>

The duplicate Settings navigation hook must be made unique before merging so Playwright can target that navigation surface reliably.

The Settings parent and profile child both render as `org-nav-settings`, causing strict Playwright locators to fail whenever the expanded group exposes both links.

**Files Needing Attention:** apps/dashboard/src/lib/features/ui/navigation/org-navigation.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/ui/navigation/org-navigation.ts | Adds path-derived navigation hooks, but the Settings parent and profile child receive the same ID. |
| apps/dashboard/src/lib/features/ui/sidebar/org-sidebar/nav-main.svelte | Exposes navigation IDs on links and uses them as keyed-list identities. |
| packages/ui/src/base/button/button.svelte | Adds an optional `testId` prop and forwards it to the rendered button or anchor. |
| e2e/playwright.config.ts | Configures serial Chromium demo tests, artifact capture, retries, and root-relative test discovery. |
| e2e/helpers/login.ts | Adds a reusable seeded-admin login helper and local tenant catalog navigation. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Spec[Playwright spec] --> Helpers[E2E helpers]
  Helpers --> Hooks[data-testid hooks]
  Hooks --> Login[Login controls]
  Hooks --> Nav[Organization navigation]
  Hooks --> Shell[Dashboard shell]
  Hooks --> Settings[Settings actions]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dashboard/src/lib/features/ui/navigation/org-navigation.ts`, line 227-231 ([link](https://github.com/classroomio/classroomio/blob/b749d5802770d49a54960beaa9836558066c4a93/apps/dashboard/src/lib/features/ui/navigation/org-navigation.ts#L227-L231)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Duplicate settings navigation hook**

   When the Settings group is expanded, its parent and profile child both derive `org-nav-settings` from `/settings`, causing Playwright's strict `getByTestId('org-nav-settings')` locator to fail because it resolves to two links.

   **Knowledge Base Used:** [Administration dashboard](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/administration-dashboard.md)
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(e2e): add Playwright test hooks and..."](https://github.com/classroomio/classroomio/commit/b749d5802770d49a54960beaa9836558066c4a93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59399575)</sub>

<!-- /greptile_comment -->