### PR TITLE
fix(dashboard): navigate from header setup icon and pending items

### DIFF
--- a/apps/dashboard/src/lib/features/setup/utils/setup-navigation.ts
+++ b/apps/dashboard/src/lib/features/setup/utils/setup-navigation.ts
@@ -1,0 +1,81 @@
+import { get } from 'svelte/store';
+import { goto } from '$app/navigation';
+import { currentOrg } from '$lib/utils/store/org';
+import { snackbar } from '$features/ui/snackbar/store';
+import { setupProgressApi } from '../api/setup-progress.svelte';
+import { goAndHighlight } from '$lib/routing/go-and-highlight';
+import { ROUTE_NAME, ROUTE_SECTIONS } from '$lib/routing/routes';
+
+export const SETUP_STEPS = {
+  UPDATE_PROFILE: 'profile',
+  UPDATE_ORG_PROFILE: 'organization',
+  CREATE_COURSE: 'course',
+  CREATE_LESSON: 'lesson',
+  CREATE_EXERCISE: 'exercise',
+  PUBLISH_COURSE: 'publish'
+} as const;
+
+export type SetupStepId = (typeof SETUP_STEPS)[keyof typeof SETUP_STEPS];
+
+export function getSetupPagePath(siteName: string): string {
+  return `/org/${siteName}/setup`;
+}
+
+function isStepCompleted(stepId: string): boolean {
+  return setupProgressApi.setupList.find((item) => item.id === stepId)?.is_completed === true;
+}
+
+export function goToSetupItem(id: string) {
+  const siteName = get(currentOrg).siteName;
+  if (!siteName) {
+    return;
+  }
+
+  const courses = setupProgressApi.progress.courses || [];
+  const lessons = setupProgressApi.progress.lessons || [];
+  const courseId = courses[0]?.id;
+  const lessonId = lessons[0]?.id;
+
+  switch (id) {
+    case SETUP_STEPS.CREATE_COURSE:
+      goto(`/org/${siteName}/courses?create=true`);
+      return;
+
+    case SETUP_STEPS.CREATE_LESSON:
+      if (isStepCompleted(SETUP_STEPS.CREATE_COURSE) && courseId) {
+        goto(`/courses/${courseId}/lessons`);
+        return;
+      }
+
+      snackbar.info('setup.info_course');
+      return;
+
+    case SETUP_STEPS.CREATE_EXERCISE:
+      if (isStepCompleted(SETUP_STEPS.CREATE_LESSON) && courseId && lessonId) {
+        goto(`/courses/${courseId}/lessons/${lessonId}`);
+        return;
+      }
+
+      snackbar.info('setup.info_lesson');
+      return;
+
+    case SETUP_STEPS.PUBLISH_COURSE:
+      if (isStepCompleted(SETUP_STEPS.CREATE_COURSE) && courseId) {
+        goAndHighlight(ROUTE_NAME.COURSE_SETTINGS, ROUTE_SECTIONS[ROUTE_NAME.COURSE_SETTINGS].PUBLISH, {
+          id: courseId
+        });
+        return;
+      }
+
+      snackbar.info('setup.info_course');
+      return;
+
+    case SETUP_STEPS.UPDATE_PROFILE:
+      goto(`/org/${siteName}/settings`);
+      return;
+
+    case SETUP_STEPS.UPDATE_ORG_PROFILE:
+      goto(`/org/${siteName}/settings/org`);
+      return;
+  }
+}

--- a/apps/dashboard/src/lib/features/ui/navigation/app-setup.svelte
+++ b/apps/dashboard/src/lib/features/ui/navigation/app-setup.svelte
@@ -9,11 +9,22 @@
   import { t } from '$lib/utils/functions/translations';
   import BadgeCheckIcon from '@lucide/svelte/icons/badge-check';
   import { calculateProgress, setupProgressApi } from '$features/setup/api/setup-progress.svelte';
+  import { getSetupPagePath, goToSetupItem } from '$features/setup/utils/setup-navigation';
+  import { goto } from '$app/navigation';
 
   function handleRefresh() {
     if ($currentOrg.siteName) {
       setupProgressApi.fetchSetupProgress($currentOrg.siteName);
     }
+  }
+
+  function handleSetupIconClick(event: MouseEvent) {
+    if (!setupPageHref || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
+
+    event.preventDefault();
+    goto(setupPageHref);
   }
 
   const setupList = $derived(
@@ -28,11 +39,18 @@
     })
   );
   const progressPercentage = $derived(calculateProgress(setupList));
