### PR TITLE
fix(scripts): add missing kill-watchers.mjs referenced by dev scripts

### DIFF
--- a/DEV_SETUP_NOTES.md
+++ b/DEV_SETUP_NOTES.md
@@ -97,6 +97,14 @@ pnpm dashboard:dev    # dashboard UI (port 5173)
 > Don't use `pnpm dev` — it tries to start the whole monorepo (~20 services) and
 > currently trips a turbo concurrency limit. The two scoped commands above are the
 > day-to-day workflow.
+> Before starting the dashboard, kill leftover watchers from previous sessions
+> (`pnpm api:dev` alone leaves ~10: `tsc --watch` x3 + `tsx watch` x7). macOS caps
+> concurrent FSEvents streams system-wide, and past that cap the `@cio/ui` CSS
+> watcher crashes with `Error: Error starting FSEvents stream`, taking
+> `pnpm dashboard:dev` down with it. Use `pnpm dashboard:dev:fresh` (kills this
+> checkout's leftover watchers, then starts the dashboard), `pnpm dev:kill-watchers`
+> on its own, or `pnpm dev:kill-watchers --all` to also stop other projects'/checkouts'
+> watchers.
 
 ### Step 7 — Log in
 Open http://localhost:5173/login → `admin@test.com` / `123456`.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "db:backfill-profile-email-verification": "pnpm --filter @cio/db db:backfill-profile-email-verification",
     "dashboard:dev:full": "pnpm turbo run build --filter=@cio/dashboard^... --filter=@cio/ui^... && pnpm concurrently -n dashboard,ui -c blue,yellow \"pnpm --filter=@cio/dashboard run dev\" \"pnpm --filter=@cio/ui run dev\"",
     "dashboard:dev": "pnpm concurrently -n dashboard,ui -c blue,yellow \"pnpm --filter=@cio/dashboard run dev\" \"pnpm --filter=@cio/ui run dev\"",
+    "dashboard:dev:fresh": "pnpm dev:kill-watchers && pnpm dashboard:dev",
+    "dev:kill-watchers": "node scripts/kill-watchers.mjs",
     "api:dev:full": "pnpm turbo run build --filter=@cio/api^... --filter=@cio/jobs-worker^... && pnpm concurrently -n api,core,jobs -c blue,red,yellow \"pnpm --filter=@cio/api run dev\" \"pnpm --filter=@cio/core run dev\" \"pnpm --filter=@cio/jobs-worker run dev\"",
     "api:dev": "pnpm concurrently -n api,core,jobs -c blue,red,yellow \"pnpm --filter=@cio/api run dev\" \"pnpm --filter=@cio/core run dev\" \"pnpm --filter=@cio/jobs-worker run dev\"",
     "jobs:dev": "pnpm --filter=@cio/jobs-worker run dev",

--- a/scripts/kill-watchers.mjs
+++ b/scripts/kill-watchers.mjs
@@ -1,0 +1,53 @@
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+
+if (process.platform === 'win32') {
+  console.log('kill-watchers only supports macOS/Linux, skipping.');
+  process.exit(0);
+}
+
+const killAll = process.argv.includes('--all');
+const repoRoot = realpathSync(process.cwd());
+
+const WATCHER_PATTERNS = [/\btsc\b.*--watch/, /\btsx\b.*\bwatch\b/, /\bvite\b/, /\btailwindcss\b.*--watch/];
+
+const psOutput = execFileSync('ps', ['-axo', 'pid=,command='], {
+  encoding: 'utf8',
+  maxBuffer: 10 * 1024 * 1024
+});
+
+const staleWatchers = [];
+
+for (const line of psOutput.split('\n')) {
+  const trimmedLine = line.trim();
+  if (!trimmedLine) continue;
+
+  const firstSpaceIndex = trimmedLine.indexOf(' ');
+  const pid = Number(trimmedLine.slice(0, firstSpaceIndex));
+  const command = trimmedLine.slice(firstSpaceIndex + 1).trim();
+
+  if (!Number.isInteger(pid) || pid === process.pid) continue;
+  if (!killAll && !command.includes(repoRoot)) continue;
+  if (!WATCHER_PATTERNS.some((pattern) => pattern.test(command))) continue;
+
+  staleWatchers.push({ pid, command });
+}
+
+if (staleWatchers.length === 0) {
+  console.log('No leftover watcher processes found.');
+  process.exit(0);
+}
+
+for (const watcher of staleWatchers) {
+  try {
+    process.kill(watcher.pid, 'SIGTERM');
+    console.log(`Killed ${watcher.pid}: ${watcher.command}`);
+  } catch (error) {
+    if (error.code === 'ESRCH') continue;
+
+    console.error(`Failed to kill ${watcher.pid}: ${error.message}`);
+  }
+}
+
+console.log(`\nKilled ${staleWatchers.length} leftover watcher process(es) from this checkout.`);
+console.log('Tip: run with --all to also stop watchers from other projects/checkouts.');


### PR DESCRIPTION
## Summary

- **Added the missing `scripts/kill-watchers.mjs`** that `dashboard:dev:fresh` and `dev:kill-watchers` depend on. On macOS, `pnpm api:dev` leaves ~10 watcher processes (`tsc --watch` x3 + `tsx watch` x7), and once the system-wide FSEvents stream cap is hit, the `@cio/ui` CSS watcher crashes with `Error: Error starting FSEvents stream`, taking `pnpm dashboard:dev` down. `dashboard:dev:fresh` kills these leftover watchers before starting, or run `dev:kill-watchers` / `dev:kill-watchers --all` independently.
- Added the `dashboard:dev:fresh` and `dev:kill-watchers` scripts to `package.json` and documented them in `DEV_SETUP_NOTES.md`.

## Test plan

- [x] `node --check scripts/kill-watchers.mjs` passes syntax check
- [x] `pnpm format:check` passes
- [ ] `pnpm dashboard:dev:fresh` successfully kills stale watchers and starts the dashboard

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds the missing watcher-cleanup utility, wires it into root development scripts, and documents the new workflow. The cleanup currently cannot distinguish stale watchers from active same-checkout processes and uses an imprecise checkout ownership match.
- Adds `scripts/kill-watchers.mjs` to enumerate and terminate `tsc`, `tsx`, Vite, and Tailwind watcher processes.
- Adds standalone and dashboard-prefixed cleanup commands to `package.json`.
- Documents the macOS FSEvents motivation and watcher-cleanup commands.

<h3>Confidence Score: 4/5</h3>

The active-watcher selection needs to be fixed before merging because the documented fresh-dashboard command can terminate the API session it depends on.

The cleanup classifies processes only by checkout-path substring and watcher command pattern, so an active `api:dev` session satisfies every filter and is terminated; the substring ownership check can also affect similarly named sibling checkouts.

**Files Needing Attention:** scripts/kill-watchers.mjs, package.json, DEV_SETUP_NOTES.md

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/kill-watchers.mjs | Adds watcher discovery and SIGTERM cleanup, but the selection logic can terminate active same-checkout watchers and prefix-matching sibling checkouts. |
| package.json | Adds cleanup commands whose fresh-dashboard composition exposes the active-watcher termination path. |
| DEV_SETUP_NOTES.md | Documents the cleanup workflow in a way that permits invoking it while the API development session remains active. |

<sub>Reviews (1): Last reviewed commit: ["fix(scripts): add missing kill-watchers...."](https://github.com/classroomio/classroomio/commit/eccdc8ba9e566ba7a48110cb8cadbb4875fd647d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59718787)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added macOS troubleshooting guidance for startup failures caused by exceeding file-watcher limits.
  * Documented commands for cleaning up leftover watcher processes, including a global cleanup option.

* **Chores**
  * Added a fresh dashboard development startup command that automatically clears stale watchers before launching.
  * Added tooling to identify and stop leftover development watchers from the current checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->