### PR TITLE
docs: document transaction boundaries for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -619,10 +619,20 @@ In every `catch` block, log the original error with the function name so logs ar
 ```
 
 ### Transactions
+
+When a service operation performs multiple related writes, establish one transaction at the service orchestration boundary and keep every database operation in that transaction. Do not commit a primary row update before a related write such as tags, memberships, or assignments can fail.
+
+- Routes must delegate transaction ownership to services; routes should not perform direct database transactions.
+- Query helpers that participate in composed operations must accept an optional `DbOrTxClient` and pass it to every read and write in the operation.
+- A query helper may open its own transaction only when no client is supplied. When a transaction client is supplied, use it directly and never open a nested transaction.
+- Validate all related identifiers and authorization requirements within the same transaction boundary before committing any writes.
+- Add a database-backed integration test for rollback-sensitive flows where possible. At minimum, test that a failure in a later operation cannot leave an earlier operation persisted.
+- Defer cache invalidation, notifications, and other non-transactional side effects until after the transaction commits.
+
 ```typescript
 const result = await db.transaction(async (tx) => {
-  const org = await createOrganization({ name, siteName });
-  const member = await createOrganizationMember({ orgId: org.id, userId });
+  const org = await createOrganization({ name, siteName }, tx);
+  const member = await createOrganizationMember({ orgId: org.id, userId }, tx);
   return { org, member };
 });
 ```


### PR DESCRIPTION
## What does this PR do?

Documents the repository's transaction-boundary paradigm in `AGENTS.md` so future changes keep related database writes atomic. The guidance covers service-owned transactions, transaction-client propagation through query helpers, avoiding nested transactions, validating before writes, rollback-focused tests, and deferring non-transactional side effects until after commit.

No issue number was provided.

## Demo

Not applicable.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [x] This change requires a documentation update

## How should this be tested?

- Review the new `### Transactions` guidance in `AGENTS.md`.
- `export PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH" && pnpm format:check`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the ClassroomIO Docs if changes were necessary


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds repository guidance for keeping related database writes atomic.
- Assigns transaction ownership to service orchestration boundaries.
- Documents transaction-client propagation, validation, rollback testing, and post-commit side effects.
- Updates the organization-creation example to pass the transaction client to both query helpers.

<h3>Confidence Score: 4/5</h3>

The documentation-only PR is safe to merge, with a non-blocking conflicting transaction example elsewhere in the repository.

The new guidance matches the actual database helper signatures and service transaction pattern, but ARCHITECHTURE.md still demonstrates the old non-atomic usage.

**Files Needing Attention:** AGENTS.md and ARCHITECHTURE.md

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds accurate transaction-boundary guidance and a correct client-propagation example, but now conflicts with the corresponding example in ARCHITECHTURE.md. |

<sub>Reviews (1): Last reviewed commit: ["docs: document transaction boundaries fo..."](https://github.com/classroomio/classroomio/commit/0bfe2ad7a3e497ac17fa96d1cb1be63daa1f8674) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59399453)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded transaction-handling guidance for services and query helpers.
  * Clarified validation, rollback testing, and post-commit handling of side effects.
  * Updated the example to demonstrate passing a transaction client through related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->