### PR TITLE
feat: add frontend-only mode for Railway preview environments

### DIFF
--- a/.github/scripts/railway-preview-name.sh
+++ b/.github/scripts/railway-preview-name.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Computes the shared pr-<slug>-<hash> base name for a Railway preview. Sourced by both
+# railway-preview.yml and railway-preview-teardown.yml so their name derivation can never
+# drift out of sync with each other.
+
+# repo: owner/repo, case-insensitive, may have a trailing ".git" (checkout tolerates both,
+# so they can reach here — a full URL can't, checkout already fails on that first).
+# branch: case-sensitive, used as-is for the hash (only the display slug is lowercased).
+preview_base_name() {
+  local repo="$1"
+  local branch="$2"
+  local repo_norm slug hash
+
+  repo_norm=$(echo "$repo" | tr '[:upper:]' '[:lower:]' | sed -e 's/\.git$//' -e 's#/$##')
+  slug=$(echo "$branch" | tr '[:upper:]/_.' '[:lower:]---' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g; s/^-//; s/-$//' | cut -c1-18 | sed 's/-$//')
+  hash=$(echo -n "${repo_norm}#${branch}" | sha256sum | cut -c1-8)
+
+  echo "pr-${slug}-${hash}"
+}

--- a/.github/workflows/railway-preview-teardown.yml
+++ b/.github/workflows/railway-preview-teardown.yml
@@ -5,7 +5,7 @@ name: Railway Preview Teardown
 # (Native Railway PR environments clean themselves up; this covers the pr-<branch>
 # envs/services made by the manual workflow.) This workflow has no record of which `mode`
 # created a given branch's preview (workflow_dispatch inputs aren't queryable from here),
-# so it attempts every possible deletion — a full-deploy environment, a frontend dashboard
+# so it attempts every possible deletion — a full_deploy environment, a frontend dashboard
 # service, and a frontend_backend api service — tolerating "not found" for whichever
 # wasn't created.
 #
@@ -43,7 +43,7 @@ jobs:
 
       - name: Delete the preview environment and/or preview service(s)
         # Mirror the name derivation in railway-preview.yml so the names match (the
-        # full-deploy env name and the frontend/frontend_backend service names all share
+        # full_deploy env name and the frontend/frontend_backend service names all share
         # the same slug+hash).
         # HEAD_REF is bound via env (not interpolated into the script) so a malicious
         # branch name can never be executed as shell — Actions expands ${{ }} as text

--- a/.github/workflows/railway-preview-teardown.yml
+++ b/.github/workflows/railway-preview-teardown.yml
@@ -6,15 +6,21 @@ name: Railway Preview Teardown
 # envs/services made by the manual workflow.) This workflow has no record of which `mode`
 # created a given branch's preview (workflow_dispatch inputs aren't queryable from here),
 # so it attempts every possible deletion — a full_deploy environment, a frontend dashboard
-# service, and a frontend_backend api service — tolerating "not found" for whichever
+# service, and a frontend_backend dashboard+api pair — tolerating "not found" for whichever
 # wasn't created.
 #
 # Uses the same RAILWAY_API_TOKEN + RAILWAY_PROJECT_ID secrets as the deploy workflow.
-# Note: secrets are unavailable to PRs from forks, so this only tears down previews for
-# same-repo branches (which is where manual previews come from anyway).
-
+#
+# Trigger is `pull_request_target`, not `pull_request`: GitHub withholds repo secrets from
+# `pull_request`-triggered runs on fork PRs, which would otherwise mean a preview created
+# against a fork branch (railway-preview.yml's `repo` input explicitly supports this) never
+# gets torn down automatically. `pull_request_target` gets secrets even for fork PRs, and
+# the usual danger of that trigger — a fork's own workflow content or checked-out code
+# running with those secrets — doesn't apply here: this job has no `actions/checkout` step
+# and never executes any repository code, only reads `github.event.pull_request.head.ref`
+# and calls Railway's API.
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 concurrency:
@@ -24,7 +30,6 @@ concurrency:
 jobs:
   teardown:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
     env:
       RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
       RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
@@ -42,9 +47,11 @@ jobs:
           railway link --project "$RAILWAY_PROJECT_ID" --workspace "$RAILWAY_WORKSPACE" --environment "$BASE_ENV"
 
       - name: Delete the preview environment and/or preview service(s)
-        # Mirror the name derivation in railway-preview.yml so the names match (the
-        # full_deploy env name and the frontend/frontend_backend service names all share
-        # the same slug+hash).
+        # Mirror the name derivation in railway-preview.yml so the names match: the
+        # full_deploy env name and the frontend/frontend_backend service names all share the
+        # same slug+hash, but frontend_backend's pair carries a "-fb-" infix so it never
+        # collides with frontend's dashboard for the same branch (see railway-preview.yml's
+        # "Derive a safe environment name" step for why).
         # HEAD_REF is bound via env (not interpolated into the script) so a malicious
         # branch name can never be executed as shell — Actions expands ${{ }} as text
         # BEFORE bash parses it, so a raw `${{ ...head.ref }}` here is a script-injection hole.
@@ -55,7 +62,8 @@ jobs:
           hash=$(echo -n "$HEAD_REF" | sha256sum | cut -c1-8)
           env_name="pr-${slug}-${hash}"
           dashboard_service_name="${env_name}-dashboard"
-          backend_service_name="${env_name}-api"
+          fb_dashboard_service_name="${env_name}-fb-dashboard"
+          fb_backend_service_name="${env_name}-fb-api"
 
           echo "Attempting to delete environment: ${env_name}"
           if ! output=$(railway environment delete "${env_name}" --yes 2>&1); then
@@ -69,11 +77,13 @@ jobs:
             echo "$output"
           fi
 
-          # Untrust the dashboard's exact origin from cio-api's TRUSTED_ORIGINS before
-          # deleting it (mirrors railway-preview.yml's "Destroy dashboard-only preview" —
-          # see that step for why this is exact-origin, not a wildcard). Read the domain
-          # while the service still exists; best-effort, since this workflow doesn't know
-          # whether a `frontend`-mode preview for this branch ever existed.
+          # Untrust the frontend-mode dashboard's exact origin from cio-api's
+          # TRUSTED_ORIGINS before deleting it (mirrors railway-preview.yml's "Destroy
+          # dashboard-only preview" — see that step for why this is exact-origin, not a
+          # wildcard, and why a failed untrust must block deletion rather than warn and
+          # continue). Only frontend mode ever touches TRUSTED_ORIGINS — frontend_backend's
+          # pair trusts each other directly via DASHBOARD_ORIGIN, so its services need no
+          # untrust step here.
           dashboard_url=$(railway variables --service "${dashboard_service_name}" --kv 2>/dev/null | grep '^RAILWAY_PUBLIC_DOMAIN=' | cut -d= -f2- || true)
           if [ -n "$dashboard_url" ]; then
             origin_to_remove="https://${dashboard_url}"
@@ -82,8 +92,11 @@ jobs:
             if echo "$current_trusted" | tr ',' '\n' | grep -qxF "$origin_to_remove"; then
               new_trusted=$(echo "$current_trusted" | tr ',' '\n' | grep -vxF "$origin_to_remove" | tr '\n' ',' | sed 's/,$//')
               if ! output=$(railway variables --service cio-api --set "TRUSTED_ORIGINS=${new_trusted}" 2>&1); then
-                echo "::warning::Failed to untrust ${origin_to_remove} from cio-api's TRUSTED_ORIGINS — continuing to delete the service anyway. $output"
+                echo "$output"
+                echo "::error::Failed to untrust ${origin_to_remove} from cio-api's TRUSTED_ORIGINS — refusing to delete ${dashboard_service_name} while its origin may still be trusted. Fix cio-api's reachability and re-run teardown (or action=destroy)."
+                exit 1
               else
+                echo "$output"
                 echo "Untrusted ${origin_to_remove} from cio-api."
               fi
             fi
@@ -101,11 +114,23 @@ jobs:
             echo "$output"
           fi
 
-          echo "Attempting to delete backend preview service: ${backend_service_name}"
-          if ! output=$(railway service delete --service "${backend_service_name}" --yes 2>&1); then
+          echo "Attempting to delete frontend_backend dashboard service: ${fb_dashboard_service_name}"
+          if ! output=$(railway service delete --service "${fb_dashboard_service_name}" --yes 2>&1); then
             echo "$output"
             if echo "$output" | grep -qi "not found"; then
-              echo "No matching backend preview service (or already deleted) — nothing to do."
+              echo "No matching frontend_backend dashboard service (or already deleted) — nothing to do."
+            else
+              exit 1
+            fi
+          else
+            echo "$output"
+          fi
+
+          echo "Attempting to delete frontend_backend api service: ${fb_backend_service_name}"
+          if ! output=$(railway service delete --service "${fb_backend_service_name}" --yes 2>&1); then
+            echo "$output"
+            if echo "$output" | grep -qi "not found"; then
+              echo "No matching frontend_backend api service (or already deleted) — nothing to do."
             else
               exit 1
             fi

--- a/.github/workflows/railway-preview-teardown.yml
+++ b/.github/workflows/railway-preview-teardown.yml
@@ -1,30 +1,19 @@
 name: Railway Preview Teardown
 
-# Auto-delete a preview environment (or preview service(s)) created by railway-preview.yml
-# when its PR closes, so manually-spun previews don't linger and accrue Railway cost.
-# (Native Railway PR environments clean themselves up; this covers the pr-<branch>
-# envs/services made by the manual workflow.) This workflow has no record of which `mode`
-# created a given branch's preview (workflow_dispatch inputs aren't queryable from here),
-# so it attempts every possible deletion — a full_deploy environment, a frontend dashboard
-# service, and a frontend_backend dashboard+api pair — tolerating "not found" for whichever
-# wasn't created.
+# Auto-deletes whatever railway-preview.yml created for a branch once its PR closes. Doesn't
+# know which `mode` was used, so it tries all three resource shapes and tolerates "not found".
 #
-# Uses the same RAILWAY_API_TOKEN + RAILWAY_PROJECT_ID secrets as the deploy workflow.
-#
-# Trigger is `pull_request_target`, not `pull_request`: GitHub withholds repo secrets from
-# `pull_request`-triggered runs on fork PRs, which would otherwise mean a preview created
-# against a fork branch (railway-preview.yml's `repo` input explicitly supports this) never
-# gets torn down automatically. `pull_request_target` gets secrets even for fork PRs, and
-# the usual danger of that trigger — a fork's own workflow content or checked-out code
-# running with those secrets — doesn't apply here: this job has no `actions/checkout` step
-# and never executes any repository code, only reads `github.event.pull_request.head.ref`
-# and calls Railway's API.
+# Trigger is pull_request_target (not pull_request) so fork PRs get torn down too — safe
+# here since this workflow never checks out or runs any repo code, only calls Railway's API.
 on:
   pull_request_target:
     types: [closed]
 
+# Shares a group with railway-preview.yml's frontend-mode runs — both read-modify-write
+# staging cio-api's TRUSTED_ORIGINS, so they must serialize with each other too, not just
+# with themselves.
 concurrency:
-  group: railway-preview-${{ github.event.pull_request.head.ref }}
+  group: railway-preview-frontend-trusted-origins
   cancel-in-progress: false
 
 jobs:
@@ -47,93 +36,68 @@ jobs:
           railway link --project "$RAILWAY_PROJECT_ID" --workspace "$RAILWAY_WORKSPACE" --environment "$BASE_ENV"
 
       - name: Delete the preview environment and/or preview service(s)
-        # Mirror the name derivation in railway-preview.yml so the names match: the
-        # full_deploy env name and the frontend/frontend_backend service names all share the
-        # same slug+hash, but frontend_backend's pair carries a "-fb-" infix so it never
-        # collides with frontend's dashboard for the same branch (see railway-preview.yml's
-        # "Derive a safe environment name" step for why).
-        # HEAD_REF is bound via env (not interpolated into the script) so a malicious
-        # branch name can never be executed as shell — Actions expands ${{ }} as text
-        # BEFORE bash parses it, so a raw `${{ ...head.ref }}` here is a script-injection hole.
+        # Name derivation must match railway-preview.yml exactly (repo+branch hash, "-fb-"
+        # infix for frontend_backend) or teardown won't find what deploy created.
+        # HEAD_REF/HEAD_REPO bound via env, not interpolated — avoids script injection.
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           slug=$(echo "$HEAD_REF" | tr '[:upper:]/_.' '[:lower:]---' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g; s/^-//; s/-$//' | cut -c1-18 | sed 's/-$//')
-          hash=$(echo -n "$HEAD_REF" | sha256sum | cut -c1-8)
+          hash=$(echo -n "${HEAD_REPO}#${HEAD_REF}" | sha256sum | cut -c1-8)
           env_name="pr-${slug}-${hash}"
           dashboard_service_name="${env_name}-dashboard"
           fb_dashboard_service_name="${env_name}-fb-dashboard"
           fb_backend_service_name="${env_name}-fb-api"
+          failed=false
 
-          echo "Attempting to delete environment: ${env_name}"
+          delete_service() {
+            local service="$1"
+            if ! output=$(railway service delete --service "$service" --yes 2>&1); then
+              echo "$output"
+              if echo "$output" | grep -qi "not found"; then
+                echo "No matching $service (or already deleted) — nothing to do."
+              else
+                failed=true
+              fi
+            else
+              echo "$output"
+              echo "Deleted $service."
+            fi
+          }
+
           if ! output=$(railway environment delete "${env_name}" --yes 2>&1); then
             echo "$output"
-            if echo "$output" | grep -qi "not found"; then
-              echo "No matching preview environment (or already deleted) — nothing to do."
-            else
-              exit 1
-            fi
+            echo "$output" | grep -qi "not found" || failed=true
           else
             echo "$output"
+            echo "Deleted environment ${env_name}."
           fi
 
-          # Untrust the frontend-mode dashboard's exact origin from cio-api's
-          # TRUSTED_ORIGINS before deleting it (mirrors railway-preview.yml's "Destroy
-          # dashboard-only preview" — see that step for why this is exact-origin, not a
-          # wildcard, and why a failed untrust must block deletion rather than warn and
-          # continue). Only frontend mode ever touches TRUSTED_ORIGINS — frontend_backend's
-          # pair trusts each other directly via DASHBOARD_ORIGIN, so its services need no
-          # untrust step here.
+          # Only frontend mode's dashboard is ever trusted on cio-api; a failed untrust
+          # blocks just this one delete (fail-closed), not the others below.
+          untrust_ok=true
           dashboard_url=$(railway variables --service "${dashboard_service_name}" --kv 2>/dev/null | grep '^RAILWAY_PUBLIC_DOMAIN=' | cut -d= -f2- || true)
           if [ -n "$dashboard_url" ]; then
             origin_to_remove="https://${dashboard_url}"
-            api_vars=$(railway variables --service cio-api --kv 2>/dev/null || true)
-            current_trusted=$(echo "$api_vars" | grep '^TRUSTED_ORIGINS=' | cut -d= -f2- || true)
+            current_trusted=$(railway variables --service cio-api --kv 2>/dev/null | grep '^TRUSTED_ORIGINS=' | cut -d= -f2- || true)
             if echo "$current_trusted" | tr ',' '\n' | grep -qxF "$origin_to_remove"; then
               new_trusted=$(echo "$current_trusted" | tr ',' '\n' | grep -vxF "$origin_to_remove" | tr '\n' ',' | sed 's/,$//')
               if ! output=$(railway variables --service cio-api --set "TRUSTED_ORIGINS=${new_trusted}" 2>&1); then
                 echo "$output"
-                echo "::error::Failed to untrust ${origin_to_remove} from cio-api's TRUSTED_ORIGINS — refusing to delete ${dashboard_service_name} while its origin may still be trusted. Fix cio-api's reachability and re-run teardown (or action=destroy)."
-                exit 1
+                echo "::error::Failed to untrust ${origin_to_remove} — refusing to delete ${dashboard_service_name} while its origin may still be trusted."
+                untrust_ok=false
+                failed=true
               else
                 echo "$output"
-                echo "Untrusted ${origin_to_remove} from cio-api."
+                echo "Untrusted ${origin_to_remove}."
               fi
             fi
           fi
+          [ "$untrust_ok" = true ] && delete_service "$dashboard_service_name"
 
-          echo "Attempting to delete dashboard preview service: ${dashboard_service_name}"
-          if ! output=$(railway service delete --service "${dashboard_service_name}" --yes 2>&1); then
-            echo "$output"
-            if echo "$output" | grep -qi "not found"; then
-              echo "No matching dashboard preview service (or already deleted) — nothing to do."
-            else
-              exit 1
-            fi
-          else
-            echo "$output"
-          fi
+          delete_service "$fb_dashboard_service_name"
+          delete_service "$fb_backend_service_name"
 
-          echo "Attempting to delete frontend_backend dashboard service: ${fb_dashboard_service_name}"
-          if ! output=$(railway service delete --service "${fb_dashboard_service_name}" --yes 2>&1); then
-            echo "$output"
-            if echo "$output" | grep -qi "not found"; then
-              echo "No matching frontend_backend dashboard service (or already deleted) — nothing to do."
-            else
-              exit 1
-            fi
-          else
-            echo "$output"
-          fi
-
-          echo "Attempting to delete frontend_backend api service: ${fb_backend_service_name}"
-          if ! output=$(railway service delete --service "${fb_backend_service_name}" --yes 2>&1); then
-            echo "$output"
-            if echo "$output" | grep -qi "not found"; then
-              echo "No matching frontend_backend api service (or already deleted) — nothing to do."
-            else
-              exit 1
-            fi
-          else
-            echo "$output"
-          fi
+          [ "$failed" = true ] && exit 1
+          exit 0

--- a/.github/workflows/railway-preview-teardown.yml
+++ b/.github/workflows/railway-preview-teardown.yml
@@ -1,9 +1,12 @@
 name: Railway Preview Teardown
 
-# Auto-delete a preview environment created by railway-preview.yml when its PR closes,
-# so manually-spun previews don't linger and accrue Railway cost. (Native Railway PR
-# environments clean themselves up; this covers the pr-<branch> envs made by the manual
-# workflow.) Deletion is best-effort — if no matching env exists, the run is a no-op.
+# Auto-delete a preview environment (or dashboard-only preview service) created by
+# railway-preview.yml when its PR closes, so manually-spun previews don't linger and
+# accrue Railway cost. (Native Railway PR environments clean themselves up; this covers
+# the pr-<branch> envs/services made by the manual workflow.) This workflow has no record
+# of which `mode` created a given branch's preview (workflow_dispatch inputs aren't
+# queryable from here), so it attempts both possible deletions — a full-stack environment
+# and a frontend-only service — tolerating "not found" for whichever wasn't created.
 #
 # Uses the same RAILWAY_API_TOKEN + RAILWAY_PROJECT_ID secrets as the deploy workflow.
 # Note: secrets are unavailable to PRs from forks, so this only tears down previews for
@@ -37,8 +40,9 @@ jobs:
         run: |
           railway link --project "$RAILWAY_PROJECT_ID" --workspace "$RAILWAY_WORKSPACE" --environment "$BASE_ENV"
 
-      - name: Delete the preview environment
-        # Mirror the name derivation in railway-preview.yml so the env name matches.
+      - name: Delete the preview environment and/or dashboard-only service
+        # Mirror the name derivation in railway-preview.yml so the names match (both the
+        # full-stack env name and the frontend-only service name share the same slug+hash).
         # HEAD_REF is bound via env (not interpolated into the script) so a malicious
         # branch name can never be executed as shell — Actions expands ${{ }} as text
         # BEFORE bash parses it, so a raw `${{ ...head.ref }}` here is a script-injection hole.
@@ -48,11 +52,25 @@ jobs:
           slug=$(echo "$HEAD_REF" | tr '[:upper:]/_.' '[:lower:]---' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g; s/^-//; s/-$//' | cut -c1-18 | sed 's/-$//')
           hash=$(echo -n "$HEAD_REF" | sha256sum | cut -c1-8)
           env_name="pr-${slug}-${hash}"
+          service_name="${env_name}-dashboard"
+
           echo "Attempting to delete environment: ${env_name}"
           if ! output=$(railway environment delete "${env_name}" --yes 2>&1); then
             echo "$output"
             if echo "$output" | grep -qi "not found"; then
               echo "No matching preview environment (or already deleted) — nothing to do."
+            else
+              exit 1
+            fi
+          else
+            echo "$output"
+          fi
+
+          echo "Attempting to delete dashboard-only preview service: ${service_name}"
+          if ! output=$(railway service delete --service "${service_name}" --yes 2>&1); then
+            echo "$output"
+            if echo "$output" | grep -qi "not found"; then
+              echo "No matching dashboard-only preview service (or already deleted) — nothing to do."
             else
               exit 1
             fi

--- a/.github/workflows/railway-preview-teardown.yml
+++ b/.github/workflows/railway-preview-teardown.yml
@@ -4,17 +4,19 @@ name: Railway Preview Teardown
 # know which `mode` was used, so it tries all three resource shapes and tolerates "not found".
 #
 # Trigger is pull_request_target (not pull_request) so fork PRs get torn down too — safe
-# here since this workflow never checks out or runs any repo code, only calls Railway's API.
+# here because the checkout below never takes a ref, so for a pull_request_target event it
+# gets the base repo's own trusted default branch, never the fork's/PR's code.
 on:
   pull_request_target:
     types: [closed]
 
 # Shares a group with railway-preview.yml's frontend-mode runs — both read-modify-write
-# staging cio-api's TRUSTED_ORIGINS, so they must serialize with each other too, not just
-# with themselves.
+# staging cio-api's TRUSTED_ORIGINS. queue: max so a third concurrent run doesn't cancel
+# one still waiting (GitHub's default keeps only one pending run per group).
 concurrency:
   group: railway-preview-frontend-trusted-origins
   cancel-in-progress: false
+  queue: max
 
 jobs:
   teardown:
@@ -25,6 +27,11 @@ jobs:
       RAILWAY_WORKSPACE: ${{ vars.RAILWAY_WORKSPACE || 'cio projects' }}
       BASE_ENV: ${{ vars.RAILWAY_BASE_ENV || 'staging' }}
     steps:
+      - name: Checkout base repo
+        # No `ref:` — for pull_request_target this checks out the base repo's own default
+        # branch, never the fork's/PR's code. Only needed to get railway-preview-name.sh.
+        uses: actions/checkout@v4
+
       - name: Install Railway CLI
         run: npm install -g @railway/cli@5.30.1
 
@@ -36,16 +43,15 @@ jobs:
           railway link --project "$RAILWAY_PROJECT_ID" --workspace "$RAILWAY_WORKSPACE" --environment "$BASE_ENV"
 
       - name: Delete the preview environment and/or preview service(s)
-        # Name derivation must match railway-preview.yml exactly (repo+branch hash, "-fb-"
-        # infix for frontend_backend) or teardown won't find what deploy created.
+        # Naming logic lives in .github/scripts/railway-preview-name.sh, shared with
+        # railway-preview.yml, so the two can't drift out of sync with each other.
         # HEAD_REF/HEAD_REPO bound via env, not interpolated — avoids script injection.
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
-          slug=$(echo "$HEAD_REF" | tr '[:upper:]/_.' '[:lower:]---' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g; s/^-//; s/-$//' | cut -c1-18 | sed 's/-$//')
-          hash=$(echo -n "${HEAD_REPO}#${HEAD_REF}" | sha256sum | cut -c1-8)
-          env_name="pr-${slug}-${hash}"
+          source .github/scripts/railway-preview-name.sh
+          env_name=$(preview_base_name "$HEAD_REPO" "$HEAD_REF")
           dashboard_service_name="${env_name}-dashboard"
           fb_dashboard_service_name="${env_name}-fb-dashboard"
           fb_backend_service_name="${env_name}-fb-api"

--- a/.github/workflows/railway-preview-teardown.yml
+++ b/.github/workflows/railway-preview-teardown.yml
@@ -1,12 +1,13 @@
 name: Railway Preview Teardown
 
-# Auto-delete a preview environment (or dashboard-only preview service) created by
-# railway-preview.yml when its PR closes, so manually-spun previews don't linger and
-# accrue Railway cost. (Native Railway PR environments clean themselves up; this covers
-# the pr-<branch> envs/services made by the manual workflow.) This workflow has no record
-# of which `mode` created a given branch's preview (workflow_dispatch inputs aren't
-# queryable from here), so it attempts both possible deletions — a full-stack environment
-# and a frontend-only service — tolerating "not found" for whichever wasn't created.
+# Auto-delete a preview environment (or preview service(s)) created by railway-preview.yml
+# when its PR closes, so manually-spun previews don't linger and accrue Railway cost.
+# (Native Railway PR environments clean themselves up; this covers the pr-<branch>
+# envs/services made by the manual workflow.) This workflow has no record of which `mode`
+# created a given branch's preview (workflow_dispatch inputs aren't queryable from here),
+# so it attempts every possible deletion — a full-deploy environment, a frontend dashboard
+# service, and a frontend_backend api service — tolerating "not found" for whichever
+# wasn't created.
 #
 # Uses the same RAILWAY_API_TOKEN + RAILWAY_PROJECT_ID secrets as the deploy workflow.
 # Note: secrets are unavailable to PRs from forks, so this only tears down previews for
@@ -40,9 +41,10 @@ jobs:
         run: |
           railway link --project "$RAILWAY_PROJECT_ID" --workspace "$RAILWAY_WORKSPACE" --environment "$BASE_ENV"
 
-      - name: Delete the preview environment and/or dashboard-only service
-        # Mirror the name derivation in railway-preview.yml so the names match (both the
-        # full-stack env name and the frontend-only service name share the same slug+hash).
+      - name: Delete the preview environment and/or preview service(s)
+        # Mirror the name derivation in railway-preview.yml so the names match (the
+        # full-deploy env name and the frontend/frontend_backend service names all share
+        # the same slug+hash).
         # HEAD_REF is bound via env (not interpolated into the script) so a malicious
         # branch name can never be executed as shell — Actions expands ${{ }} as text
         # BEFORE bash parses it, so a raw `${{ ...head.ref }}` here is a script-injection hole.
@@ -52,7 +54,8 @@ jobs:
           slug=$(echo "$HEAD_REF" | tr '[:upper:]/_.' '[:lower:]---' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g; s/^-//; s/-$//' | cut -c1-18 | sed 's/-$//')
           hash=$(echo -n "$HEAD_REF" | sha256sum | cut -c1-8)
           env_name="pr-${slug}-${hash}"
-          service_name="${env_name}-dashboard"
+          dashboard_service_name="${env_name}-dashboard"
+          backend_service_name="${env_name}-api"
 
           echo "Attempting to delete environment: ${env_name}"
           if ! output=$(railway environment delete "${env_name}" --yes 2>&1); then
@@ -66,11 +69,23 @@ jobs:
             echo "$output"
           fi
 
-          echo "Attempting to delete dashboard-only preview service: ${service_name}"
-          if ! output=$(railway service delete --service "${service_name}" --yes 2>&1); then
+          echo "Attempting to delete dashboard preview service: ${dashboard_service_name}"
+          if ! output=$(railway service delete --service "${dashboard_service_name}" --yes 2>&1); then
             echo "$output"
             if echo "$output" | grep -qi "not found"; then
-              echo "No matching dashboard-only preview service (or already deleted) — nothing to do."
+              echo "No matching dashboard preview service (or already deleted) — nothing to do."
+            else
+              exit 1
+            fi
+          else
+            echo "$output"
+          fi
+
+          echo "Attempting to delete backend preview service: ${backend_service_name}"
+          if ! output=$(railway service delete --service "${backend_service_name}" --yes 2>&1); then
+            echo "$output"
+            if echo "$output" | grep -qi "not found"; then
+              echo "No matching backend preview service (or already deleted) — nothing to do."
             else
               exit 1
             fi

--- a/.github/workflows/railway-preview-teardown.yml
+++ b/.github/workflows/railway-preview-teardown.yml
@@ -69,6 +69,26 @@ jobs:
             echo "$output"
           fi
 
+          # Untrust the dashboard's exact origin from cio-api's TRUSTED_ORIGINS before
+          # deleting it (mirrors railway-preview.yml's "Destroy dashboard-only preview" —
+          # see that step for why this is exact-origin, not a wildcard). Read the domain
+          # while the service still exists; best-effort, since this workflow doesn't know
+          # whether a `frontend`-mode preview for this branch ever existed.
+          dashboard_url=$(railway variables --service "${dashboard_service_name}" --kv 2>/dev/null | grep '^RAILWAY_PUBLIC_DOMAIN=' | cut -d= -f2- || true)
+          if [ -n "$dashboard_url" ]; then
+            origin_to_remove="https://${dashboard_url}"
+            api_vars=$(railway variables --service cio-api --kv 2>/dev/null || true)
+            current_trusted=$(echo "$api_vars" | grep '^TRUSTED_ORIGINS=' | cut -d= -f2- || true)
+            if echo "$current_trusted" | tr ',' '\n' | grep -qxF "$origin_to_remove"; then
+              new_trusted=$(echo "$current_trusted" | tr ',' '\n' | grep -vxF "$origin_to_remove" | tr '\n' ',' | sed 's/,$//')
+              if ! output=$(railway variables --service cio-api --set "TRUSTED_ORIGINS=${new_trusted}" 2>&1); then
+                echo "::warning::Failed to untrust ${origin_to_remove} from cio-api's TRUSTED_ORIGINS — continuing to delete the service anyway. $output"
+              else
+                echo "Untrusted ${origin_to_remove} from cio-api."
+              fi
+            fi
+          fi
+
           echo "Attempting to delete dashboard preview service: ${dashboard_service_name}"
           if ! output=$(railway service delete --service "${dashboard_service_name}" --yes 2>&1); then
             echo "$output"

--- a/.github/workflows/railway-preview.yml
+++ b/.github/workflows/railway-preview.yml
@@ -70,12 +70,17 @@ on:
           - skillshare-test
           - none
 
-# frontend mode shares one global, non-cancelling group (also shared with
-# railway-preview-teardown.yml) since it read-modify-writes cio-api's TRUSTED_ORIGINS —
-# concurrent writers must queue, not race. Other modes stay isolated per branch+mode.
+# frontend mode shares one global group (also shared with railway-preview-teardown.yml)
+# since it read-modify-writes cio-api's TRUSTED_ORIGINS. Every mode queues rather than
+# cancels — queue: max requires cancel-in-progress: false, and using one flat policy for
+# all modes (instead of cancel-in-progress only for full_deploy/frontend_backend) is
+# simpler than splitting queue behavior per mode. Re-triggering a full_deploy/
+# frontend_backend run for the same branch now waits for the stale run instead of killing
+# it.
 concurrency:
   group: ${{ inputs.mode == 'frontend' && 'railway-preview-frontend-trusted-origins' || format('railway-preview-{0}-{1}', inputs.branch, inputs.mode) }}
-  cancel-in-progress: ${{ inputs.mode != 'frontend' }}
+  cancel-in-progress: false
+  queue: max
 
 env:
   RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
@@ -105,19 +110,16 @@ jobs:
 
       - name: Derive a safe environment name
         id: env
-        # BRANCH bound via env, not interpolated — avoids script injection. Slug is lossy
-        # (capped at 18 chars, under Railway's ~32-char limit) so the hash is what actually
-        # guarantees uniqueness. Hash covers repo+branch, not just branch — otherwise a
-        # fork could open a same-named branch and its PR closing would compute the same
-        # name as a real preview, letting teardown delete someone else's resources.
+        # BRANCH/REPO bound via env, not interpolated — avoids script injection. Naming
+        # logic itself lives in .github/scripts/railway-preview-name.sh, shared with
+        # railway-preview-teardown.yml, so the two can't drift out of sync with each other.
         env:
           BRANCH: ${{ inputs.branch }}
           REPO: ${{ inputs.repo != '' && inputs.repo || github.repository }}
           MODE: ${{ inputs.mode }}
         run: |
-          slug=$(echo "$BRANCH" | tr '[:upper:]/_.' '[:lower:]---' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g; s/^-//; s/-$//' | cut -c1-18 | sed 's/-$//')
-          hash=$(echo -n "${REPO}#${BRANCH}" | sha256sum | cut -c1-8)
-          name="pr-${slug}-${hash}"
+          source .github/scripts/railway-preview-name.sh
+          name=$(preview_base_name "$REPO" "$BRANCH")
           echo "name=${name}" >> "$GITHUB_OUTPUT"
           # frontend_backend gets its own "-fb-" names so it never collides with frontend
           # mode's dashboard for the same branch.
@@ -193,6 +195,8 @@ jobs:
           SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
           BACKEND_SERVICE_NAME: ${{ steps.env.outputs.backend_service_name }}
         run: |
+          failed=false
+
           delete_service() {
             local service="$1"
             if ! output=$(railway service delete --service "$service" --yes 2>&1); then
@@ -200,7 +204,7 @@ jobs:
               if echo "$output" | grep -qi "not found"; then
                 echo "No matching $service (or already deleted) — nothing to do."
               else
-                return 1
+                failed=true
               fi
             else
               echo "$output"
@@ -210,6 +214,9 @@ jobs:
           delete_service "$SERVICE_NAME"
           delete_service "$BACKEND_SERVICE_NAME"
           echo "Deleted services $SERVICE_NAME and $BACKEND_SERVICE_NAME." >> "$GITHUB_STEP_SUMMARY"
+
+          [ "$failed" = true ] && exit 1
+          exit 0
 
       # ---------------------------------------------------------------- deploy
       - name: Create preview environment (duplicate base)
@@ -336,11 +343,17 @@ jobs:
         env:
           SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
         run: |
-          DASHBOARD_URL=$(railway variables --service "$SERVICE_NAME" --kv | grep '^RAILWAY_PUBLIC_DOMAIN=' | cut -d= -f2-)
-          if [ -z "$DASHBOARD_URL" ]; then
-            echo "::error::$SERVICE_NAME has no public domain yet — 'railway domain' may have failed."
-            exit 1
-          fi
+          DASHBOARD_URL=""
+          for attempt in $(seq 1 10); do
+            DASHBOARD_URL=$(railway variables --service "$SERVICE_NAME" --kv 2>/dev/null | grep '^RAILWAY_PUBLIC_DOMAIN=' | cut -d= -f2- || true)
+            [ -n "$DASHBOARD_URL" ] && break
+            if [ "$attempt" -eq 10 ]; then
+              echo "::error::$SERVICE_NAME has no public domain after 10 attempts — 'railway domain' may have failed."
+              exit 1
+            fi
+            echo "$SERVICE_NAME has no public domain yet (attempt $attempt/10) — retrying in 5s..."
+            sleep 5
+          done
           NEW_ORIGIN="https://${DASHBOARD_URL}"
 
           API_VARS=$(railway variables --service cio-api --kv)
@@ -353,12 +366,20 @@ jobs:
             else
               UPDATED_TRUSTED="${CURRENT_TRUSTED},${NEW_ORIGIN}"
             fi
-            if ! output=$(railway variables --service cio-api --set "TRUSTED_ORIGINS=${UPDATED_TRUSTED}" 2>&1); then
-              echo "::error::Failed to trust ${NEW_ORIGIN} on cio-api's TRUSTED_ORIGINS. $output"
-              exit 1
-            fi
-            echo "$output"
-            echo "Trusted ${NEW_ORIGIN} on cio-api."
+            for attempt in $(seq 1 3); do
+              if output=$(railway variables --service cio-api --set "TRUSTED_ORIGINS=${UPDATED_TRUSTED}" 2>&1); then
+                echo "$output"
+                echo "Trusted ${NEW_ORIGIN} on cio-api."
+                break
+              fi
+              echo "$output"
+              if [ "$attempt" -eq 3 ]; then
+                echo "::error::Failed to trust ${NEW_ORIGIN} on cio-api's TRUSTED_ORIGINS after 3 attempts."
+                exit 1
+              fi
+              echo "Variable update failed (attempt $attempt/3) — retrying in 5s..."
+              sleep 5
+            done
           fi
 
       - name: Create backend preview service

--- a/.github/workflows/railway-preview.yml
+++ b/.github/workflows/railway-preview.yml
@@ -20,31 +20,14 @@ name: Railway Preview Environment
 # migrations + essential seed). The optional organization seed adds only that demo
 # organization's users, memberships, and content.
 #
-# mode: frontend
-#   Instead of duplicating the whole `staging` environment, this creates ONE new service
-#   (`<prname>-dashboard`) directly inside `staging`, wired via Railway reference variables
-#   to staging's already-running cio-api/cio-minio. No new project/environment/DB. Use this
-#   when you only need to test dashboard UI and are fine sharing staging's data/auth.
-#   The workflow trusts this preview's EXACT dashboard origin on staging cio-api's
-#   TRUSTED_ORIGINS at deploy time and untrusts it at destroy time (comma-append/remove, no
-#   wildcard — an origin-suffix wildcard here would trust every app on that shared Railway
-#   domain, not just ours). No manual setup needed, but each deploy/destroy redeploys the
-#   shared staging cio-api (variable changes redeploy by default), briefly affecting anyone
-#   else on staging at that moment.
+# mode: frontend — one <prname>-dashboard service inside staging, wired to staging's
+# shared cio-api/cio-minio. Its exact origin gets trusted on cio-api's TRUSTED_ORIGINS at
+# deploy and untrusted at destroy (not a wildcard — see PREVIEW_ENV.md).
 #
-# mode: frontend_backend
-#   Like `frontend`, but creates a fresh `<prname>-fb-api` inside `staging`, paired with a
-#   `<prname>-fb-dashboard` (not staging's shared cio-api, and NOT the same dashboard
-#   `frontend` mode would create for this branch — distinct names so the two modes never
-#   collide or silently reconfigure each other's service) — for testing a change that
-#   touches both dashboard and API code. Still shares staging's Postgres/Redis/MinIO (and
-#   its existing cio-jobs worker, since jobs reads off the shared Redis queue regardless of
-#   which api enqueued the work — this does assume the branch's job names/payloads stay
-#   compatible with whatever cio-jobs is currently running from `staging`). The api runs
-#   with SKIP_DB_SETUP=true (staging's own cio-api remains the one that migrates), so a PR
-#   needing a new, unapplied DB migration should use `full_deploy` instead. No
-#   TRUSTED_ORIGINS change needed — this pair trusts each other directly via
-#   DASHBOARD_ORIGIN, the same way `full_deploy` previews do.
+# mode: frontend_backend — like frontend, but pairs a fresh <prname>-fb-api with a
+# <prname>-fb-dashboard (own names so it never collides with frontend mode). Still shares
+# staging's Postgres/Redis/MinIO/cio-jobs; api runs SKIP_DB_SETUP=true. See PREVIEW_ENV.md
+# for the full trade-offs of both modes.
 
 on:
   workflow_dispatch:
@@ -87,12 +70,9 @@ on:
           - skillshare-test
           - none
 
-# full_deploy/frontend_backend: one run per branch+mode at a time, newer supersedes an
-# in-flight one — different branches touch independent Railway resources, safe to run in
-# parallel. frontend: ALL runs (any branch) share one group and never cancel each other —
-# every frontend-mode run reads-modifies-writes the SAME shared cio-api TRUSTED_ORIGINS
-# variable, so concurrent runs for different branches must queue, not race (and cancelling
-# one mid-write would be worse than the race itself).
+# frontend mode shares one global, non-cancelling group (also shared with
+# railway-preview-teardown.yml) since it read-modify-writes cio-api's TRUSTED_ORIGINS —
+# concurrent writers must queue, not race. Other modes stay isolated per branch+mode.
 concurrency:
   group: ${{ inputs.mode == 'frontend' && 'railway-preview-frontend-trusted-origins' || format('railway-preview-{0}-{1}', inputs.branch, inputs.mode) }}
   cancel-in-progress: ${{ inputs.mode != 'frontend' }}
@@ -125,27 +105,22 @@ jobs:
 
       - name: Derive a safe environment name
         id: env
-        # BRANCH is bound via env (not interpolated into the script) so an attacker-supplied
-        # value can't be executed as shell. "feat/foo_bar" -> "pr-feat-foo-bar-<hash>" — the
-        # slug alone is lossy (e.g. "foo/bar" and "foo_bar" both slug to "foo-bar"), so a
-        # hash of the original branch string disambiguates collisions. Slug is capped at 18
-        # chars so "pr-<slug>-<hash>" stays under Railway's ~32-char environment name limit
-        # even for long auto-generated branch names — the hash (not the slug) is what
-        # actually guarantees uniqueness, so truncating the slug is safe.
+        # BRANCH bound via env, not interpolated — avoids script injection. Slug is lossy
+        # (capped at 18 chars, under Railway's ~32-char limit) so the hash is what actually
+        # guarantees uniqueness. Hash covers repo+branch, not just branch — otherwise a
+        # fork could open a same-named branch and its PR closing would compute the same
+        # name as a real preview, letting teardown delete someone else's resources.
         env:
           BRANCH: ${{ inputs.branch }}
+          REPO: ${{ inputs.repo != '' && inputs.repo || github.repository }}
           MODE: ${{ inputs.mode }}
         run: |
           slug=$(echo "$BRANCH" | tr '[:upper:]/_.' '[:lower:]---' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g; s/^-//; s/-$//' | cut -c1-18 | sed 's/-$//')
-          hash=$(echo -n "$BRANCH" | sha256sum | cut -c1-8)
+          hash=$(echo -n "${REPO}#${BRANCH}" | sha256sum | cut -c1-8)
           name="pr-${slug}-${hash}"
           echo "name=${name}" >> "$GITHUB_OUTPUT"
-          # frontend/frontend_backend modes create services inside staging itself rather
-          # than a new environment. Same slug+hash as the full_deploy env name, but with a
-          # mode-specific suffix so the two modes never collide on the same service for a
-          # branch — running frontend then frontend_backend (or vice versa) for the same
-          # branch must not silently reconfigure the other mode's service, or leave one
-          # orphaned when destroyed with the wrong mode.
+          # frontend_backend gets its own "-fb-" names so it never collides with frontend
+          # mode's dashboard for the same branch.
           if [ "$MODE" = "frontend_backend" ]; then
             echo "dashboard_service_name=${name}-fb-dashboard" >> "$GITHUB_OUTPUT"
             echo "backend_service_name=${name}-fb-api" >> "$GITHUB_OUTPUT"
@@ -172,19 +147,9 @@ jobs:
 
       - name: Destroy dashboard-only preview
         if: ${{ inputs.action == 'destroy' && inputs.mode == 'frontend' }}
-        # No environment to delete here — just the one service inside staging. `service
-        # delete` runs against the linked project/environment established above, same as
-        # `environment delete`.
-        #
-        # Before deleting, untrust this preview's exact origin from staging cio-api's
-        # TRUSTED_ORIGINS (added at deploy time — see "Trust this preview's origin on
-        # staging cio-api"). Read the service's own RAILWAY_PUBLIC_DOMAIN first: it still
-        # exists at this point, so there's no need to reconstruct the Railway-generated
-        # domain string. Fail-closed: if the untrust call fails, stop here and do NOT
-        # delete the service — a stale trusted-origin entry with no live service behind it
-        # could later be inherited by an unrelated app that gets assigned that same
-        # now-freed Railway subdomain, which is worse than a service that keeps costing
-        # money until destroy is re-run.
+        # Untrust the exact origin (added at deploy) before deleting — fail-closed: if
+        # untrust fails, stop and leave the service running rather than risk a stale
+        # trusted-origin entry with nothing live behind it.
         env:
           SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
         run: |
@@ -291,23 +256,10 @@ jobs:
           done
 
       # ------------------------------------------------------ frontend / frontend_backend
-      # Stays linked to staging (from "Link to base project" above) — no new environment.
-      # Both modes need the same dashboard service + domain, created the same way; they
-      # only differ in what the dashboard's PRIVATE_SERVER_URL points at (see the
-      # "Configure dashboard-only preview variables" step below) and whether a paired
-      # <prname>-api also gets created.
       - name: Create dashboard-only preview service
         if: ${{ inputs.action == 'deploy' && (inputs.mode == 'frontend' || inputs.mode == 'frontend_backend') }}
-        # `railway add --service` has no "already exists" upsert behavior, so check first
-        # (a rerun for the same branch should redeploy the existing service, not fail or
-        # create a second one). Then poll until it's queryable — a freshly created
-        # ServiceInstance can take a moment to become visible, same propagation lag as the
-        # cio-minio race further down.
-        #
-        # The check itself distinguishes a genuine "not found" from any other probe failure
-        # (auth hiccup, transient API error, rate limit) — the latter must NOT be treated as
-        # "doesn't exist," since that would call `railway add` on a service that may already
-        # exist. Ambiguous failures get a few retries before the step gives up loudly.
+        # Check-then-create (railway add has no upsert), distinguishing a real "not found"
+        # from other probe failures so a transient error can't cause a duplicate create.
         env:
           SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
         run: |
@@ -378,15 +330,9 @@ jobs:
 
       - name: Trust this preview's origin on staging cio-api
         if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend' }}
-        # `frontend` mode's dashboard talks directly to staging's shared cio-api, so its
-        # exact origin must be trusted for CORS/session cookies (cio-api's TRUSTED_ORIGINS,
-        # read once at boot — see apps/api/src/constants). Deliberately NOT a
-        # `*.up.railway.app` wildcard: that would trust every app on that shared Railway
-        # domain suffix, not just this one. Read-then-append only, never overwrite, so
-        # staging's existing trusted origins (localhost, *.classroomio.com, etc.) survive —
-        # same pattern already used for ALLOWED_EXTERNAL_DOMAINS in the full_deploy MinIO
-        # step below. Setting this variable redeploys cio-api (accepted cost for exact-match
-        # trust instead of a standing wildcard); untrusted again on destroy.
+        # Read-then-append cio-api's TRUSTED_ORIGINS (never overwrite, so staging's other
+        # trusted origins survive) with this dashboard's exact origin — not a wildcard, see
+        # PREVIEW_ENV.md. Redeploys cio-api; untrusted again on destroy.
         env:
           SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
         run: |
@@ -417,9 +363,7 @@ jobs:
 
       - name: Create backend preview service
         if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend_backend' }}
-        # Same check-then-create + poll pattern as the dashboard service above (including
-        # the not-found-vs-other-failure distinction), targeting the paired <prname>-api
-        # instead.
+        # Same check-then-create pattern as the dashboard service above, for the paired api.
         env:
           BACKEND_SERVICE_NAME: ${{ steps.env.outputs.backend_service_name }}
         run: |
@@ -464,16 +408,10 @@ jobs:
 
       - name: Configure backend preview variables
         if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend_backend' }}
-        # Pairs this api with <prname>-dashboard (created above) rather than staging's
-        # shared cio-api, but still points at staging's Postgres/Redis/cio-minio — see the
-        # plan's "frontend_backend design" section for why. SKIP_DB_SETUP=true because this
-        # is a second api instance against staging's live Postgres: running migrations from
-        # two instances concurrently risks a race, and staging's own cio-api already keeps
-        # the shared schema current (same rule docker/docs/SELF_HOST.md documents for
-        # multiple API replicas). BETTER_AUTH_SECRET/PRIVATE_SERVER_KEY are generated fresh
-        # here since this is a new service, not a duplicate — cio-dashboard picks up
-        # PRIVATE_SERVER_KEY via a reference in the next step, so the value is never passed
-        # around outside Railway.
+        # Pairs with <prname>-dashboard, not staging's shared cio-api. SKIP_DB_SETUP=true
+        # avoids a migration race against staging's live Postgres (docker/docs/SELF_HOST.md
+        # documents the same rule for multiple API replicas). Fresh auth secrets — dashboard
+        # picks up PRIVATE_SERVER_KEY via reference in the next step.
         env:
           BACKEND_SERVICE_NAME: ${{ steps.env.outputs.backend_service_name }}
           DASHBOARD_SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
@@ -516,17 +454,10 @@ jobs:
 
       - name: Configure dashboard-only preview variables
         if: ${{ inputs.action == 'deploy' && (inputs.mode == 'frontend' || inputs.mode == 'frontend_backend') }}
-        # Wires this standalone service to cio-minio (always staging's shared one) and to an
-        # api — staging's shared cio-api in `frontend` mode, or the freshly paired
-        # <prname>-api in `frontend_backend` mode — via Railway reference variables
-        # (${{ Service.VAR }}), same pattern documented in RAILWAY_SETUP_GUIDE.md's
-        # cio-dashboard step. No dynamic-domain propagation dance needed here (unlike the
-        # full_deploy MinIO step below) because these are already stable, long-lived
-        # services by the time this step runs.
-        #
-        # The `${{ }}` reference syntax is Railway's, not GitHub Actions' — building it via
-        # a `$` variable + printf (rather than writing "${{" literally in this YAML) keeps
-        # the runner from trying to evaluate it as its own expression.
+        # Wires to cio-minio and an api — staging's shared cio-api in frontend mode, or the
+        # paired <prname>-api in frontend_backend — via Railway reference variables.
+        # ref() builds the "${{ }}" reference syntax via a `$` var + printf rather than a
+        # literal in this YAML, so GitHub Actions doesn't try to evaluate it as its own.
         env:
           SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
           MODE: ${{ inputs.mode }}
@@ -731,8 +662,7 @@ jobs:
         # output, so it can never match a stale, unrelated deployment. A failure with no id
         # means nothing was created yet and fails immediately.
         #
-        # frontend/frontend_backend modes deploy a shorter list than the usual three — the
-        # script itself is unchanged either way.
+        # frontend/frontend_backend just deploy a shorter APP_SERVICES list.
         env:
           APP_SERVICES: ${{ inputs.mode == 'frontend' && steps.env.outputs.dashboard_service_name || inputs.mode == 'frontend_backend' && format('{0} {1}', steps.env.outputs.backend_service_name, steps.env.outputs.dashboard_service_name) || env.APP_SERVICES }}
         run: bash .github/scripts/railway-preview-deploy.sh

--- a/.github/workflows/railway-preview.yml
+++ b/.github/workflows/railway-preview.yml
@@ -19,6 +19,16 @@ name: Railway Preview Environment
 # (docker/entrypoint-api.sh -> `pnpm --filter @cio/db db:setup`, which runs drizzle
 # migrations + essential seed). The optional organization seed adds only that demo
 # organization's users, memberships, and content.
+#
+# mode: frontend-only (extra one-time prerequisite)
+#   Instead of duplicating the whole `staging` environment, this creates ONE new service
+#   (`<prname>-dashboard`) directly inside `staging`, wired via Railway reference variables
+#   to staging's already-running cio-api/cio-minio. No new project/environment/DB. Use this
+#   when you only need to test dashboard UI and are fine sharing staging's data/auth.
+#   One-time setup: add `https://*.up.railway.app` to staging cio-api's TRUSTED_ORIGINS
+#   variable (comma-append) so every frontend-only preview's Railway-generated domain is
+#   trusted for CORS/session cookies without touching cio-api per PR (TRUSTED_ORIGINS is
+#   read once at boot and already supports `*` wildcards — see apps/api/src/constants).
 
 on:
   workflow_dispatch:
@@ -32,6 +42,14 @@ on:
         description: "Branch (or PR head ref) to deploy into the preview env"
         required: true
         type: string
+      mode:
+        description: "full-stack = duplicate all of staging; frontend-only = one dashboard-only service inside staging, wired to staging's shared backend"
+        required: true
+        type: choice
+        default: full-stack
+        options:
+          - full-stack
+          - frontend-only
       action:
         description: "deploy = create/update the preview; destroy = delete it"
         required: true
@@ -52,9 +70,11 @@ on:
           - skillshare-test
           - none
 
-# One run per branch at a time; a newer run supersedes an in-flight one.
+# One run per branch+mode at a time; a newer run supersedes an in-flight one. Split by mode
+# so a full-stack run and a frontend-only run for the same branch don't cancel each other —
+# they touch different Railway resources (a whole environment vs. one service).
 concurrency:
-  group: railway-preview-${{ inputs.branch }}
+  group: railway-preview-${{ inputs.branch }}-${{ inputs.mode }}
   cancel-in-progress: true
 
 env:
@@ -97,7 +117,12 @@ jobs:
         run: |
           slug=$(echo "$BRANCH" | tr '[:upper:]/_.' '[:lower:]---' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g; s/^-//; s/-$//' | cut -c1-18 | sed 's/-$//')
           hash=$(echo -n "$BRANCH" | sha256sum | cut -c1-8)
-          echo "name=pr-${slug}-${hash}" >> "$GITHUB_OUTPUT"
+          name="pr-${slug}-${hash}"
+          echo "name=${name}" >> "$GITHUB_OUTPUT"
+          # frontend-only mode's dashboard-only service, created inside staging itself
+          # rather than a new environment. Same slug+hash as the full-stack env name, so
+          # it stays collision-safe and teardown can reconstruct it the same way.
+          echo "dashboard_service_name=${name}-dashboard" >> "$GITHUB_OUTPUT"
 
       - name: Link to base project
         # `railway environment new`/`delete` take no --project/--workspace/--environment
@@ -108,16 +133,36 @@ jobs:
 
       # ---------------------------------------------------------------- destroy
       - name: Destroy preview environment
-        if: ${{ inputs.action == 'destroy' }}
+        if: ${{ inputs.action == 'destroy' && inputs.mode == 'full-stack' }}
         env:
           ENV_NAME: ${{ steps.env.outputs.name }}
         run: |
           railway environment delete "$ENV_NAME" --yes
           echo "Deleted environment $ENV_NAME." >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Destroy dashboard-only preview
+        if: ${{ inputs.action == 'destroy' && inputs.mode == 'frontend-only' }}
+        # No environment to delete here — just the one service inside staging. `service
+        # delete` runs against the linked project/environment established above, same as
+        # `environment delete`.
+        env:
+          SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
+        run: |
+          if ! output=$(railway service delete --service "$SERVICE_NAME" --yes 2>&1); then
+            echo "$output"
+            if echo "$output" | grep -qi "not found"; then
+              echo "No matching dashboard-only preview service (or already deleted) — nothing to do."
+            else
+              exit 1
+            fi
+          else
+            echo "$output"
+          fi
+          echo "Deleted service $SERVICE_NAME." >> "$GITHUB_STEP_SUMMARY"
+
       # ---------------------------------------------------------------- deploy
       - name: Create preview environment (duplicate base)
-        if: ${{ inputs.action == 'deploy' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' }}
         # `--duplicate` copies service config and variables but not public domains (see
         # domain-generation steps below). Only "already exists" is swallowed here — any
         # other failure must surface, not silently continue into a "Link" step that can't
@@ -137,7 +182,7 @@ jobs:
           fi
 
       - name: Link project + preview environment
-        if: ${{ inputs.action == 'deploy' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' }}
         # A brand-new environment (first run for a branch) can take a moment to become
         # visible to `railway link` right after `railway environment new` returns — same
         # duplication-propagation lag as the cio-minio ServiceInstance race below. Retry
@@ -159,8 +204,110 @@ jobs:
             sleep 5
           done
 
+      # ------------------------------------------------------ frontend-only
+      # Stays linked to staging (from "Link to base project" above) — no new environment.
+      - name: Create dashboard-only preview service
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend-only' }}
+        # `railway add --service` has no "already exists" upsert behavior, so check first
+        # (a rerun for the same branch should redeploy the existing service, not fail or
+        # create a second one). Then poll until it's queryable — a freshly created
+        # ServiceInstance can take a moment to become visible, same propagation lag as the
+        # cio-minio race further down.
+        env:
+          SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
+        run: |
+          if railway variables --service "$SERVICE_NAME" --kv >/dev/null 2>&1; then
+            echo "Service $SERVICE_NAME already exists in $BASE_ENV; reusing it."
+          else
+            echo "Creating service $SERVICE_NAME in $BASE_ENV..."
+            railway add --service "$SERVICE_NAME"
+          fi
+
+          for attempt in $(seq 1 10); do
+            if railway variables --service "$SERVICE_NAME" --kv >/dev/null 2>&1; then
+              echo "Service $SERVICE_NAME is queryable."
+              break
+            fi
+            if [ "$attempt" -eq 10 ]; then
+              echo "::error::Service $SERVICE_NAME never became queryable after 10 attempts."
+              exit 1
+            fi
+            echo "Service not ready yet (attempt $attempt/10) — retrying in 5s..."
+            sleep 5
+          done
+
+      - name: Generate domain for dashboard-only preview
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend-only' }}
+        # Must happen BEFORE the variables step below sets ORIGIN/PRIVATE_APP_HOST from
+        # RAILWAY_PUBLIC_DOMAIN — same ordering requirement documented for DASHBOARD_ORIGIN
+        # in RAILWAY_SETUP_GUIDE.md (an empty reference at boot crashes SvelteKit/better-auth
+        # origin checks).
+        env:
+          SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
+        run: |
+          for attempt in $(seq 1 10); do
+            if output=$(railway domain --service "$SERVICE_NAME" 2>&1); then
+              echo "$output"
+              break
+            fi
+            echo "$output"
+            if echo "$output" | grep -qi "already exists"; then
+              break
+            fi
+            if [ "$attempt" -eq 10 ]; then
+              echo "::error::Could not generate a domain for $SERVICE_NAME after 10 attempts."
+              exit 1
+            fi
+            echo "$SERVICE_NAME not ready yet (attempt $attempt/10) — retrying in 5s..."
+            sleep 5
+          done
+
+      - name: Configure dashboard-only preview variables
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend-only' }}
+        # Wires this standalone service to staging's already-running cio-api/cio-minio via
+        # Railway reference variables (${{ Service.VAR }}), same pattern documented in
+        # RAILWAY_SETUP_GUIDE.md's cio-dashboard step. No dynamic-domain propagation dance
+        # needed here (unlike the full-stack MinIO step below) because staging's
+        # cio-api/cio-minio domains are already stable, long-lived services.
+        #
+        # The `${{ }}` reference syntax is Railway's, not GitHub Actions' — building it via
+        # a `$` variable + printf (rather than writing "${{" literally in this YAML) keeps
+        # the runner from trying to evaluate it as its own expression.
+        env:
+          SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
+        run: |
+          D='$'
+          ref() { printf '%s{{%s}}' "$D" "$1"; }
+
+          set_var() {
+            local kv="$1"
+            local attempt output
+            for attempt in $(seq 1 3); do
+              if output=$(railway variables --service "$SERVICE_NAME" --set "$kv" 2>&1); then
+                echo "$output"
+                return 0
+              fi
+              echo "$output"
+              if [ "$attempt" -eq 3 ]; then
+                echo "::error::Setting '$kv' on $SERVICE_NAME failed after 3 attempts."
+                return 1
+              fi
+              echo "Variable update failed (attempt $attempt/3) — retrying in 5s..."
+              sleep 5
+            done
+          }
+
+          set_var "RAILWAY_DOCKERFILE_PATH=docker/Dockerfile.dashboard"
+          set_var "PUBLIC_IS_SELFHOSTED=true"
+          set_var "ORIGIN=https://$(ref RAILWAY_PUBLIC_DOMAIN)"
+          set_var "PRIVATE_APP_HOST=$(ref RAILWAY_PUBLIC_DOMAIN)"
+          set_var "PRIVATE_APP_SUBDOMAINS=app"
+          set_var "PRIVATE_SERVER_URL=http://$(ref cio-api.RAILWAY_PRIVATE_DOMAIN):$(ref cio-api.PORT)"
+          set_var "PRIVATE_SERVER_KEY=$(ref cio-api.PRIVATE_SERVER_KEY)"
+          set_var "CSP_MEDIA_SRC_DOMAINS=https://$(ref cio-minio.RAILWAY_PUBLIC_DOMAIN)"
+
       - name: Pin the Dockerfile per service
-        if: ${{ inputs.action == 'deploy' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' }}
         # `railway up` uploads local source but does NOT carry the dashboard's "Dockerfile
         # Path" build setting, so without this Railway falls back to Railpack and builds
         # the whole monorepo as a generic Node app. (Same gotcha documented in the setup guide.)
@@ -170,7 +317,7 @@ jobs:
           railway variables --service cio-jobs       --set "RAILWAY_DOCKERFILE_PATH=docker/Dockerfile.jobs"
 
       - name: Seed MinIO buckets (fresh volume starts empty)
-        if: ${{ inputs.action == 'deploy' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' }}
         # Railway has no minio-init sidecar and a duplicated env's MinIO volume is empty,
         # so create the buckets the app expects. Root creds carry over via duplication,
         # but the public domain doesn't, so generate one here (same as "Report the preview
@@ -321,32 +468,39 @@ jobs:
         # status instead of trusting the exit code; the id comes from this invocation's own
         # output, so it can never match a stale, unrelated deployment. A failure with no id
         # means nothing was created yet and fails immediately.
+        #
+        # frontend-only mode deploys just the one dashboard-only service instead of the
+        # usual three — the script itself is unchanged, it just takes a shorter list.
+        env:
+          APP_SERVICES: ${{ inputs.mode == 'frontend-only' && steps.env.outputs.dashboard_service_name || env.APP_SERVICES }}
         run: bash .github/scripts/railway-preview-deploy.sh
 
       - name: Setup pnpm
-        if: ${{ inputs.action == 'deploy' && inputs.seed_organization != 'none' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' && inputs.seed_organization != 'none' }}
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        if: ${{ inputs.action == 'deploy' && inputs.seed_organization != 'none' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' && inputs.seed_organization != 'none' }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
 
       - name: Install dependencies
-        if: ${{ inputs.action == 'deploy' && inputs.seed_organization != 'none' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' && inputs.seed_organization != 'none' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build workspace dependencies
-        if: ${{ inputs.action == 'deploy' && inputs.seed_organization != 'none' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' && inputs.seed_organization != 'none' }}
         # @cio/db imports compiled output (e.g. @cio/utils/dist/...) from its workspace
         # deps, not source — they must be built before the seed script can import them.
         run: pnpm --filter @cio/db^... build
 
       - name: Seed the selected demo data (optional)
         id: seed
-        if: ${{ inputs.action == 'deploy' && inputs.seed_organization != 'none' }}
+        # frontend-only mode never seeds — it shares staging's own Postgres, which already
+        # has its own data; seeding it here would mutate the shared staging dataset.
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' && inputs.seed_organization != 'none' }}
         # cio-api only carries the private DATABASE_URL; `railway run` executes on this
         # GitHub runner, so seeding needs Postgres's own DATABASE_PUBLIC_URL instead
         # (railway.internal isn't reachable from here).
@@ -375,7 +529,7 @@ jobs:
           fi
 
       - name: Report the preview URL
-        if: ${{ inputs.action == 'deploy' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' }}
         # BRANCH / ENV_NAME bound via env (never interpolated into the script).
         env:
           BRANCH: ${{ inputs.branch }}
@@ -400,4 +554,29 @@ jobs:
             echo "> All services passed their Railway deploy/healthcheck before this link was printed, so it should be live now."
             echo ""
             echo "Tear down with this workflow using **action = destroy** and the same branch."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report the dashboard-only preview URL
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend-only' }}
+        env:
+          BRANCH: ${{ inputs.branch }}
+          SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
+        run: |
+          URL=$(railway variables --service "$SERVICE_NAME" --kv | grep '^RAILWAY_PUBLIC_DOMAIN=' | cut -d= -f2-)
+          if [ -z "$URL" ]; then
+            echo "::error::$SERVICE_NAME has no public domain — 'railway domain' may have failed."
+            exit 1
+          fi
+
+          {
+            echo "### Frontend-only Railway preview ready :rocket:"
+            echo ""
+            echo "- Service: \`$SERVICE_NAME\` (branch \`$BRANCH\`), running inside \`$BASE_ENV\`"
+            echo "- Dashboard: https://${URL}"
+            echo ""
+            echo "> This preview shares staging's Postgres, Redis, MinIO, and auth with cio-api —"
+            echo "> it isn't isolated. Anything created while testing (users, uploads, org data)"
+            echo "> lands in the shared \`$BASE_ENV\` dataset, not a private sandbox."
+            echo ""
+            echo "Tear down with this workflow using **action = destroy**, **mode = frontend-only**, and the same branch."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/railway-preview.yml
+++ b/.github/workflows/railway-preview.yml
@@ -33,14 +33,18 @@ name: Railway Preview Environment
 #   else on staging at that moment.
 #
 # mode: frontend_backend
-#   Like `frontend`, but also creates a fresh `<prname>-api` inside `staging`, paired with
-#   `<prname>-dashboard` (not staging's shared cio-api) — for testing a change that touches
-#   both dashboard and API code. Still shares staging's Postgres/Redis/MinIO (and its
-#   existing cio-jobs worker, since jobs reads off the shared Redis queue regardless of
-#   which api enqueued the work). `<prname>-api` runs with SKIP_DB_SETUP=true (staging's own
-#   cio-api remains the one that migrates), so a PR needing a new, unapplied DB migration
-#   should use `full_deploy` instead. No TRUSTED_ORIGINS change needed — this pair trusts
-#   each other directly via DASHBOARD_ORIGIN, the same way `full_deploy` previews do.
+#   Like `frontend`, but creates a fresh `<prname>-fb-api` inside `staging`, paired with a
+#   `<prname>-fb-dashboard` (not staging's shared cio-api, and NOT the same dashboard
+#   `frontend` mode would create for this branch — distinct names so the two modes never
+#   collide or silently reconfigure each other's service) — for testing a change that
+#   touches both dashboard and API code. Still shares staging's Postgres/Redis/MinIO (and
+#   its existing cio-jobs worker, since jobs reads off the shared Redis queue regardless of
+#   which api enqueued the work — this does assume the branch's job names/payloads stay
+#   compatible with whatever cio-jobs is currently running from `staging`). The api runs
+#   with SKIP_DB_SETUP=true (staging's own cio-api remains the one that migrates), so a PR
+#   needing a new, unapplied DB migration should use `full_deploy` instead. No
+#   TRUSTED_ORIGINS change needed — this pair trusts each other directly via
+#   DASHBOARD_ORIGIN, the same way `full_deploy` previews do.
 
 on:
   workflow_dispatch:
@@ -83,12 +87,15 @@ on:
           - skillshare-test
           - none
 
-# One run per branch+mode at a time; a newer run supersedes an in-flight one. Split by mode
-# so runs in different modes for the same branch don't cancel each other — they touch
-# different Railway resources (a whole environment vs. one or two services).
+# full_deploy/frontend_backend: one run per branch+mode at a time, newer supersedes an
+# in-flight one — different branches touch independent Railway resources, safe to run in
+# parallel. frontend: ALL runs (any branch) share one group and never cancel each other —
+# every frontend-mode run reads-modifies-writes the SAME shared cio-api TRUSTED_ORIGINS
+# variable, so concurrent runs for different branches must queue, not race (and cancelling
+# one mid-write would be worse than the race itself).
 concurrency:
-  group: railway-preview-${{ inputs.branch }}-${{ inputs.mode }}
-  cancel-in-progress: true
+  group: ${{ inputs.mode == 'frontend' && 'railway-preview-frontend-trusted-origins' || format('railway-preview-{0}-{1}', inputs.branch, inputs.mode) }}
+  cancel-in-progress: ${{ inputs.mode != 'frontend' }}
 
 env:
   RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
@@ -127,15 +134,25 @@ jobs:
         # actually guarantees uniqueness, so truncating the slug is safe.
         env:
           BRANCH: ${{ inputs.branch }}
+          MODE: ${{ inputs.mode }}
         run: |
           slug=$(echo "$BRANCH" | tr '[:upper:]/_.' '[:lower:]---' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g; s/^-//; s/-$//' | cut -c1-18 | sed 's/-$//')
           hash=$(echo -n "$BRANCH" | sha256sum | cut -c1-8)
           name="pr-${slug}-${hash}"
           echo "name=${name}" >> "$GITHUB_OUTPUT"
           # frontend/frontend_backend modes create services inside staging itself rather
-          # than a new environment. Same slug+hash as the full_deploy env name.
-          echo "dashboard_service_name=${name}-dashboard" >> "$GITHUB_OUTPUT"
-          echo "backend_service_name=${name}-api" >> "$GITHUB_OUTPUT"
+          # than a new environment. Same slug+hash as the full_deploy env name, but with a
+          # mode-specific suffix so the two modes never collide on the same service for a
+          # branch — running frontend then frontend_backend (or vice versa) for the same
+          # branch must not silently reconfigure the other mode's service, or leave one
+          # orphaned when destroyed with the wrong mode.
+          if [ "$MODE" = "frontend_backend" ]; then
+            echo "dashboard_service_name=${name}-fb-dashboard" >> "$GITHUB_OUTPUT"
+            echo "backend_service_name=${name}-fb-api" >> "$GITHUB_OUTPUT"
+          else
+            echo "dashboard_service_name=${name}-dashboard" >> "$GITHUB_OUTPUT"
+            echo "backend_service_name=${name}-api" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Link to base project
         # `railway environment new`/`delete` take no --project/--workspace/--environment
@@ -163,9 +180,11 @@ jobs:
         # TRUSTED_ORIGINS (added at deploy time — see "Trust this preview's origin on
         # staging cio-api"). Read the service's own RAILWAY_PUBLIC_DOMAIN first: it still
         # exists at this point, so there's no need to reconstruct the Railway-generated
-        # domain string. Best-effort — an untrust failure warns but doesn't block deleting
-        # the service (a stale trusted-origin entry is harmless residue; an orphaned
-        # Railway service is not).
+        # domain string. Fail-closed: if the untrust call fails, stop here and do NOT
+        # delete the service — a stale trusted-origin entry with no live service behind it
+        # could later be inherited by an unrelated app that gets assigned that same
+        # now-freed Railway subdomain, which is worse than a service that keeps costing
+        # money until destroy is re-run.
         env:
           SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
         run: |
@@ -177,7 +196,9 @@ jobs:
             if echo "$CURRENT_TRUSTED" | tr ',' '\n' | grep -qxF "$ORIGIN_TO_REMOVE"; then
               NEW_TRUSTED=$(echo "$CURRENT_TRUSTED" | tr ',' '\n' | grep -vxF "$ORIGIN_TO_REMOVE" | tr '\n' ',' | sed 's/,$//')
               if ! output=$(railway variables --service cio-api --set "TRUSTED_ORIGINS=${NEW_TRUSTED}" 2>&1); then
-                echo "::warning::Failed to untrust ${ORIGIN_TO_REMOVE} from cio-api's TRUSTED_ORIGINS — continuing to delete the service anyway. $output"
+                echo "$output"
+                echo "::error::Failed to untrust ${ORIGIN_TO_REMOVE} from cio-api's TRUSTED_ORIGINS — refusing to delete $SERVICE_NAME while its origin may still be trusted. Fix cio-api's reachability and re-run destroy."
+                exit 1
               else
                 echo "$output"
                 echo "Untrusted ${ORIGIN_TO_REMOVE} from cio-api."

--- a/.github/workflows/railway-preview.yml
+++ b/.github/workflows/railway-preview.yml
@@ -37,32 +37,32 @@ name: Railway Preview Environment
 #   existing cio-jobs worker, since jobs reads off the shared Redis queue regardless of
 #   which api enqueued the work). `<prname>-api` runs with SKIP_DB_SETUP=true (staging's own
 #   cio-api remains the one that migrates), so a PR needing a new, unapplied DB migration
-#   should use `full-deploy` instead. No TRUSTED_ORIGINS change needed — this pair trusts
-#   each other directly via DASHBOARD_ORIGIN, the same way `full-deploy` previews do.
+#   should use `full_deploy` instead. No TRUSTED_ORIGINS change needed — this pair trusts
+#   each other directly via DASHBOARD_ORIGIN, the same way `full_deploy` previews do.
 
 on:
   workflow_dispatch:
     inputs:
       repo:
-        description: "Repo to deploy from (leave blank for classroomio/classroomio; set to e.g. Arun5768/classroomio for a fork)"
+        description: "Fork to deploy from (blank = classroomio/classroomio)"
         required: false
         type: string
         default: ""
       branch:
-        description: "Branch (or PR head ref) to deploy into the preview env"
+        description: "Branch or PR head ref to deploy"
         required: true
         type: string
       mode:
-        description: "full-deploy = duplicate all of staging; frontend_backend = fresh dashboard+api pair inside staging, sharing its DB/Redis/MinIO; frontend = dashboard only, wired to staging's shared api"
+        description: "Deploy scope — see PREVIEW_ENV.md"
         required: true
         type: choice
-        default: full-deploy
+        default: full_deploy
         options:
-          - full-deploy
+          - full_deploy
           - frontend_backend
           - frontend
       action:
-        description: "deploy = create/update the preview; destroy = delete it"
+        description: "Deploy or destroy the preview"
         required: true
         type: choice
         default: deploy
@@ -131,7 +131,7 @@ jobs:
           name="pr-${slug}-${hash}"
           echo "name=${name}" >> "$GITHUB_OUTPUT"
           # frontend/frontend_backend modes create services inside staging itself rather
-          # than a new environment. Same slug+hash as the full-deploy env name.
+          # than a new environment. Same slug+hash as the full_deploy env name.
           echo "dashboard_service_name=${name}-dashboard" >> "$GITHUB_OUTPUT"
           echo "backend_service_name=${name}-api" >> "$GITHUB_OUTPUT"
 
@@ -144,7 +144,7 @@ jobs:
 
       # ---------------------------------------------------------------- destroy
       - name: Destroy preview environment
-        if: ${{ inputs.action == 'destroy' && inputs.mode == 'full-deploy' }}
+        if: ${{ inputs.action == 'destroy' && inputs.mode == 'full_deploy' }}
         env:
           ENV_NAME: ${{ steps.env.outputs.name }}
         run: |
@@ -197,7 +197,7 @@ jobs:
 
       # ---------------------------------------------------------------- deploy
       - name: Create preview environment (duplicate base)
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full_deploy' }}
         # `--duplicate` copies service config and variables but not public domains (see
         # domain-generation steps below). Only "already exists" is swallowed here — any
         # other failure must surface, not silently continue into a "Link" step that can't
@@ -217,7 +217,7 @@ jobs:
           fi
 
       - name: Link project + preview environment
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full_deploy' }}
         # A brand-new environment (first run for a branch) can take a moment to become
         # visible to `railway link` right after `railway environment new` returns — same
         # duplication-propagation lag as the cio-minio ServiceInstance race below. Retry
@@ -387,7 +387,7 @@ jobs:
         # <prname>-api in `frontend_backend` mode — via Railway reference variables
         # (${{ Service.VAR }}), same pattern documented in RAILWAY_SETUP_GUIDE.md's
         # cio-dashboard step. No dynamic-domain propagation dance needed here (unlike the
-        # full-deploy MinIO step below) because these are already stable, long-lived
+        # full_deploy MinIO step below) because these are already stable, long-lived
         # services by the time this step runs.
         #
         # The `${{ }}` reference syntax is Railway's, not GitHub Actions' — building it via
@@ -435,7 +435,7 @@ jobs:
           set_var "CSP_MEDIA_SRC_DOMAINS=https://$(ref cio-minio.RAILWAY_PUBLIC_DOMAIN)"
 
       - name: Pin the Dockerfile per service
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full_deploy' }}
         # `railway up` uploads local source but does NOT carry the dashboard's "Dockerfile
         # Path" build setting, so without this Railway falls back to Railpack and builds
         # the whole monorepo as a generic Node app. (Same gotcha documented in the setup guide.)
@@ -445,7 +445,7 @@ jobs:
           railway variables --service cio-jobs       --set "RAILWAY_DOCKERFILE_PATH=docker/Dockerfile.jobs"
 
       - name: Seed MinIO buckets (fresh volume starts empty)
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full_deploy' }}
         # Railway has no minio-init sidecar and a duplicated env's MinIO volume is empty,
         # so create the buckets the app expects. Root creds carry over via duplication,
         # but the public domain doesn't, so generate one here (same as "Report the preview
@@ -604,22 +604,22 @@ jobs:
         run: bash .github/scripts/railway-preview-deploy.sh
 
       - name: Setup pnpm
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' && inputs.seed_organization != 'none' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full_deploy' && inputs.seed_organization != 'none' }}
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' && inputs.seed_organization != 'none' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full_deploy' && inputs.seed_organization != 'none' }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
 
       - name: Install dependencies
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' && inputs.seed_organization != 'none' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full_deploy' && inputs.seed_organization != 'none' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build workspace dependencies
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' && inputs.seed_organization != 'none' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full_deploy' && inputs.seed_organization != 'none' }}
         # @cio/db imports compiled output (e.g. @cio/utils/dist/...) from its workspace
         # deps, not source — they must be built before the seed script can import them.
         run: pnpm --filter @cio/db^... build
@@ -628,7 +628,7 @@ jobs:
         id: seed
         # frontend/frontend_backend modes never seed — they share staging's own Postgres,
         # which already has its own data; seeding it here would mutate the shared dataset.
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' && inputs.seed_organization != 'none' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full_deploy' && inputs.seed_organization != 'none' }}
         # cio-api only carries the private DATABASE_URL; `railway run` executes on this
         # GitHub runner, so seeding needs Postgres's own DATABASE_PUBLIC_URL instead
         # (railway.internal isn't reachable from here).
@@ -657,7 +657,7 @@ jobs:
           fi
 
       - name: Report the preview URL
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full_deploy' }}
         # BRANCH / ENV_NAME bound via env (never interpolated into the script).
         env:
           BRANCH: ${{ inputs.branch }}
@@ -731,7 +731,7 @@ jobs:
             echo "> This preview has its own api ($BACKEND_SERVICE_NAME), but it shares staging's"
             echo "> Postgres, Redis, and MinIO — not isolated. \`$BACKEND_SERVICE_NAME\` runs with"
             echo "> SKIP_DB_SETUP=true, so it does NOT apply new migrations; if this branch adds one,"
-            echo "> use **mode = full-deploy** instead."
+            echo "> use **mode = full_deploy** instead."
             echo ""
             echo "Tear down with this workflow using **action = destroy**, **mode = frontend_backend**, and the same branch."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/railway-preview.yml
+++ b/.github/workflows/railway-preview.yml
@@ -99,6 +99,18 @@ jobs:
     # builds + polling, which finishes well under this cap.
     timeout-minutes: 90
     steps:
+      - name: Checkout workflow repo
+        # No repository/ref override — this is the branch the workflow_dispatch run was
+        # actually launched from, always guaranteed to have .github/scripts/*. NOT the same
+        # as "Checkout target branch" below, which checks out the arbitrary branch being
+        # previewed and would wipe these scripts if that branch predates them.
+        uses: actions/checkout@v4
+
+      - name: Preserve helper scripts
+        # Copied outside the git-managed workspace so they survive "Checkout target branch"
+        # overwriting everything below with inputs.repo/inputs.branch's own tree.
+        run: cp .github/scripts/railway-preview-name.sh .github/scripts/railway-preview-deploy.sh "$RUNNER_TEMP/"
+
       - name: Checkout target branch
         uses: actions/checkout@v4
         with:
@@ -111,14 +123,15 @@ jobs:
       - name: Derive a safe environment name
         id: env
         # BRANCH/REPO bound via env, not interpolated — avoids script injection. Naming
-        # logic itself lives in .github/scripts/railway-preview-name.sh, shared with
-        # railway-preview-teardown.yml, so the two can't drift out of sync with each other.
+        # logic itself lives in railway-preview-name.sh (see "Preserve helper scripts"
+        # above), shared with railway-preview-teardown.yml, so the two can't drift out of
+        # sync with each other.
         env:
           BRANCH: ${{ inputs.branch }}
           REPO: ${{ inputs.repo != '' && inputs.repo || github.repository }}
           MODE: ${{ inputs.mode }}
         run: |
-          source .github/scripts/railway-preview-name.sh
+          source "$RUNNER_TEMP/railway-preview-name.sh"
           name=$(preview_base_name "$REPO" "$BRANCH")
           echo "name=${name}" >> "$GITHUB_OUTPUT"
           # frontend_backend gets its own "-fb-" names so it never collides with frontend
@@ -686,7 +699,7 @@ jobs:
         # frontend/frontend_backend just deploy a shorter APP_SERVICES list.
         env:
           APP_SERVICES: ${{ inputs.mode == 'frontend' && steps.env.outputs.dashboard_service_name || inputs.mode == 'frontend_backend' && format('{0} {1}', steps.env.outputs.backend_service_name, steps.env.outputs.dashboard_service_name) || env.APP_SERVICES }}
-        run: bash .github/scripts/railway-preview-deploy.sh
+        run: bash "$RUNNER_TEMP/railway-preview-deploy.sh"
 
       - name: Setup pnpm
         if: ${{ inputs.action == 'deploy' && inputs.mode == 'full_deploy' && inputs.seed_organization != 'none' }}

--- a/.github/workflows/railway-preview.yml
+++ b/.github/workflows/railway-preview.yml
@@ -20,15 +20,17 @@ name: Railway Preview Environment
 # migrations + essential seed). The optional organization seed adds only that demo
 # organization's users, memberships, and content.
 #
-# mode: frontend (extra one-time prerequisite)
+# mode: frontend
 #   Instead of duplicating the whole `staging` environment, this creates ONE new service
 #   (`<prname>-dashboard`) directly inside `staging`, wired via Railway reference variables
 #   to staging's already-running cio-api/cio-minio. No new project/environment/DB. Use this
 #   when you only need to test dashboard UI and are fine sharing staging's data/auth.
-#   One-time setup: add `https://*.up.railway.app` to staging cio-api's TRUSTED_ORIGINS
-#   variable (comma-append) so every `frontend` preview's Railway-generated domain is
-#   trusted for CORS/session cookies without touching cio-api per PR (TRUSTED_ORIGINS is
-#   read once at boot and already supports `*` wildcards — see apps/api/src/constants).
+#   The workflow trusts this preview's EXACT dashboard origin on staging cio-api's
+#   TRUSTED_ORIGINS at deploy time and untrusts it at destroy time (comma-append/remove, no
+#   wildcard — an origin-suffix wildcard here would trust every app on that shared Railway
+#   domain, not just ours). No manual setup needed, but each deploy/destroy redeploys the
+#   shared staging cio-api (variable changes redeploy by default), briefly affecting anyone
+#   else on staging at that moment.
 #
 # mode: frontend_backend
 #   Like `frontend`, but also creates a fresh `<prname>-api` inside `staging`, paired with
@@ -156,9 +158,37 @@ jobs:
         # No environment to delete here — just the one service inside staging. `service
         # delete` runs against the linked project/environment established above, same as
         # `environment delete`.
+        #
+        # Before deleting, untrust this preview's exact origin from staging cio-api's
+        # TRUSTED_ORIGINS (added at deploy time — see "Trust this preview's origin on
+        # staging cio-api"). Read the service's own RAILWAY_PUBLIC_DOMAIN first: it still
+        # exists at this point, so there's no need to reconstruct the Railway-generated
+        # domain string. Best-effort — an untrust failure warns but doesn't block deleting
+        # the service (a stale trusted-origin entry is harmless residue; an orphaned
+        # Railway service is not).
         env:
           SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
         run: |
+          DASHBOARD_URL=$(railway variables --service "$SERVICE_NAME" --kv 2>/dev/null | grep '^RAILWAY_PUBLIC_DOMAIN=' | cut -d= -f2- || true)
+          if [ -n "$DASHBOARD_URL" ]; then
+            ORIGIN_TO_REMOVE="https://${DASHBOARD_URL}"
+            API_VARS=$(railway variables --service cio-api --kv 2>/dev/null || true)
+            CURRENT_TRUSTED=$(echo "$API_VARS" | grep '^TRUSTED_ORIGINS=' | cut -d= -f2- || true)
+            if echo "$CURRENT_TRUSTED" | tr ',' '\n' | grep -qxF "$ORIGIN_TO_REMOVE"; then
+              NEW_TRUSTED=$(echo "$CURRENT_TRUSTED" | tr ',' '\n' | grep -vxF "$ORIGIN_TO_REMOVE" | tr '\n' ',' | sed 's/,$//')
+              if ! output=$(railway variables --service cio-api --set "TRUSTED_ORIGINS=${NEW_TRUSTED}" 2>&1); then
+                echo "::warning::Failed to untrust ${ORIGIN_TO_REMOVE} from cio-api's TRUSTED_ORIGINS — continuing to delete the service anyway. $output"
+              else
+                echo "$output"
+                echo "Untrusted ${ORIGIN_TO_REMOVE} from cio-api."
+              fi
+            else
+              echo "${ORIGIN_TO_REMOVE} was not in cio-api's TRUSTED_ORIGINS — nothing to untrust."
+            fi
+          else
+            echo "$SERVICE_NAME has no recorded domain (or doesn't exist) — nothing to untrust."
+          fi
+
           if ! output=$(railway service delete --service "$SERVICE_NAME" --yes 2>&1); then
             echo "$output"
             if echo "$output" | grep -qi "not found"; then
@@ -252,10 +282,34 @@ jobs:
         # create a second one). Then poll until it's queryable — a freshly created
         # ServiceInstance can take a moment to become visible, same propagation lag as the
         # cio-minio race further down.
+        #
+        # The check itself distinguishes a genuine "not found" from any other probe failure
+        # (auth hiccup, transient API error, rate limit) — the latter must NOT be treated as
+        # "doesn't exist," since that would call `railway add` on a service that may already
+        # exist. Ambiguous failures get a few retries before the step gives up loudly.
         env:
           SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
         run: |
-          if railway variables --service "$SERVICE_NAME" --kv >/dev/null 2>&1; then
+          exists=""
+          for attempt in $(seq 1 3); do
+            if output=$(railway variables --service "$SERVICE_NAME" --kv 2>&1); then
+              exists="yes"
+              break
+            fi
+            if echo "$output" | grep -qi "not found"; then
+              exists="no"
+              break
+            fi
+            echo "$output"
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Could not determine whether $SERVICE_NAME exists after 3 attempts (last error above, not a 'not found')."
+              exit 1
+            fi
+            echo "Probe failed with an unexpected error (attempt $attempt/3) — retrying in 5s..."
+            sleep 5
+          done
+
+          if [ "$exists" = "yes" ]; then
             echo "Service $SERVICE_NAME already exists in $BASE_ENV; reusing it."
           else
             echo "Creating service $SERVICE_NAME in $BASE_ENV..."
@@ -301,14 +355,73 @@ jobs:
             sleep 5
           done
 
+      - name: Trust this preview's origin on staging cio-api
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend' }}
+        # `frontend` mode's dashboard talks directly to staging's shared cio-api, so its
+        # exact origin must be trusted for CORS/session cookies (cio-api's TRUSTED_ORIGINS,
+        # read once at boot — see apps/api/src/constants). Deliberately NOT a
+        # `*.up.railway.app` wildcard: that would trust every app on that shared Railway
+        # domain suffix, not just this one. Read-then-append only, never overwrite, so
+        # staging's existing trusted origins (localhost, *.classroomio.com, etc.) survive —
+        # same pattern already used for ALLOWED_EXTERNAL_DOMAINS in the full_deploy MinIO
+        # step below. Setting this variable redeploys cio-api (accepted cost for exact-match
+        # trust instead of a standing wildcard); untrusted again on destroy.
+        env:
+          SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
+        run: |
+          DASHBOARD_URL=$(railway variables --service "$SERVICE_NAME" --kv | grep '^RAILWAY_PUBLIC_DOMAIN=' | cut -d= -f2-)
+          if [ -z "$DASHBOARD_URL" ]; then
+            echo "::error::$SERVICE_NAME has no public domain yet — 'railway domain' may have failed."
+            exit 1
+          fi
+          NEW_ORIGIN="https://${DASHBOARD_URL}"
+
+          API_VARS=$(railway variables --service cio-api --kv)
+          CURRENT_TRUSTED=$(echo "$API_VARS" | grep '^TRUSTED_ORIGINS=' | cut -d= -f2- || true)
+          if echo "$CURRENT_TRUSTED" | tr ',' '\n' | grep -qxF "$NEW_ORIGIN"; then
+            echo "${NEW_ORIGIN} is already trusted on cio-api."
+          else
+            if [ -z "$CURRENT_TRUSTED" ]; then
+              UPDATED_TRUSTED="$NEW_ORIGIN"
+            else
+              UPDATED_TRUSTED="${CURRENT_TRUSTED},${NEW_ORIGIN}"
+            fi
+            if ! output=$(railway variables --service cio-api --set "TRUSTED_ORIGINS=${UPDATED_TRUSTED}" 2>&1); then
+              echo "::error::Failed to trust ${NEW_ORIGIN} on cio-api's TRUSTED_ORIGINS. $output"
+              exit 1
+            fi
+            echo "$output"
+            echo "Trusted ${NEW_ORIGIN} on cio-api."
+          fi
+
       - name: Create backend preview service
         if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend_backend' }}
-        # Same check-then-create + poll pattern as the dashboard service above, targeting
-        # the paired <prname>-api instead.
+        # Same check-then-create + poll pattern as the dashboard service above (including
+        # the not-found-vs-other-failure distinction), targeting the paired <prname>-api
+        # instead.
         env:
           BACKEND_SERVICE_NAME: ${{ steps.env.outputs.backend_service_name }}
         run: |
-          if railway variables --service "$BACKEND_SERVICE_NAME" --kv >/dev/null 2>&1; then
+          exists=""
+          for attempt in $(seq 1 3); do
+            if output=$(railway variables --service "$BACKEND_SERVICE_NAME" --kv 2>&1); then
+              exists="yes"
+              break
+            fi
+            if echo "$output" | grep -qi "not found"; then
+              exists="no"
+              break
+            fi
+            echo "$output"
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Could not determine whether $BACKEND_SERVICE_NAME exists after 3 attempts (last error above, not a 'not found')."
+              exit 1
+            fi
+            echo "Probe failed with an unexpected error (attempt $attempt/3) — retrying in 5s..."
+            sleep 5
+          done
+
+          if [ "$exists" = "yes" ]; then
             echo "Service $BACKEND_SERVICE_NAME already exists in $BASE_ENV; reusing it."
           else
             echo "Creating service $BACKEND_SERVICE_NAME in $BASE_ENV..."

--- a/.github/workflows/railway-preview.yml
+++ b/.github/workflows/railway-preview.yml
@@ -20,15 +20,25 @@ name: Railway Preview Environment
 # migrations + essential seed). The optional organization seed adds only that demo
 # organization's users, memberships, and content.
 #
-# mode: frontend-only (extra one-time prerequisite)
+# mode: frontend (extra one-time prerequisite)
 #   Instead of duplicating the whole `staging` environment, this creates ONE new service
 #   (`<prname>-dashboard`) directly inside `staging`, wired via Railway reference variables
 #   to staging's already-running cio-api/cio-minio. No new project/environment/DB. Use this
 #   when you only need to test dashboard UI and are fine sharing staging's data/auth.
 #   One-time setup: add `https://*.up.railway.app` to staging cio-api's TRUSTED_ORIGINS
-#   variable (comma-append) so every frontend-only preview's Railway-generated domain is
+#   variable (comma-append) so every `frontend` preview's Railway-generated domain is
 #   trusted for CORS/session cookies without touching cio-api per PR (TRUSTED_ORIGINS is
 #   read once at boot and already supports `*` wildcards — see apps/api/src/constants).
+#
+# mode: frontend_backend
+#   Like `frontend`, but also creates a fresh `<prname>-api` inside `staging`, paired with
+#   `<prname>-dashboard` (not staging's shared cio-api) — for testing a change that touches
+#   both dashboard and API code. Still shares staging's Postgres/Redis/MinIO (and its
+#   existing cio-jobs worker, since jobs reads off the shared Redis queue regardless of
+#   which api enqueued the work). `<prname>-api` runs with SKIP_DB_SETUP=true (staging's own
+#   cio-api remains the one that migrates), so a PR needing a new, unapplied DB migration
+#   should use `full-deploy` instead. No TRUSTED_ORIGINS change needed — this pair trusts
+#   each other directly via DASHBOARD_ORIGIN, the same way `full-deploy` previews do.
 
 on:
   workflow_dispatch:
@@ -43,13 +53,14 @@ on:
         required: true
         type: string
       mode:
-        description: "full-stack = duplicate all of staging; frontend-only = one dashboard-only service inside staging, wired to staging's shared backend"
+        description: "full-deploy = duplicate all of staging; frontend_backend = fresh dashboard+api pair inside staging, sharing its DB/Redis/MinIO; frontend = dashboard only, wired to staging's shared api"
         required: true
         type: choice
-        default: full-stack
+        default: full-deploy
         options:
-          - full-stack
-          - frontend-only
+          - full-deploy
+          - frontend_backend
+          - frontend
       action:
         description: "deploy = create/update the preview; destroy = delete it"
         required: true
@@ -71,8 +82,8 @@ on:
           - none
 
 # One run per branch+mode at a time; a newer run supersedes an in-flight one. Split by mode
-# so a full-stack run and a frontend-only run for the same branch don't cancel each other —
-# they touch different Railway resources (a whole environment vs. one service).
+# so runs in different modes for the same branch don't cancel each other — they touch
+# different Railway resources (a whole environment vs. one or two services).
 concurrency:
   group: railway-preview-${{ inputs.branch }}-${{ inputs.mode }}
   cancel-in-progress: true
@@ -119,10 +130,10 @@ jobs:
           hash=$(echo -n "$BRANCH" | sha256sum | cut -c1-8)
           name="pr-${slug}-${hash}"
           echo "name=${name}" >> "$GITHUB_OUTPUT"
-          # frontend-only mode's dashboard-only service, created inside staging itself
-          # rather than a new environment. Same slug+hash as the full-stack env name, so
-          # it stays collision-safe and teardown can reconstruct it the same way.
+          # frontend/frontend_backend modes create services inside staging itself rather
+          # than a new environment. Same slug+hash as the full-deploy env name.
           echo "dashboard_service_name=${name}-dashboard" >> "$GITHUB_OUTPUT"
+          echo "backend_service_name=${name}-api" >> "$GITHUB_OUTPUT"
 
       - name: Link to base project
         # `railway environment new`/`delete` take no --project/--workspace/--environment
@@ -133,7 +144,7 @@ jobs:
 
       # ---------------------------------------------------------------- destroy
       - name: Destroy preview environment
-        if: ${{ inputs.action == 'destroy' && inputs.mode == 'full-stack' }}
+        if: ${{ inputs.action == 'destroy' && inputs.mode == 'full-deploy' }}
         env:
           ENV_NAME: ${{ steps.env.outputs.name }}
         run: |
@@ -141,7 +152,7 @@ jobs:
           echo "Deleted environment $ENV_NAME." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Destroy dashboard-only preview
-        if: ${{ inputs.action == 'destroy' && inputs.mode == 'frontend-only' }}
+        if: ${{ inputs.action == 'destroy' && inputs.mode == 'frontend' }}
         # No environment to delete here — just the one service inside staging. `service
         # delete` runs against the linked project/environment established above, same as
         # `environment delete`.
@@ -160,9 +171,33 @@ jobs:
           fi
           echo "Deleted service $SERVICE_NAME." >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Destroy frontend_backend preview
+        if: ${{ inputs.action == 'destroy' && inputs.mode == 'frontend_backend' }}
+        env:
+          SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
+          BACKEND_SERVICE_NAME: ${{ steps.env.outputs.backend_service_name }}
+        run: |
+          delete_service() {
+            local service="$1"
+            if ! output=$(railway service delete --service "$service" --yes 2>&1); then
+              echo "$output"
+              if echo "$output" | grep -qi "not found"; then
+                echo "No matching $service (or already deleted) — nothing to do."
+              else
+                return 1
+              fi
+            else
+              echo "$output"
+            fi
+          }
+
+          delete_service "$SERVICE_NAME"
+          delete_service "$BACKEND_SERVICE_NAME"
+          echo "Deleted services $SERVICE_NAME and $BACKEND_SERVICE_NAME." >> "$GITHUB_STEP_SUMMARY"
+
       # ---------------------------------------------------------------- deploy
       - name: Create preview environment (duplicate base)
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' }}
         # `--duplicate` copies service config and variables but not public domains (see
         # domain-generation steps below). Only "already exists" is swallowed here — any
         # other failure must surface, not silently continue into a "Link" step that can't
@@ -182,7 +217,7 @@ jobs:
           fi
 
       - name: Link project + preview environment
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' }}
         # A brand-new environment (first run for a branch) can take a moment to become
         # visible to `railway link` right after `railway environment new` returns — same
         # duplication-propagation lag as the cio-minio ServiceInstance race below. Retry
@@ -204,10 +239,14 @@ jobs:
             sleep 5
           done
 
-      # ------------------------------------------------------ frontend-only
+      # ------------------------------------------------------ frontend / frontend_backend
       # Stays linked to staging (from "Link to base project" above) — no new environment.
+      # Both modes need the same dashboard service + domain, created the same way; they
+      # only differ in what the dashboard's PRIVATE_SERVER_URL points at (see the
+      # "Configure dashboard-only preview variables" step below) and whether a paired
+      # <prname>-api also gets created.
       - name: Create dashboard-only preview service
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend-only' }}
+        if: ${{ inputs.action == 'deploy' && (inputs.mode == 'frontend' || inputs.mode == 'frontend_backend') }}
         # `railway add --service` has no "already exists" upsert behavior, so check first
         # (a rerun for the same branch should redeploy the existing service, not fail or
         # create a second one). Then poll until it's queryable — a freshly created
@@ -237,7 +276,7 @@ jobs:
           done
 
       - name: Generate domain for dashboard-only preview
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend-only' }}
+        if: ${{ inputs.action == 'deploy' && (inputs.mode == 'frontend' || inputs.mode == 'frontend_backend') }}
         # Must happen BEFORE the variables step below sets ORIGIN/PRIVATE_APP_HOST from
         # RAILWAY_PUBLIC_DOMAIN — same ordering requirement documented for DASHBOARD_ORIGIN
         # in RAILWAY_SETUP_GUIDE.md (an empty reference at boot crashes SvelteKit/better-auth
@@ -262,19 +301,102 @@ jobs:
             sleep 5
           done
 
+      - name: Create backend preview service
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend_backend' }}
+        # Same check-then-create + poll pattern as the dashboard service above, targeting
+        # the paired <prname>-api instead.
+        env:
+          BACKEND_SERVICE_NAME: ${{ steps.env.outputs.backend_service_name }}
+        run: |
+          if railway variables --service "$BACKEND_SERVICE_NAME" --kv >/dev/null 2>&1; then
+            echo "Service $BACKEND_SERVICE_NAME already exists in $BASE_ENV; reusing it."
+          else
+            echo "Creating service $BACKEND_SERVICE_NAME in $BASE_ENV..."
+            railway add --service "$BACKEND_SERVICE_NAME"
+          fi
+
+          for attempt in $(seq 1 10); do
+            if railway variables --service "$BACKEND_SERVICE_NAME" --kv >/dev/null 2>&1; then
+              echo "Service $BACKEND_SERVICE_NAME is queryable."
+              break
+            fi
+            if [ "$attempt" -eq 10 ]; then
+              echo "::error::Service $BACKEND_SERVICE_NAME never became queryable after 10 attempts."
+              exit 1
+            fi
+            echo "Service not ready yet (attempt $attempt/10) — retrying in 5s..."
+            sleep 5
+          done
+
+      - name: Configure backend preview variables
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend_backend' }}
+        # Pairs this api with <prname>-dashboard (created above) rather than staging's
+        # shared cio-api, but still points at staging's Postgres/Redis/cio-minio — see the
+        # plan's "frontend_backend design" section for why. SKIP_DB_SETUP=true because this
+        # is a second api instance against staging's live Postgres: running migrations from
+        # two instances concurrently risks a race, and staging's own cio-api already keeps
+        # the shared schema current (same rule docker/docs/SELF_HOST.md documents for
+        # multiple API replicas). BETTER_AUTH_SECRET/PRIVATE_SERVER_KEY are generated fresh
+        # here since this is a new service, not a duplicate — cio-dashboard picks up
+        # PRIVATE_SERVER_KEY via a reference in the next step, so the value is never passed
+        # around outside Railway.
+        env:
+          BACKEND_SERVICE_NAME: ${{ steps.env.outputs.backend_service_name }}
+          DASHBOARD_SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
+        run: |
+          D='$'
+          ref() { printf '%s{{%s}}' "$D" "$1"; }
+
+          set_var() {
+            local kv="$1"
+            local attempt output
+            for attempt in $(seq 1 3); do
+              if output=$(railway variables --service "$BACKEND_SERVICE_NAME" --set "$kv" 2>&1); then
+                echo "$output"
+                return 0
+              fi
+              echo "$output"
+              if [ "$attempt" -eq 3 ]; then
+                echo "::error::Setting '$kv' on $BACKEND_SERVICE_NAME failed after 3 attempts."
+                return 1
+              fi
+              echo "Variable update failed (attempt $attempt/3) — retrying in 5s..."
+              sleep 5
+            done
+          }
+
+          set_var "RAILWAY_DOCKERFILE_PATH=docker/Dockerfile.api"
+          set_var "PUBLIC_IS_SELFHOSTED=true"
+          set_var "SKIP_DB_SETUP=true"
+          set_var "DATABASE_URL=$(ref Postgres.DATABASE_URL)"
+          set_var "REDIS_URL=$(ref Redis.REDIS_URL)"
+          set_var "DASHBOARD_ORIGIN=https://$(ref "${DASHBOARD_SERVICE_NAME}.RAILWAY_PUBLIC_DOMAIN")"
+          set_var "BETTER_AUTH_SECRET=$(openssl rand -hex 32)"
+          set_var "PRIVATE_SERVER_KEY=$(openssl rand -hex 32)"
+          set_var "OBJECT_STORAGE_ENDPOINT=http://$(ref cio-minio.RAILWAY_PRIVATE_DOMAIN):9000"
+          set_var "OBJECT_STORAGE_PUBLIC_ENDPOINT=https://$(ref cio-minio.RAILWAY_PUBLIC_DOMAIN)"
+          set_var "OBJECT_STORAGE_ACCESS_KEY_ID=$(ref cio-minio.MINIO_ROOT_USER)"
+          set_var "OBJECT_STORAGE_SECRET_ACCESS_KEY=$(ref cio-minio.MINIO_ROOT_PASSWORD)"
+          set_var "OBJECT_STORAGE_FORCE_PATH_STYLE=true"
+          set_var "OBJECT_STORAGE_MEDIA_PUBLIC_BASE_URL=https://$(ref cio-minio.RAILWAY_PUBLIC_DOMAIN)/media"
+
       - name: Configure dashboard-only preview variables
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend-only' }}
-        # Wires this standalone service to staging's already-running cio-api/cio-minio via
-        # Railway reference variables (${{ Service.VAR }}), same pattern documented in
-        # RAILWAY_SETUP_GUIDE.md's cio-dashboard step. No dynamic-domain propagation dance
-        # needed here (unlike the full-stack MinIO step below) because staging's
-        # cio-api/cio-minio domains are already stable, long-lived services.
+        if: ${{ inputs.action == 'deploy' && (inputs.mode == 'frontend' || inputs.mode == 'frontend_backend') }}
+        # Wires this standalone service to cio-minio (always staging's shared one) and to an
+        # api — staging's shared cio-api in `frontend` mode, or the freshly paired
+        # <prname>-api in `frontend_backend` mode — via Railway reference variables
+        # (${{ Service.VAR }}), same pattern documented in RAILWAY_SETUP_GUIDE.md's
+        # cio-dashboard step. No dynamic-domain propagation dance needed here (unlike the
+        # full-deploy MinIO step below) because these are already stable, long-lived
+        # services by the time this step runs.
         #
         # The `${{ }}` reference syntax is Railway's, not GitHub Actions' — building it via
         # a `$` variable + printf (rather than writing "${{" literally in this YAML) keeps
         # the runner from trying to evaluate it as its own expression.
         env:
           SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
+          MODE: ${{ inputs.mode }}
+          BACKEND_SERVICE_NAME: ${{ steps.env.outputs.backend_service_name }}
         run: |
           D='$'
           ref() { printf '%s{{%s}}' "$D" "$1"; }
@@ -297,17 +419,23 @@ jobs:
             done
           }
 
+          if [ "$MODE" = "frontend_backend" ]; then
+            API_REF="$BACKEND_SERVICE_NAME"
+          else
+            API_REF="cio-api"
+          fi
+
           set_var "RAILWAY_DOCKERFILE_PATH=docker/Dockerfile.dashboard"
           set_var "PUBLIC_IS_SELFHOSTED=true"
           set_var "ORIGIN=https://$(ref RAILWAY_PUBLIC_DOMAIN)"
           set_var "PRIVATE_APP_HOST=$(ref RAILWAY_PUBLIC_DOMAIN)"
           set_var "PRIVATE_APP_SUBDOMAINS=app"
-          set_var "PRIVATE_SERVER_URL=http://$(ref cio-api.RAILWAY_PRIVATE_DOMAIN):$(ref cio-api.PORT)"
-          set_var "PRIVATE_SERVER_KEY=$(ref cio-api.PRIVATE_SERVER_KEY)"
+          set_var "PRIVATE_SERVER_URL=http://$(ref "${API_REF}.RAILWAY_PRIVATE_DOMAIN"):$(ref "${API_REF}.PORT")"
+          set_var "PRIVATE_SERVER_KEY=$(ref "${API_REF}.PRIVATE_SERVER_KEY")"
           set_var "CSP_MEDIA_SRC_DOMAINS=https://$(ref cio-minio.RAILWAY_PUBLIC_DOMAIN)"
 
       - name: Pin the Dockerfile per service
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' }}
         # `railway up` uploads local source but does NOT carry the dashboard's "Dockerfile
         # Path" build setting, so without this Railway falls back to Railpack and builds
         # the whole monorepo as a generic Node app. (Same gotcha documented in the setup guide.)
@@ -317,7 +445,7 @@ jobs:
           railway variables --service cio-jobs       --set "RAILWAY_DOCKERFILE_PATH=docker/Dockerfile.jobs"
 
       - name: Seed MinIO buckets (fresh volume starts empty)
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' }}
         # Railway has no minio-init sidecar and a duplicated env's MinIO volume is empty,
         # so create the buckets the app expects. Root creds carry over via duplication,
         # but the public domain doesn't, so generate one here (same as "Report the preview
@@ -469,38 +597,38 @@ jobs:
         # output, so it can never match a stale, unrelated deployment. A failure with no id
         # means nothing was created yet and fails immediately.
         #
-        # frontend-only mode deploys just the one dashboard-only service instead of the
-        # usual three — the script itself is unchanged, it just takes a shorter list.
+        # frontend/frontend_backend modes deploy a shorter list than the usual three — the
+        # script itself is unchanged either way.
         env:
-          APP_SERVICES: ${{ inputs.mode == 'frontend-only' && steps.env.outputs.dashboard_service_name || env.APP_SERVICES }}
+          APP_SERVICES: ${{ inputs.mode == 'frontend' && steps.env.outputs.dashboard_service_name || inputs.mode == 'frontend_backend' && format('{0} {1}', steps.env.outputs.backend_service_name, steps.env.outputs.dashboard_service_name) || env.APP_SERVICES }}
         run: bash .github/scripts/railway-preview-deploy.sh
 
       - name: Setup pnpm
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' && inputs.seed_organization != 'none' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' && inputs.seed_organization != 'none' }}
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' && inputs.seed_organization != 'none' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' && inputs.seed_organization != 'none' }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
 
       - name: Install dependencies
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' && inputs.seed_organization != 'none' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' && inputs.seed_organization != 'none' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build workspace dependencies
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' && inputs.seed_organization != 'none' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' && inputs.seed_organization != 'none' }}
         # @cio/db imports compiled output (e.g. @cio/utils/dist/...) from its workspace
         # deps, not source — they must be built before the seed script can import them.
         run: pnpm --filter @cio/db^... build
 
       - name: Seed the selected demo data (optional)
         id: seed
-        # frontend-only mode never seeds — it shares staging's own Postgres, which already
-        # has its own data; seeding it here would mutate the shared staging dataset.
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' && inputs.seed_organization != 'none' }}
+        # frontend/frontend_backend modes never seed — they share staging's own Postgres,
+        # which already has its own data; seeding it here would mutate the shared dataset.
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' && inputs.seed_organization != 'none' }}
         # cio-api only carries the private DATABASE_URL; `railway run` executes on this
         # GitHub runner, so seeding needs Postgres's own DATABASE_PUBLIC_URL instead
         # (railway.internal isn't reachable from here).
@@ -529,7 +657,7 @@ jobs:
           fi
 
       - name: Report the preview URL
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-stack' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'full-deploy' }}
         # BRANCH / ENV_NAME bound via env (never interpolated into the script).
         env:
           BRANCH: ${{ inputs.branch }}
@@ -557,7 +685,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Report the dashboard-only preview URL
-        if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend-only' }}
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend' }}
         env:
           BRANCH: ${{ inputs.branch }}
           SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
@@ -578,5 +706,32 @@ jobs:
             echo "> it isn't isolated. Anything created while testing (users, uploads, org data)"
             echo "> lands in the shared \`$BASE_ENV\` dataset, not a private sandbox."
             echo ""
-            echo "Tear down with this workflow using **action = destroy**, **mode = frontend-only**, and the same branch."
+            echo "Tear down with this workflow using **action = destroy**, **mode = frontend**, and the same branch."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report the frontend_backend preview URL
+        if: ${{ inputs.action == 'deploy' && inputs.mode == 'frontend_backend' }}
+        env:
+          BRANCH: ${{ inputs.branch }}
+          SERVICE_NAME: ${{ steps.env.outputs.dashboard_service_name }}
+          BACKEND_SERVICE_NAME: ${{ steps.env.outputs.backend_service_name }}
+        run: |
+          URL=$(railway variables --service "$SERVICE_NAME" --kv | grep '^RAILWAY_PUBLIC_DOMAIN=' | cut -d= -f2-)
+          if [ -z "$URL" ]; then
+            echo "::error::$SERVICE_NAME has no public domain — 'railway domain' may have failed."
+            exit 1
+          fi
+
+          {
+            echo "### frontend_backend Railway preview ready :rocket:"
+            echo ""
+            echo "- Services: \`$SERVICE_NAME\` + \`$BACKEND_SERVICE_NAME\` (branch \`$BRANCH\`), running inside \`$BASE_ENV\`"
+            echo "- Dashboard: https://${URL}"
+            echo ""
+            echo "> This preview has its own api ($BACKEND_SERVICE_NAME), but it shares staging's"
+            echo "> Postgres, Redis, and MinIO — not isolated. \`$BACKEND_SERVICE_NAME\` runs with"
+            echo "> SKIP_DB_SETUP=true, so it does NOT apply new migrations; if this branch adds one,"
+            echo "> use **mode = full-deploy** instead."
+            echo ""
+            echo "Tear down with this workflow using **action = destroy**, **mode = frontend_backend**, and the same branch."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/PREVIEW_ENV.md
+++ b/PREVIEW_ENV.md
@@ -57,6 +57,10 @@ streams its build logs and blocks until that service passes its deploy/healthche
 waits for all of them — so the printed URL is live the moment the run finishes, and a failed
 healthcheck fails the run rather than reporting a broken preview.
 
+Re-running the workflow for a branch+mode that already has a run in flight **queues** behind
+it rather than cancelling it — if you dispatched with a wrong input and want the corrected
+run to start immediately, cancel the earlier run yourself from the Actions tab.
+
 #### `frontend` mode
 
 Most changes only touch dashboard UI, so most previews don't need a whole duplicated stack.

--- a/PREVIEW_ENV.md
+++ b/PREVIEW_ENV.md
@@ -37,15 +37,20 @@ Two mechanisms, both enabled:
   fresh dashboard+api pair inside `staging`, sharing its DB/Redis/MinIO; `frontend` creates
   just a dashboard service inside `staging`, wired to `staging`'s shared api (see below).
 - `action` — `deploy` (create/update) or `destroy` (delete).
-- `seed` — also load the full demo dataset (`admin@test.com` etc.); migrations + essential
-  seed always run on api boot regardless. Ignored outside `full_deploy` mode.
+- `seed` — also load the full demo dataset (`admin@test.com` etc.); ignored outside
+  `full_deploy` mode. Migrations + essential seed run on **that mode's own api boot**
+  regardless of this input — but that only happens for `full_deploy` (a fresh duplicated
+  `cio-api`) and doesn't apply to `frontend` (no new api boots at all) or `frontend_backend`
+  (its api boots with `SKIP_DB_SETUP=true`, so migrations are explicitly skipped — see that
+  mode's section below).
 
 The run prints the preview **Dashboard URL** in its job **summary**. Everything is named off
 `pr-<branch-slug>-<hash>` — an 8-character hash of the branch name is appended because the
 slug alone is lossy (e.g. `foo/bar` and `foo_bar` both slug to `foo-bar`) — as an
 **environment** for `full_deploy`, a `pr-<branch-slug>-<hash>-dashboard` **service** for
-`frontend`, or both `pr-<branch-slug>-<hash>-dashboard` and `pr-<branch-slug>-<hash>-api`
-**services** for `frontend_backend`.
+`frontend`, or both `pr-<branch-slug>-<hash>-fb-dashboard` and `pr-<branch-slug>-<hash>-fb-api`
+**services** for `frontend_backend` (the `-fb-` infix keeps it from colliding with a
+`frontend`-mode preview for the same branch).
 
 The deploy step starts the app-service build(s) **in parallel** (each `railway up --ci`
 streams its build logs and blocks until that service passes its deploy/healthcheck), then
@@ -80,11 +85,20 @@ Tear down with `action = destroy`, `mode = frontend`, and the same branch.
 
 For a change that touches both dashboard and API code but doesn't need its own isolated
 database. With `mode = frontend_backend`, the workflow creates **two new services**,
-`pr-<branch-slug>-<hash>-dashboard` and `pr-<branch-slug>-<hash>-api`, paired with each
-other — built from `docker/Dockerfile.dashboard`/`docker/Dockerfile.api` — but still
-pointed at `staging`'s shared Postgres, Redis, and MinIO. `staging`'s existing `cio-jobs`
-keeps handling background work for this preview too, since it reads off the same shared
-Redis queue regardless of which api enqueued a job — no dedicated jobs service is created.
+`pr-<branch-slug>-<hash>-fb-dashboard` and `pr-<branch-slug>-<hash>-fb-api`, paired with
+each other — built from `docker/Dockerfile.dashboard`/`docker/Dockerfile.api` — but still
+pointed at `staging`'s shared Postgres, Redis, and MinIO. The `-fb-` infix keeps these
+distinct from `frontend` mode's `...-dashboard`, so running one mode then the other for the
+same branch never collides with or reconfigures the other's service.
+
+`staging`'s existing `cio-jobs` keeps handling background work for this preview too, since
+it reads off the same shared Redis queue regardless of which api enqueued a job — no
+dedicated jobs service is created. This assumes job compatibility: if your branch renames a
+BullMQ job or changes its payload shape, `staging`'s `cio-jobs` (running whatever's
+currently on the `staging` branch) may not pick up the renamed job at all, or may mishandle
+the new payload. If your change touches job names/payloads, verify against `staging`'s
+current `cio-jobs` code, or use `full_deploy` instead (its duplicated environment gets its
+own `cio-jobs` built from the same branch).
 
 Because the new api and dashboard trust each other directly (`DASHBOARD_ORIGIN` on the new
 api references the new dashboard, the same way `full_deploy` previews' duplicated `cio-api`

--- a/PREVIEW_ENV.md
+++ b/PREVIEW_ENV.md
@@ -33,18 +33,45 @@ Two mechanisms, both enabled:
 
 **Actions → "Railway Preview Environment" → Run workflow:**
 - `branch` — the branch/PR head to deploy.
+- `mode` — `full-stack` (default) duplicates all of `staging`; `frontend-only` creates just
+  one dashboard-only service inside `staging` itself (see below).
 - `action` — `deploy` (create/update) or `destroy` (delete).
 - `seed` — also load the full demo dataset (`admin@test.com` etc.); migrations + essential
-  seed always run on api boot regardless.
+  seed always run on api boot regardless. Ignored in `frontend-only` mode.
 
-The run prints the preview **Dashboard URL** in its job **summary**. The env is named
-`pr-<branch-slug>-<hash>` — an 8-character hash of the branch name is appended because the
-slug alone is lossy (e.g. `foo/bar` and `foo_bar` both slug to `foo-bar`).
+The run prints the preview **Dashboard URL** in its job **summary**. The env (or, in
+`frontend-only` mode, the service) is named `pr-<branch-slug>-<hash>` — an 8-character hash
+of the branch name is appended because the slug alone is lossy (e.g. `foo/bar` and
+`foo_bar` both slug to `foo-bar`).
 
-The deploy step starts the three app-service builds **in parallel** (each `railway up --ci`
+The deploy step starts the app-service build(s) **in parallel** (each `railway up --ci`
 streams its build logs and blocks until that service passes its deploy/healthcheck), then
 waits for all of them — so the printed URL is live the moment the run finishes, and a failed
 healthcheck fails the run rather than reporting a broken preview.
+
+#### `frontend-only` mode
+
+Most changes only touch dashboard UI, so most previews don't need a whole duplicated stack.
+With `mode = frontend-only`, the workflow skips environment duplication entirely and
+instead creates **one new service**, `pr-<branch-slug>-<hash>-dashboard`, directly inside
+`staging` — built from the branch's `docker/Dockerfile.dashboard` and wired via Railway
+reference variables to `staging`'s already-running `cio-api` and `cio-minio`. No new
+project, environment, Postgres, Redis, or MinIO volume.
+
+Trade-off: this preview is **not isolated**. It shares staging's Postgres, Redis, MinIO,
+and auth session store with `cio-api` — anything created while testing (users, uploads, org
+data) lands in the shared `staging` dataset, not a private sandbox. Use `full-stack` mode
+instead when a change needs its own isolated backend/data.
+
+**One-time prerequisite:** `cio-api`'s `TRUSTED_ORIGINS` (read once at boot, comma-separated,
+supports `*` wildcards — see `apps/api/src/constants`) must include
+`https://*.up.railway.app` so every `frontend-only` preview's Railway-generated domain is
+trusted for CORS/session cookies. Add this once to staging's `cio-api` service (Railway
+dashboard, or `railway variables --service cio-api --set 'TRUSTED_ORIGINS=...'` appended to
+whatever's already set) — it's never touched per-PR, so creating/destroying a
+`frontend-only` preview never mutates or restarts the shared `cio-api`.
+
+Tear down with `action = destroy`, `mode = frontend-only`, and the same branch.
 
 ## MinIO Storage
 
@@ -84,6 +111,8 @@ Railway's docs are thin on a couple of points the workflow depends on — confir
 
 ## Cost
 
-Every environment (staging + each preview) runs the full 6 services incl. a MinIO volume, so
-previews are not free while alive. Destroy them promptly — the teardown workflow handles PR
-close automatically; use `action = destroy` for previews whose PR is still open.
+Every full-stack environment (staging + each preview) runs the full 6 services incl. a
+MinIO volume, so previews are not free while alive. Destroy them promptly — the teardown
+workflow handles PR close automatically; use `action = destroy` for previews whose PR is
+still open. `frontend-only` previews are much cheaper — just one extra service — since they
+share staging's Postgres/Redis/MinIO instead of duplicating them.

--- a/PREVIEW_ENV.md
+++ b/PREVIEW_ENV.md
@@ -40,10 +40,12 @@ Two mechanisms, both enabled:
 - `seed` — also load the full demo dataset (`admin@test.com` etc.); migrations + essential
   seed always run on api boot regardless. Ignored outside `full_deploy` mode.
 
-The run prints the preview **Dashboard URL** in its job **summary**. The env (`full_deploy`)
-or service(s) (`frontend`/`frontend_backend`) are named `pr-<branch-slug>-<hash>[-suffix]` —
-an 8-character hash of the branch name is appended because the slug alone is lossy (e.g.
-`foo/bar` and `foo_bar` both slug to `foo-bar`).
+The run prints the preview **Dashboard URL** in its job **summary**. Everything is named off
+`pr-<branch-slug>-<hash>` — an 8-character hash of the branch name is appended because the
+slug alone is lossy (e.g. `foo/bar` and `foo_bar` both slug to `foo-bar`) — as an
+**environment** for `full_deploy`, a `pr-<branch-slug>-<hash>-dashboard` **service** for
+`frontend`, or both `pr-<branch-slug>-<hash>-dashboard` and `pr-<branch-slug>-<hash>-api`
+**services** for `frontend_backend`.
 
 The deploy step starts the app-service build(s) **in parallel** (each `railway up --ci`
 streams its build logs and blocks until that service passes its deploy/healthcheck), then
@@ -64,13 +66,13 @@ and auth session store with `cio-api` — anything created while testing (users,
 data) lands in the shared `staging` dataset, not a private sandbox. Use `full_deploy` mode
 instead when a change needs its own isolated backend/data.
 
-**One-time prerequisite:** `cio-api`'s `TRUSTED_ORIGINS` (read once at boot, comma-separated,
-supports `*` wildcards — see `apps/api/src/constants`) must include
-`https://*.up.railway.app` so every `frontend` preview's Railway-generated domain is
-trusted for CORS/session cookies. Add this once to staging's `cio-api` service (Railway
-dashboard, or `railway variables --service cio-api --set 'TRUSTED_ORIGINS=...'` appended to
-whatever's already set) — it's never touched per-PR, so creating/destroying a `frontend`
-preview never mutates or restarts the shared `cio-api`.
+**No manual setup needed.** The workflow trusts this preview's *exact* dashboard origin on
+staging `cio-api`'s `TRUSTED_ORIGINS` (comma-append, read once at boot — see
+`apps/api/src/constants`) when it deploys, and untrusts that exact origin again when it's
+destroyed. Deliberately not a `*.up.railway.app` wildcard — that would trust every app on
+that shared Railway domain suffix, not just this one. Cost: each `frontend` deploy/destroy
+redeploys the shared staging `cio-api` (variable changes redeploy by default), briefly
+affecting anyone else on staging at that moment.
 
 Tear down with `action = destroy`, `mode = frontend`, and the same branch.
 
@@ -86,8 +88,9 @@ Redis queue regardless of which api enqueued a job — no dedicated jobs service
 
 Because the new api and dashboard trust each other directly (`DASHBOARD_ORIGIN` on the new
 api references the new dashboard, the same way `full_deploy` previews' duplicated `cio-api`
-trusts its own duplicated dashboard), this mode needs **none** of `frontend` mode's
-`TRUSTED_ORIGINS` wildcard prerequisite.
+trusts its own duplicated dashboard), this mode never touches staging's shared `cio-api`
+`TRUSTED_ORIGINS` at all — no redeploy of shared staging on create/destroy, unlike
+`frontend` mode.
 
 Trade-offs:
 - **Not isolated**: same shared-Postgres/Redis/MinIO caveat as `frontend` mode — signups,

--- a/PREVIEW_ENV.md
+++ b/PREVIEW_ENV.md
@@ -33,14 +33,14 @@ Two mechanisms, both enabled:
 
 **Actions → "Railway Preview Environment" → Run workflow:**
 - `branch` — the branch/PR head to deploy.
-- `mode` — `full-deploy` (default) duplicates all of `staging`; `frontend_backend` creates a
+- `mode` — `full_deploy` (default) duplicates all of `staging`; `frontend_backend` creates a
   fresh dashboard+api pair inside `staging`, sharing its DB/Redis/MinIO; `frontend` creates
   just a dashboard service inside `staging`, wired to `staging`'s shared api (see below).
 - `action` — `deploy` (create/update) or `destroy` (delete).
 - `seed` — also load the full demo dataset (`admin@test.com` etc.); migrations + essential
-  seed always run on api boot regardless. Ignored outside `full-deploy` mode.
+  seed always run on api boot regardless. Ignored outside `full_deploy` mode.
 
-The run prints the preview **Dashboard URL** in its job **summary**. The env (`full-deploy`)
+The run prints the preview **Dashboard URL** in its job **summary**. The env (`full_deploy`)
 or service(s) (`frontend`/`frontend_backend`) are named `pr-<branch-slug>-<hash>[-suffix]` —
 an 8-character hash of the branch name is appended because the slug alone is lossy (e.g.
 `foo/bar` and `foo_bar` both slug to `foo-bar`).
@@ -61,7 +61,7 @@ environment, Postgres, Redis, or MinIO volume.
 
 Trade-off: this preview is **not isolated**. It shares staging's Postgres, Redis, MinIO,
 and auth session store with `cio-api` — anything created while testing (users, uploads, org
-data) lands in the shared `staging` dataset, not a private sandbox. Use `full-deploy` mode
+data) lands in the shared `staging` dataset, not a private sandbox. Use `full_deploy` mode
 instead when a change needs its own isolated backend/data.
 
 **One-time prerequisite:** `cio-api`'s `TRUSTED_ORIGINS` (read once at boot, comma-separated,
@@ -85,7 +85,7 @@ keeps handling background work for this preview too, since it reads off the same
 Redis queue regardless of which api enqueued a job — no dedicated jobs service is created.
 
 Because the new api and dashboard trust each other directly (`DASHBOARD_ORIGIN` on the new
-api references the new dashboard, the same way `full-deploy` previews' duplicated `cio-api`
+api references the new dashboard, the same way `full_deploy` previews' duplicated `cio-api`
 trusts its own duplicated dashboard), this mode needs **none** of `frontend` mode's
 `TRUSTED_ORIGINS` wildcard prerequisite.
 
@@ -95,7 +95,7 @@ Trade-offs:
 - **No new migrations**: the new api runs with `SKIP_DB_SETUP=true` (staging's own `cio-api`
   remains the one that migrates the shared schema — running migrations from two instances
   against the same live Postgres concurrently risks a race). **If your branch adds a new,
-  not-yet-applied DB migration, use `full-deploy` instead** — this mode won't apply it.
+  not-yet-applied DB migration, use `full_deploy` instead** — this mode won't apply it.
 
 Tear down with `action = destroy`, `mode = frontend_backend`, and the same branch.
 
@@ -116,7 +116,7 @@ Tear down with `action = destroy`, `mode = frontend_backend`, and the same branc
 
 ## Database behavior
 
-- **`full-deploy` previews** get their **own isolated Postgres** — they start fresh.
+- **`full_deploy` previews** get their **own isolated Postgres** — they start fresh.
   `cio-api` **self-migrates on boot** (`docker/entrypoint-api.sh` → `pnpm --filter @cio/db
   db:setup` → `drizzle-kit migrate` + essential seed). No manual migrate step needed. The
   branch must include a committed Drizzle migration (`pnpm --filter @cio/db db:generate`) —
@@ -140,7 +140,7 @@ Railway's docs are thin on a couple of points the workflow depends on — confir
 
 ## Cost
 
-Every `full-deploy` environment (staging + each preview) runs the full 6 services incl. a
+Every `full_deploy` environment (staging + each preview) runs the full 6 services incl. a
 MinIO volume, so previews are not free while alive. Destroy them promptly — the teardown
 workflow handles PR close automatically; use `action = destroy` for previews whose PR is
 still open. `frontend`/`frontend_backend` previews are much cheaper — one or two extra

--- a/PREVIEW_ENV.md
+++ b/PREVIEW_ENV.md
@@ -33,45 +33,71 @@ Two mechanisms, both enabled:
 
 **Actions → "Railway Preview Environment" → Run workflow:**
 - `branch` — the branch/PR head to deploy.
-- `mode` — `full-stack` (default) duplicates all of `staging`; `frontend-only` creates just
-  one dashboard-only service inside `staging` itself (see below).
+- `mode` — `full-deploy` (default) duplicates all of `staging`; `frontend_backend` creates a
+  fresh dashboard+api pair inside `staging`, sharing its DB/Redis/MinIO; `frontend` creates
+  just a dashboard service inside `staging`, wired to `staging`'s shared api (see below).
 - `action` — `deploy` (create/update) or `destroy` (delete).
 - `seed` — also load the full demo dataset (`admin@test.com` etc.); migrations + essential
-  seed always run on api boot regardless. Ignored in `frontend-only` mode.
+  seed always run on api boot regardless. Ignored outside `full-deploy` mode.
 
-The run prints the preview **Dashboard URL** in its job **summary**. The env (or, in
-`frontend-only` mode, the service) is named `pr-<branch-slug>-<hash>` — an 8-character hash
-of the branch name is appended because the slug alone is lossy (e.g. `foo/bar` and
-`foo_bar` both slug to `foo-bar`).
+The run prints the preview **Dashboard URL** in its job **summary**. The env (`full-deploy`)
+or service(s) (`frontend`/`frontend_backend`) are named `pr-<branch-slug>-<hash>[-suffix]` —
+an 8-character hash of the branch name is appended because the slug alone is lossy (e.g.
+`foo/bar` and `foo_bar` both slug to `foo-bar`).
 
 The deploy step starts the app-service build(s) **in parallel** (each `railway up --ci`
 streams its build logs and blocks until that service passes its deploy/healthcheck), then
 waits for all of them — so the printed URL is live the moment the run finishes, and a failed
 healthcheck fails the run rather than reporting a broken preview.
 
-#### `frontend-only` mode
+#### `frontend` mode
 
 Most changes only touch dashboard UI, so most previews don't need a whole duplicated stack.
-With `mode = frontend-only`, the workflow skips environment duplication entirely and
-instead creates **one new service**, `pr-<branch-slug>-<hash>-dashboard`, directly inside
-`staging` — built from the branch's `docker/Dockerfile.dashboard` and wired via Railway
-reference variables to `staging`'s already-running `cio-api` and `cio-minio`. No new
-project, environment, Postgres, Redis, or MinIO volume.
+With `mode = frontend`, the workflow skips environment duplication entirely and instead
+creates **one new service**, `pr-<branch-slug>-<hash>-dashboard`, directly inside `staging`
+— built from the branch's `docker/Dockerfile.dashboard` and wired via Railway reference
+variables to `staging`'s already-running `cio-api` and `cio-minio`. No new project,
+environment, Postgres, Redis, or MinIO volume.
 
 Trade-off: this preview is **not isolated**. It shares staging's Postgres, Redis, MinIO,
 and auth session store with `cio-api` — anything created while testing (users, uploads, org
-data) lands in the shared `staging` dataset, not a private sandbox. Use `full-stack` mode
+data) lands in the shared `staging` dataset, not a private sandbox. Use `full-deploy` mode
 instead when a change needs its own isolated backend/data.
 
 **One-time prerequisite:** `cio-api`'s `TRUSTED_ORIGINS` (read once at boot, comma-separated,
 supports `*` wildcards — see `apps/api/src/constants`) must include
-`https://*.up.railway.app` so every `frontend-only` preview's Railway-generated domain is
+`https://*.up.railway.app` so every `frontend` preview's Railway-generated domain is
 trusted for CORS/session cookies. Add this once to staging's `cio-api` service (Railway
 dashboard, or `railway variables --service cio-api --set 'TRUSTED_ORIGINS=...'` appended to
-whatever's already set) — it's never touched per-PR, so creating/destroying a
-`frontend-only` preview never mutates or restarts the shared `cio-api`.
+whatever's already set) — it's never touched per-PR, so creating/destroying a `frontend`
+preview never mutates or restarts the shared `cio-api`.
 
-Tear down with `action = destroy`, `mode = frontend-only`, and the same branch.
+Tear down with `action = destroy`, `mode = frontend`, and the same branch.
+
+#### `frontend_backend` mode
+
+For a change that touches both dashboard and API code but doesn't need its own isolated
+database. With `mode = frontend_backend`, the workflow creates **two new services**,
+`pr-<branch-slug>-<hash>-dashboard` and `pr-<branch-slug>-<hash>-api`, paired with each
+other — built from `docker/Dockerfile.dashboard`/`docker/Dockerfile.api` — but still
+pointed at `staging`'s shared Postgres, Redis, and MinIO. `staging`'s existing `cio-jobs`
+keeps handling background work for this preview too, since it reads off the same shared
+Redis queue regardless of which api enqueued a job — no dedicated jobs service is created.
+
+Because the new api and dashboard trust each other directly (`DASHBOARD_ORIGIN` on the new
+api references the new dashboard, the same way `full-deploy` previews' duplicated `cio-api`
+trusts its own duplicated dashboard), this mode needs **none** of `frontend` mode's
+`TRUSTED_ORIGINS` wildcard prerequisite.
+
+Trade-offs:
+- **Not isolated**: same shared-Postgres/Redis/MinIO caveat as `frontend` mode — signups,
+  uploads, and org data land in `staging`'s shared dataset.
+- **No new migrations**: the new api runs with `SKIP_DB_SETUP=true` (staging's own `cio-api`
+  remains the one that migrates the shared schema — running migrations from two instances
+  against the same live Postgres concurrently risks a race). **If your branch adds a new,
+  not-yet-applied DB migration, use `full-deploy` instead** — this mode won't apply it.
+
+Tear down with `action = destroy`, `mode = frontend_backend`, and the same branch.
 
 ## MinIO Storage
 
@@ -90,11 +116,14 @@ Tear down with `action = destroy`, `mode = frontend-only`, and the same branch.
 
 ## Database behavior
 
-- Each environment has its **own isolated Postgres** — previews start fresh.
-- `cio-api` **self-migrates on boot** (`docker/entrypoint-api.sh` → `pnpm --filter @cio/db
-  db:setup` → `drizzle-kit migrate` + essential seed). No manual migrate step needed.
-- **The branch must include a committed Drizzle migration** (`pnpm --filter @cio/db
-  db:generate`) — the boot path runs committed migrations only, not schema `push`.
+- **`full-deploy` previews** get their **own isolated Postgres** — they start fresh.
+  `cio-api` **self-migrates on boot** (`docker/entrypoint-api.sh` → `pnpm --filter @cio/db
+  db:setup` → `drizzle-kit migrate` + essential seed). No manual migrate step needed. The
+  branch must include a committed Drizzle migration (`pnpm --filter @cio/db db:generate`) —
+  the boot path runs committed migrations only, not schema `push`.
+- **`frontend`/`frontend_backend` previews share `staging`'s own Postgres** — no isolation,
+  and (for `frontend_backend`) the new api runs with `SKIP_DB_SETUP=true` so it never
+  migrates that shared schema itself. See each mode's section above for the trade-offs.
 
 ## Verify before relying on it (spike, do on a throwaway env)
 
@@ -111,8 +140,8 @@ Railway's docs are thin on a couple of points the workflow depends on — confir
 
 ## Cost
 
-Every full-stack environment (staging + each preview) runs the full 6 services incl. a
+Every `full-deploy` environment (staging + each preview) runs the full 6 services incl. a
 MinIO volume, so previews are not free while alive. Destroy them promptly — the teardown
 workflow handles PR close automatically; use `action = destroy` for previews whose PR is
-still open. `frontend-only` previews are much cheaper — just one extra service — since they
-share staging's Postgres/Redis/MinIO instead of duplicating them.
+still open. `frontend`/`frontend_backend` previews are much cheaper — one or two extra
+services — since they share staging's Postgres/Redis/MinIO instead of duplicating them.


### PR DESCRIPTION
## What does this PR do?

Adds a `frontend-only` mode to the Railway preview workflow. Instead of duplicating the whole `staging` environment (6 services), it creates one dashboard-only service (`pr-<slug>-<hash>-dashboard`) directly inside `staging`, wired via Railway reference variables to staging's existing `cio-api`/`cio-minio`. Use this when a change only touches dashboard UI and doesn't need an isolated backend.

`full-stack` mode (the existing behavior) is unchanged and stays the default.

**Requires one manual, one-time step before this is usable**: add `https://*.up.railway.app` to staging `cio-api`'s `TRUSTED_ORIGINS` variable, so frontend-only previews' Railway-generated domains pass CORS/session checks against the shared api. See `PREVIEW_ENV.md` for details.

Fixes # (place issue number here without bracket)

## Demo

<!-- video/screenshot -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [x] This change requires a documentation update

## How should this be tested?

- Add the `TRUSTED_ORIGINS` wildcard to staging `cio-api` (see `PREVIEW_ENV.md`)
- Run "Railway Preview Environment" with `mode = frontend-only`, `action = deploy` on a branch — confirm a service named `pr-<slug>-<hash>-dashboard` appears inside `staging` (not a new project/environment), gets a domain, builds, and loads with working login against the shared `cio-api`
- Confirm staging's other 5 services are untouched by the run
- Run `action = destroy` with the same branch + mode — confirm only the dashboard-only service is removed
- Re-run once with `mode = full-stack` to confirm no regression

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
- [x] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description — **this PR changes `.github/workflows/railway-preview.yml` and `.github/workflows/railway-preview-teardown.yml`**

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the ClassroomIO Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview deployments now support `full_deploy`, `frontend`, and `frontend_backend` modes.
  * Frontend-backend previews can run a dedicated API alongside the dashboard while sharing staging resources where applicable.
  * Shared staging APIs now allowlist each dashboard’s exact preview origin.
  * Deployment reports include relevant preview service URLs.
  * Cleanup supports all preview modes, including fork-created previews, and safely handles already-absent resources.

* **Documentation**
  * Updated preview guidance covering modes, resource sharing, prerequisites, teardown, migrations, and costs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a frontend-only Railway preview mode that creates a branch-specific dashboard service inside staging while retaining full-stack previews as the default.
- Creates, configures, deploys, reports, and destroys dashboard-only preview services.
- Extends automatic PR-close teardown to clean up either preview resource type.
- Documents shared staging resources, mode selection, cleanup, and the required trusted-origin configuration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified in the changed preview workflow or documentation.

The new mode preserves the existing full-stack path, scopes dashboard-only resources to staging, configures the required deployment inputs before upload, and provides matching manual and automatic cleanup.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/railway-preview.yml | Adds mode-aware creation, configuration, deployment, reporting, and manual cleanup for a dashboard-only Railway service. |
| .github/workflows/railway-preview-teardown.yml | Extends PR-close cleanup to attempt deletion of both full-stack environments and frontend-only services. |
| PREVIEW_ENV.md | Documents frontend-only previews, shared staging resources, trusted-origin setup, teardown, and cost trade-offs. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Dispatch[Railway preview workflow] --> Mode{Preview mode}
  Mode -->|full-stack| Environment[Duplicate staging environment]
  Environment --> FullDeploy[Deploy dashboard, API, and jobs]
  Mode -->|frontend-only| Service[Create dashboard service in staging]
  Service --> Configure[Configure domain and Railway references]
  Configure --> SharedAPI[Shared staging cio-api]
  Configure --> SharedMinIO[Shared staging cio-minio]
  Service --> DashboardDeploy[Deploy current branch dashboard]
  Close[PR close or destroy action] --> Cleanup{Cleanup resources}
  Cleanup --> DeleteEnvironment[Delete matching preview environment]
  Cleanup --> DeleteService[Delete matching staging dashboard service]
```

<sub>Reviews (1): Last reviewed commit: ["feat: add frontend-only mode for Railway..."](https://github.com/classroomio/classroomio/commit/0e20551061bf3585ced774e700ea842f382a35eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59475379)</sub>

<!-- /greptile_comment -->