+  const setupPageHref = $derived($currentOrg.siteName ? getSetupPagePath($currentOrg.siteName) : undefined);
 </script>
 
 {#if progressPercentage < 100}
   <HoverCard.Root openDelay={200}>
-    <HoverCard.Trigger class="hidden md:block">
+    <HoverCard.Trigger
+      href={setupPageHref}
+      class="hidden md:block"
+      aria-label={$t('org_navigation.setup')}
+      data-testid="app-setup-trigger"
+      onclick={handleSetupIconClick}
+    >
       <SetupProgress size="small" setupItems={setupList} />
     </HoverCard.Trigger>
     <HoverCard.Content class="hidden w-80 md:block">
@@ -47,15 +65,22 @@
           </div>
 
           {#each setupList as item (item.id)}
-            <div class="flex items-center gap-2 text-sm">
-              {#if item.is_completed}
+            {#if item.is_completed}
+              <div class="flex items-center gap-2 text-sm">
                 <BadgeCheckIcon class="custom size-4 shrink-0 text-green-600! opacity-50" />
                 <span class="ui:text-muted-foreground line-through opacity-50">{$t(item.title)}</span>
-              {:else}
+              </div>
+            {:else}
+              <button
+                type="button"
+                class="ui:hover:bg-accent flex w-full items-center gap-2 rounded-md px-1 py-1 text-left text-sm"
+                data-testid="app-setup-item-{item.id}"
+                onclick={() => goToSetupItem(item.id)}
+              >
                 <CircleIcon class="size-4 shrink-0 text-gray-400" />
                 <span>{$t(item.title)}</span>
-              {/if}
-            </div>
+              </button>
+            {/if}
           {/each}
         </div>
       {/if}

--- a/apps/dashboard/src/lib/features/ui/navigation/app-setup.svelte
+++ b/apps/dashboard/src/lib/features/ui/navigation/app-setup.svelte
@@ -11,12 +11,16 @@
   import { calculateProgress, setupProgressApi } from '$features/setup/api/setup-progress.svelte';
   import { getSetupPagePath, goToSetupItem } from '$features/setup/utils/setup-navigation';
   import { goto } from '$app/navigation';
+  import { page } from '$app/state';
 
   function handleRefresh() {
     if ($currentOrg.siteName) {
       setupProgressApi.fetchSetupProgress($currentOrg.siteName);
     }
   }
+
+  const setupSiteName = $derived($currentOrg.siteName || page.params.slug);
+  const setupPageHref = $derived(setupSiteName ? getSetupPagePath(setupSiteName) : undefined);
 
   function handleSetupIconClick(event: MouseEvent) {
     if (!setupPageHref || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
@@ -39,7 +43,6 @@
     })
   );
   const progressPercentage = $derived(calculateProgress(setupList));
-  const setupPageHref = $derived($currentOrg.siteName ? getSetupPagePath($currentOrg.siteName) : undefined);
 </script>
 
 {#if progressPercentage < 100}

--- a/apps/dashboard/src/routes/(app)/org/[slug]/setup/+page.svelte
+++ b/apps/dashboard/src/routes/(app)/org/[slug]/setup/+page.svelte
@@ -11,19 +11,14 @@
   import FileTextIcon from '@lucide/svelte/icons/file-text';
   import SetupProgress from '$features/setup/components/setup-progress.svelte';
 
-  import { currentOrg } from '$lib/utils/store/org';
-  import { goto } from '$app/navigation';
-  import { snackbar } from '$features/ui/snackbar/store';
   import { profile } from '$lib/utils/store/user';
   import { t } from '$lib/utils/functions/translations';
   import { setupProgressApi } from '$features/setup/api/setup-progress.svelte';
-  import { ROUTE_NAME, ROUTE_SECTIONS } from '$lib/routing/routes';
-  import { goAndHighlight } from '$lib/routing/go-and-highlight';
+  import { goToSetupItem, SETUP_STEPS } from '$features/setup/utils/setup-navigation';
 
   let { data } = $props();
 
   $effect(() => {
-    console.log('data', data);
     if (data.setupProgress && data.orgSiteName) {
       setupProgressApi.initializeFromServerData(data.setupProgress, data.orgSiteName);
     }
@@ -41,81 +36,8 @@
     })
   );
 
-  $effect(() => {
-    console.log('setup list', setupList);
-  });
-
   const completed = $derived(setupList.filter((list) => list.is_completed).length);
   const total = $derived(setupList.length);
-
-  const StepsEnum = {
-    UPDATE_PROFILE: 'profile',
-    UPDATE_ORG_PROFILE: 'organization',
-    CREATE_COURSE: 'course',
-    CREATE_LESSON: 'lesson',
-    CREATE_EXERCISE: 'exercise',
-    PUBLISH_COURSE: 'publish'
-  };
-
-  const isCompleted = (id: string) => {
-    return setupList?.find((c) => c.id === id)?.is_completed == true;
-  };
-
-  const handleClick = (id: string) => {
-    switch (id) {
-      case StepsEnum.CREATE_COURSE:
-        goto(`/org/${$currentOrg.siteName}/courses?create=true`);
-        break;
-
-      case StepsEnum.CREATE_LESSON:
-        if (isCompleted('course')) {
-          const courses = setupProgressApi.progress.courses || [];
-          const courseId = courses[0]?.id;
-          if (courseId) {
-            goto(`/courses/${courseId}/lessons`);
-          }
-        } else {
-          snackbar.info('setup.info_course');
-        }
-        break;
-
-      case StepsEnum.CREATE_EXERCISE:
-        if (isCompleted('lesson')) {
-          const courses = setupProgressApi.progress.courses || [];
-          const lessons = setupProgressApi.progress.lessons || [];
-          const courseId = courses[0]?.id;
-          const lessonId = lessons[0]?.id;
-          if (courseId && lessonId) {
-            goto(`/courses/${courseId}/lessons/${lessonId}`);
-          }
-        } else {
-          snackbar.info('setup.info_lesson');
-        }
-        break;
-
-      case StepsEnum.PUBLISH_COURSE:
-        if (isCompleted('course')) {
-          const courses = setupProgressApi.progress.courses || [];
-          const courseId = courses[0]?.id;
-          if (courseId) {
-            goAndHighlight(ROUTE_NAME.COURSE_SETTINGS, ROUTE_SECTIONS[ROUTE_NAME.COURSE_SETTINGS].PUBLISH, {
-              id: courseId
-            });
-          }
-        } else {
-          snackbar.info('setup.info_course');
-        }
-        break;
-
-      case StepsEnum.UPDATE_PROFILE:
-        goto(`/org/${$currentOrg.siteName}/settings`);
-        break;
-
-      case StepsEnum.UPDATE_ORG_PROFILE:
-        goto(`/org/${$currentOrg.siteName}/settings/org`);
-        break;
-    }
-  };
 </script>
 
 <svelte:head>
@@ -147,7 +69,7 @@
                 {$t('setup.completed')}
               </Item.Description>
               <div class="flex gap-1">
-                {#each Array(total) as _, i}
+                {#each Array(total) as _, i (i)}
                   <div
                     class="size-2 rounded-full {i < completed ? 'bg-green-600' : 'bg-gray-300 dark:bg-gray-600'}"
                   ></div>
@@ -159,22 +81,32 @@
 
         <!-- Setup Items -->
         <Item.Group class="space-y-2">
-          {#each setupList as list}
-            <Item.Root variant="muted" class={list.is_completed ? 'opacity-60' : ''}>
+          {#each setupList as list (list.id)}
+            <Item.Root
+              variant="muted"
+              class={list.is_completed ? 'opacity-60' : ''}
+              onclick={() => {
+                if (list.is_completed) {
+                  return;
+                }
+
+                goToSetupItem(list.id);
+              }}
+            >
               <Item.Media variant="icon">
                 {#if list.is_completed}
                   <div class="flex size-5 items-center justify-center rounded">
                     <BadgeCheckIcon class="size-5 text-white" />
                   </div>
-                {:else if list.id === StepsEnum.CREATE_COURSE}
+                {:else if list.id === SETUP_STEPS.CREATE_COURSE}
                   <BookOpenIcon class="size-5 text-gray-600" />
-                {:else if list.id === StepsEnum.CREATE_LESSON || list.id === StepsEnum.CREATE_EXERCISE}
+                {:else if list.id === SETUP_STEPS.CREATE_LESSON || list.id === SETUP_STEPS.CREATE_EXERCISE}
                   <FileTextIcon class="size-5 text-gray-600" />
-                {:else if list.id === StepsEnum.PUBLISH_COURSE}
+                {:else if list.id === SETUP_STEPS.PUBLISH_COURSE}
                   <GlobeIcon class="size-5 text-gray-600" />
-                {:else if list.id === StepsEnum.UPDATE_PROFILE}
+                {:else if list.id === SETUP_STEPS.UPDATE_PROFILE}
                   <UserPlusIcon class="size-5 text-gray-600" />
-                {:else if list.id === StepsEnum.UPDATE_ORG_PROFILE}
+                {:else if list.id === SETUP_STEPS.UPDATE_ORG_PROFILE}
                   <UsersIcon class="size-5 text-gray-600" />
                 {:else}
                   <BookOpenIcon class="size-5 text-gray-600" />
@@ -194,7 +126,7 @@
                     {$t('setup.done')}
                   </Button>
                 {:else}
-                  <Button variant="outline" size="sm" onclick={() => handleClick(list.id)} class="w-full sm:w-auto">
+                  <Button variant="outline" size="sm" type="button" class="w-full sm:w-auto">
                     {$t('setup.todo')}
                     <ChevronRightIcon class="ml-2 size-4" />
                   </Button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The header setup progress ring was hover-only: clicking it did not go anywhere, and checklist rows in the hover card were not links.

This change:

- Sends a click on the header setup icon to `/org/{siteName}/setup`
- Sends a click on a pending checklist item to that item’s destination (create course, lesson, exercise, publish settings, or profile/org settings)
- Shares that navigation from the setup page so both surfaces stay in sync
- Resolves the setup link from the org slug when the org store has not hydrated yet

## Demo

[Header setup progress ring before click](https://cursor.com/agents/bc-86e074df-989d-4d10-8faf-a0509b99dde5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsetup_nav_header_before_click.png)
[Setup page after clicking the header icon](https://cursor.com/agents/bc-86e074df-989d-4d10-8faf-a0509b99dde5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsetup_nav_setup_page.png)
[Checklist hover with pending organization item](https://cursor.com/agents/bc-86e074df-989d-4d10-8faf-a0509b99dde5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsetup_nav_checklist_hover.png)
[Organization settings after clicking the pending item](https://cursor.com/agents/bc-86e074df-989d-4d10-8faf-a0509b99dde5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsetup_nav_org_settings_from_page.png)
[setup_icon_and_pending_items_navigation.mp4](https://cursor.com/agents/bc-86e074df-989d-4d10-8faf-a0509b99dde5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsetup_icon_and_pending_items_navigation.mp4)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

1. Log in as an org admin with incomplete setup (seeded `admin@test.com` / `123456` works).
2. Click the circular setup progress icon in the top header. Confirm it opens `/org/{siteName}/setup`.
3. Hover the same icon, then click a pending checklist item. Confirm it lands on that step:
   - Profile picture → org settings profile page
   - Org picture → organization settings
   - Create course → courses page with the create modal
   - Create lesson / exercise → the first course/lesson when those exist; otherwise an info snackbar
   - Publish course → course settings with the publish section highlighted
4. On the setup page, click a pending row or its Todo button and confirm the same destinations.

Verified locally against the seeded `udemy-test` admin: header icon → setup page; pending “Update organisation profile picture” → `/org/udemy-test/settings/org`.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86e074df-989d-4d10-8faf-a0509b99dde5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86e074df-989d-4d10-8faf-a0509b99dde5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a centralized setup checklist with navigation to profile settings, course creation, lessons, exercises, and course publishing.
  - The setup icon now links directly to the organization’s setup page.
  - Incomplete checklist items are clickable and guide you to the next required step.
  - Added helpful snackbar guidance when prerequisites or required information are missing.
  - Completed setup items remain clearly marked and non-interactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes setup-checklist navigation and makes both the header progress control and pending setup rows actionable.
- Adds shared destination handling for profile, organization, course, lesson, exercise, and publishing steps.
- Links the header setup icon and hover-card checklist to setup destinations.
- Makes pending rows on the setup page clickable and removes duplicated navigation logic.

<h3>Confidence Score: 4/5</h3>

The organization-context fallback should be applied consistently before merging so header checklist clicks cannot silently fail during store hydration.

The header can render a valid setup link from the route slug while its newly added checklist actions depend exclusively on an asynchronously hydrated organization store, and the setup-page row enhancement is pointer-only outside the nested button.

**Files Needing Attention:** apps/dashboard/src/lib/features/setup/utils/setup-navigation.ts; apps/dashboard/src/routes/(app)/org/[slug]/setup/+page.svelte

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/setup/utils/setup-navigation.ts | Centralizes setup destinations, but item navigation silently exits when the current-organization store has not hydrated. |
| apps/dashboard/src/lib/features/ui/navigation/app-setup.svelte | Adds link behavior to the setup icon and pointer-accessible actions for pending hover-card items. |
| apps/dashboard/src/routes/(app)/org/[slug]/setup/+page.svelte | Reuses shared navigation and expands row click targets, but the clickable row itself lacks interactive semantics. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): resolve setup icon href ..."](https://github.com/classroomio/classroomio/commit/45f3853f6e1085a098c473907043f3bdc89831bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59581778)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->