### PR TITLE
fix(dashboard): hide UserJot in widget preview

### DIFF
--- a/apps/dashboard/src/lib/utils/services/userjot/index.ts
+++ b/apps/dashboard/src/lib/utils/services/userjot/index.ts
@@ -11,6 +11,7 @@ function isWidgetAllowed(): boolean {
   if (dev) return false;
   if (PUBLIC_IS_SELFHOSTED === 'true') return false;
   if (get(globalStore).isOrgSite) return false;
+  if (window.location.pathname === '/widget-preview') return false;
 
   return true;
 }


### PR DESCRIPTION
## What does this PR do?

Prevents the UserJot SDK and launcher from loading inside the `/widget-preview` iframe while preserving the launcher on normal cloud dashboard pages.

The preview route loads the root dashboard layout inside an iframe, so it previously initialized a second UserJot launcher within the preview. The shared UserJot eligibility guard now excludes that route, covering initialization and all later identify/open/logout calls.

## Demo

Pending: record the widget editor showing one UserJot launcher on the dashboard and none inside the preview.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Open a widget editor in the cloud dashboard and confirm the dashboard UserJot launcher remains visible.
- Inspect the embedded widget preview and confirm no UserJot launcher or SDK is loaded inside the iframe.
- Confirm customer org sites and self-hosted deployments continue not to initialize UserJot.

## Verification

- `pnpm --filter @cio/dashboard^... build`
- `pnpm --filter @cio/dashboard build`
- `pnpm format:check`

## Checklist

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Ran the required dashboard dependency and production builds
- [x] Ran the changed-file formatting checks
- [x] My changes don't cause any responsiveness issues
- [x] No migration, lockfile, workflow, publish configuration, or documentation changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the UserJot widget from initializing on the widget preview page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents UserJot initialization and subsequent SDK operations inside the widget-preview iframe while preserving its behavior elsewhere.
- Adds the canonical `/widget-preview` route to the shared UserJot eligibility guard.
- Applies the exclusion consistently to initialization, identification, opening, and logout operations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The preview iframe uses the exact canonical path excluded by the shared guard, and every current guard caller executes in a browser-only lifecycle or event path.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/utils/services/userjot/index.ts | Adds a browser-path eligibility check that correctly suppresses UserJot on the canonical widget-preview route without introducing a reachable failure. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): hide UserJot in widget p..."](https://github.com/classroomio/classroomio/commit/22509132bfef224ea398bbd99e90116caaf84911) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59477159)</sub>

<!-- /greptile_comment -->