### PR TITLE
feat(course): enable lesson version history

### DIFF
--- a/apps/dashboard/src/lib/features/course/pages/lesson.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/lesson.svelte
@@ -445,16 +445,6 @@
 
       <RoleBasedSecurity allowedRoles={[1, 2]}>
         <div class="flex flex-row items-center gap-2 lg:flex">
-          {#if mode === MODES.edit && window.innerWidth >= 1024}
-            <IconButton
-              onclick={() => (isVersionDrawerOpen = true)}
-              aria-label={$t('course.navItem.lessons.version_history.title')}
-              tooltip={$t('course.navItem.lessons.version_history.title')}
-            >
-              <HistoryIcon size={20} />
-            </IconButton>
-          {/if}
-
           {#if mode === MODES.edit}
             <span class="ui:text-muted-foreground text-sm" aria-live="polite">
               {#if lessonApi.isSaving}
@@ -471,6 +461,15 @@
               <Pencil size={20} />
             {/if}
           </IconButton>
+          {#if mode === MODES.edit && window.innerWidth >= 1024}
+            <IconButton
+              onclick={() => (isVersionDrawerOpen = true)}
+              aria-label={$t('course.navItem.lessons.version_history.title')}
+              tooltip={$t('course.navItem.lessons.version_history.title')}
+            >
+              <HistoryIcon size={20} />
+            </IconButton>
+          {/if}
         </div>
 
         <RefreshPageData onRefresh={() => lessonApi.get(courseId, lessonId)} />

--- a/apps/dashboard/src/lib/features/course/pages/lesson.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/lesson.svelte
@@ -10,7 +10,7 @@
   import { fade } from 'svelte/transition';
   import Save from '@lucide/svelte/icons/save';
   import Pencil from '@lucide/svelte/icons/pencil';
-  // import HistoryIcon from '@lucide/svelte/icons/history';
+  import HistoryIcon from '@lucide/svelte/icons/history';
   import VideoIcon from '@lucide/svelte/icons/video';
   import SettingsIcon from '@lucide/svelte/icons/settings';
 
@@ -445,13 +445,15 @@
 
       <RoleBasedSecurity allowedRoles={[1, 2]}>
         <div class="flex flex-row items-center gap-2 lg:flex">
-          <!--
           {#if mode === MODES.edit && window.innerWidth >= 1024}
-            <IconButton onclick={() => (isVersionDrawerOpen = true)}>
+            <IconButton
+              onclick={() => (isVersionDrawerOpen = true)}
+              aria-label={$t('course.navItem.lessons.version_history.title')}
+              tooltip={$t('course.navItem.lessons.version_history.title')}
+            >
               <HistoryIcon size={20} />
             </IconButton>
           {/if}
-          -->
 
           {#if mode === MODES.edit}
             <span class="ui:text-muted-foreground text-sm" aria-live="polite">


### PR DESCRIPTION
## Summary
- expose the existing lesson version-history drawer from lesson edit mode
- add a translated accessible label and tooltip to the history action
- keep the existing instructor/admin and desktop-only visibility rules

## Verification
- `pnpm format:changed`
- `pnpm format:check`
- `pnpm --filter @cio/dashboard^... build`
- `pnpm --filter @cio/dashboard build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Restored the version history button in the lesson editor header.
  - Added an accessible label and tooltip for the version history action.
  - The action is now positioned alongside the save control for easier access while editing lessons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR exposes the existing lesson-version history drawer to instructors and administrators in desktop edit mode, with a translated accessible label and tooltip.
- Imports and renders the Lucide history action.
- Opens the existing version-history drawer from the lesson action bar.
- Retains role, edit-mode, and desktop visibility conditions.

<h3>Confidence Score: 4/5</h3>

The PR is not safe to merge until the history action’s browser-only viewport check is replaced with an SSR-safe responsive mechanism.

A server-rendered edit-mode lesson evaluates the newly activated `window.innerWidth` expression and fails before the page can load.

**Files Needing Attention:** apps/dashboard/src/lib/features/course/pages/lesson.svelte

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/course/pages/lesson.svelte | Exposes the history action correctly, but its direct viewport read breaks server rendering for edit-mode lesson URLs and is not reactive to viewport changes. |

<sub>Reviews (1): Last reviewed commit: ["feat(course): enable lesson version hist..."](https://github.com/classroomio/classroomio/commit/f684cd990dcd776afa7596ce1661da370888b120) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59515685)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->