### PR TITLE
ci: apply database migrations on merge, and verify them on PRs

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -31,11 +31,13 @@ jobs:
     timeout-minutes: 20
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20.19.3
           cache: 'pnpm'
@@ -58,15 +60,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
         run: |
-          COUNT=$(node -e "
-            const postgres = require('postgres');
-            (async () => {
-              const sql = postgres(process.env.DATABASE_URL, { max: 1 });
-              const rows = await sql\`select count(*)::int n from drizzle.__drizzle_migrations\`.catch(() => [{ n: 0 }]);
-              process.stdout.write(String(rows[0].n));
-              await sql.end();
-            })();
-          ")
+          COUNT=$(pnpm --silent db:ledger count)
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "applied before: $COUNT"
 
@@ -76,27 +70,17 @@ jobs:
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
         run: pnpm db:migrate
 
-      # `drizzle-kit migrate` reports success even when it applied nothing, so
-      # compare the ledger before and after rather than trusting the exit code.
-      - name: Report what was applied
+      # `drizzle-kit migrate` reports success even when it applied nothing, and
+      # equal row counts can still be different migrations — so compare the
+      # recorded hashes against the journal.
+      - name: Verify every migration is recorded
         working-directory: packages/db
         env:
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
           BEFORE: ${{ steps.before.outputs.count }}
         run: |
-          AFTER=$(node -e "
-            const postgres = require('postgres');
-            (async () => {
-              const sql = postgres(process.env.DATABASE_URL, { max: 1 });
-              const rows = await sql\`select count(*)::int n from drizzle.__drizzle_migrations\`;
-              process.stdout.write(String(rows[0].n));
-              await sql.end();
-            })();
-          ")
-          JOURNAL=$(node -e "process.stdout.write(String(require('./src/migrations/meta/_journal.json').entries.length))")
-          echo "applied before: $BEFORE"
-          echo "applied after:  $AFTER"
-          echo "journal entries: $JOURNAL"
+          pnpm --silent db:ledger verify | tee ledger.txt
+          AFTER=$(pnpm --silent db:ledger count)
           {
             echo "### Database migrations"
             echo ""
@@ -104,11 +88,10 @@ jobs:
             echo "|---|---|"
             echo "| applied before | $BEFORE |"
             echo "| applied after | $AFTER |"
-            echo "| journal entries | $JOURNAL |"
             echo "| newly applied | $((AFTER - BEFORE)) |"
+            echo ""
+            echo '```'
+            cat ledger.txt
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-
-          if [ "$AFTER" -ne "$JOURNAL" ]; then
-            echo "Ledger ($AFTER) does not match the journal ($JOURNAL) — some migrations did not apply." >&2
-            exit 1
-          fi
+          rm -f ledger.txt

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,114 @@
+name: Apply database migrations
+
+# Applies pending drizzle migrations to production when a migration lands on main.
+# Gated by the `production` environment, so required reviewers (if configured)
+# must approve before it touches the database.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/db/src/migrations/**'
+      - '.github/workflows/db-migrate.yml'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why this is being run manually'
+        required: false
+
+permissions:
+  contents: read
+
+# Never run two migrations at once, and never cancel one midway.
+concurrency:
+  group: db-migrate-production
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.3
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check the connection string is configured
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "PROD_DATABASE_URL is not set on the production environment." >&2
+            exit 1
+          fi
+
+      - name: Record migrations already applied
+        id: before
+        working-directory: packages/db
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+        run: |
+          COUNT=$(node -e "
+            const postgres = require('postgres');
+            (async () => {
+              const sql = postgres(process.env.DATABASE_URL, { max: 1 });
+              const rows = await sql\`select count(*)::int n from drizzle.__drizzle_migrations\`.catch(() => [{ n: 0 }]);
+              process.stdout.write(String(rows[0].n));
+              await sql.end();
+            })();
+          ")
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "applied before: $COUNT"
+
+      - name: Apply migrations
+        working-directory: packages/db
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+        run: pnpm db:migrate
+
+      # `drizzle-kit migrate` reports success even when it applied nothing, so
+      # compare the ledger before and after rather than trusting the exit code.
+      - name: Report what was applied
+        working-directory: packages/db
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          BEFORE: ${{ steps.before.outputs.count }}
+        run: |
+          AFTER=$(node -e "
+            const postgres = require('postgres');
+            (async () => {
+              const sql = postgres(process.env.DATABASE_URL, { max: 1 });
+              const rows = await sql\`select count(*)::int n from drizzle.__drizzle_migrations\`;
+              process.stdout.write(String(rows[0].n));
+              await sql.end();
+            })();
+          ")
+          JOURNAL=$(node -e "process.stdout.write(String(require('./src/migrations/meta/_journal.json').entries.length))")
+          echo "applied before: $BEFORE"
+          echo "applied after:  $AFTER"
+          echo "journal entries: $JOURNAL"
+          {
+            echo "### Database migrations"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| applied before | $BEFORE |"
+            echo "| applied after | $AFTER |"
+            echo "| journal entries | $JOURNAL |"
+            echo "| newly applied | $((AFTER - BEFORE)) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$AFTER" -ne "$JOURNAL" ]; then
+            echo "Ledger ($AFTER) does not match the journal ($JOURNAL) — some migrations did not apply." >&2
+            exit 1
+          fi

--- a/.github/workflows/db-migration-check.yml
+++ b/.github/workflows/db-migration-check.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'packages/db/src/migrations/**'
       - 'packages/db/src/schema.ts'
+      - 'packages/db/drizzle.config.ts'
       - '.github/workflows/db-migration-check.yml'
 
 permissions:
@@ -37,11 +38,13 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/migration_check
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20.19.3
           cache: 'pnpm'
@@ -80,33 +83,16 @@ jobs:
 
       - name: Ledger must match the journal
         working-directory: packages/db
+        run: pnpm --silent db:ledger verify
+
+      # drizzle applies only entries newer than the newest already applied, so a
+      # journal entry dated before one that precedes it is silently skipped.
+      # `main` carries one such inversion from before this was checked, so only
+      # entries added by this PR are enforced.
+      - name: New journal entries must be newest and not future-dated
+        working-directory: packages/db
         run: |
-          node -e "
-            const postgres = require('postgres');
-            const journal = require('./src/migrations/meta/_journal.json').entries;
-            (async () => {
-              const sql = postgres(process.env.DATABASE_URL, { max: 1 });
-              const [{ n }] = await sql\`select count(*)::int n from drizzle.__drizzle_migrations\`;
-              await sql.end();
-              console.log('journal entries:', journal.length, '| applied:', n);
-
-              if (n !== journal.length) {
-                console.error('Applied count does not match the journal.');
-                process.exit(1);
-              }
-
-              // drizzle applies only entries newer than the newest already
-              // applied, so a timestamp out of order is silently skipped.
-              const whens = journal.map((e) => e.when);
-              const newest = Math.max(...whens);
-              const last = whens[whens.length - 1];
-              if (last !== newest) {
-                console.error('The last journal entry is not the newest; later migrations would be skipped.');
-                process.exit(1);
-              }
-              if (last > Date.now()) {
-                console.error('The last journal entry is dated in the future; migrations authored before then would be skipped.');
-                process.exit(1);
-              }
-            })();
-          "
+          git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
+          git show "FETCH_HEAD:packages/db/src/migrations/meta/_journal.json" > "$RUNNER_TEMP/base-journal.json" \
+            || echo '{"entries":[]}' > "$RUNNER_TEMP/base-journal.json"
+          pnpm --silent db:journal-check "$RUNNER_TEMP/base-journal.json"

--- a/.github/workflows/db-migration-check.yml
+++ b/.github/workflows/db-migration-check.yml
@@ -1,0 +1,112 @@
+name: Database migration check
+
+# Proves migrations apply to an empty database and that the journal, snapshots
+# and schema agree — before a migration can reach main. No production access.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/db/src/migrations/**'
+      - 'packages/db/src/schema.ts'
+      - '.github/workflows/db-migration-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: migration_check
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/migration_check
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.3
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate the migration chain
+        working-directory: packages/db
+        run: pnpm exec drizzle-kit check
+
+      - name: Apply every migration to an empty database
+        working-directory: packages/db
+        run: pnpm db:migrate
+
+      - name: Applying twice must be a no-op
+        working-directory: packages/db
+        run: pnpm db:migrate
+
+      # A migration whose effects don't match `schema.ts` means the next
+      # `generate` produces a diff that re-applies work already done.
+      # `generate` prompts when a change is ambiguous (created vs renamed), which
+      # would hang with no TTY — so cap it and treat a hang as drift.
+      - name: Schema must match the migrations
+        working-directory: packages/db
+        timeout-minutes: 3
+        run: |
+          OUTPUT=$(pnpm exec drizzle-kit generate --name=ci_drift_probe < /dev/null 2>&1) || true
+          echo "$OUTPUT"
+          if ! echo "$OUTPUT" | grep -q "No schema changes"; then
+            echo "" >&2
+            echo "schema.ts has changes not captured by a migration." >&2
+            echo "Run: pnpm --filter @cio/db db:generate" >&2
+            exit 1
+          fi
+
+      - name: Ledger must match the journal
+        working-directory: packages/db
+        run: |
+          node -e "
+            const postgres = require('postgres');
+            const journal = require('./src/migrations/meta/_journal.json').entries;
+            (async () => {
+              const sql = postgres(process.env.DATABASE_URL, { max: 1 });
+              const [{ n }] = await sql\`select count(*)::int n from drizzle.__drizzle_migrations\`;
+              await sql.end();
+              console.log('journal entries:', journal.length, '| applied:', n);
+
+              if (n !== journal.length) {
+                console.error('Applied count does not match the journal.');
+                process.exit(1);
+              }
+
+              // drizzle applies only entries newer than the newest already
+              // applied, so a timestamp out of order is silently skipped.
+              const whens = journal.map((e) => e.when);
+              const newest = Math.max(...whens);
+              const last = whens[whens.length - 1];
+              if (last !== newest) {
+                console.error('The last journal entry is not the newest; later migrations would be skipped.');
+                process.exit(1);
+              }
+              if (last > Date.now()) {
+                console.error('The last journal entry is dated in the future; migrations authored before then would be skipped.');
+                process.exit(1);
+              }
+            })();
+          "

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -58,6 +58,8 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:baseline": "tsx src/scripts/baseline.ts",
+    "db:ledger": "tsx src/scripts/migration-ledger.ts",
+    "db:journal-check": "tsx src/scripts/check-journal-order.ts",
     "db:reset": "tsx src/scripts/db-reset.ts --skip-seed",
     "db:setup": "tsx src/scripts/db-setup.ts",
     "db:setup:seed": "tsx src/scripts/db-setup.ts --seed",

--- a/packages/db/src/scripts/check-journal-order.ts
+++ b/packages/db/src/scripts/check-journal-order.ts
@@ -1,0 +1,84 @@
+import fs from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '../migrations');
+
+interface JournalEntry {
+  idx: number;
+  when: number;
+  tag: string;
+}
+
+function readEntries(path: string): JournalEntry[] {
+  if (!fs.existsSync(path)) return [];
+
+  return (JSON.parse(fs.readFileSync(path, 'utf8')) as { entries?: JournalEntry[] }).entries ?? [];
+}
+
+/**
+ * drizzle applies only journal entries newer than the newest one already
+ * applied, so an entry dated at or before one that precedes it in the journal
+ * is silently skipped — as is every entry authored before a future-dated one.
+ *
+ * Only entries absent from `baseEntries` are checked: existing history may
+ * contain inversions that predate this rule, and rewriting their timestamps
+ * would change hashes of migrations that have already run.
+ */
+export function findJournalOrderProblems(
+  headEntries: JournalEntry[],
+  baseEntries: JournalEntry[],
+  now: number
+): string[] {
+  const baseTags = new Set(baseEntries.map((entry) => entry.tag));
+  const problems: string[] = [];
+
+  headEntries.forEach((entry, index) => {
+    if (baseTags.has(entry.tag)) return;
+
+    const precedingMax = Math.max(0, ...headEntries.slice(0, index).map((preceding) => preceding.when));
+
+    if (entry.when <= precedingMax) {
+      problems.push(
+        `${entry.tag}: when=${entry.when} is not newer than an earlier entry (${precedingMax}); drizzle would skip it`
+      );
+    }
+
+    if (entry.when > now) {
+      problems.push(
+        `${entry.tag}: when=${entry.when} is in the future; every migration authored before then would be skipped`
+      );
+    }
+  });
+
+  return problems;
+}
+
+const invokedDirectly = fileURLToPath(import.meta.url) === resolve(process.argv[1] ?? '');
+
+if (invokedDirectly) {
+  const basePath = process.argv[2];
+
+  if (!basePath) {
+    console.error('Usage: tsx src/scripts/check-journal-order.ts <base-journal.json>');
+    process.exit(1);
+  }
+
+  const headEntries = readEntries(resolve(migrationsDir, 'meta/_journal.json'));
+  const baseEntries = readEntries(basePath);
+  const added = headEntries.filter((entry) => !new Set(baseEntries.map((e) => e.tag)).has(entry.tag));
+
+  if (added.length === 0) {
+    console.log('no new journal entries');
+    process.exit(0);
+  }
+
+  const problems = findJournalOrderProblems(headEntries, baseEntries, Date.now());
+
+  if (problems.length > 0) {
+    problems.forEach((problem) => console.error(problem));
+    process.exit(1);
+  }
+
+  console.log(`ok: ${added.map((entry) => entry.tag).join(', ')}`);
+}

--- a/packages/db/src/scripts/migration-ledger.ts
+++ b/packages/db/src/scripts/migration-ledger.ts
@@ -1,0 +1,116 @@
+import 'dotenv/config';
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import postgres from 'postgres';
+
+const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '../migrations');
+
+interface JournalEntry {
+  idx: number;
+  when: number;
+  tag: string;
+}
+
+/** Same hash drizzle-orm records: sha256 of the raw `<tag>.sql` contents. */
+export function readJournal(): { tag: string; when: number; hash: string }[] {
+  const journalPath = resolve(migrationsDir, 'meta/_journal.json');
+  const { entries } = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as { entries: JournalEntry[] };
+
+  return entries.map((entry) => ({
+    tag: entry.tag,
+    when: entry.when,
+    hash: crypto
+      .createHash('sha256')
+      .update(fs.readFileSync(resolve(migrationsDir, `${entry.tag}.sql`), 'utf8'))
+      .digest('hex')
+  }));
+}
+
+/**
+ * Hashes recorded in `drizzle.__drizzle_migrations`.
+ *
+ * A missing ledger means "nothing applied yet" and is reported as an empty
+ * array. Every other failure — auth, TLS, host — is rethrown, because treating
+ * it as an empty ledger would make a broken connection look like a fresh
+ * database and let a comparison pass for the wrong reason.
+ */
+export async function readAppliedHashes(sql: postgres.Sql): Promise<string[]> {
+  try {
+    const rows = await sql<{ hash: string }[]>`
+      SELECT hash FROM drizzle.__drizzle_migrations ORDER BY created_at
+    `;
+
+    return rows.map((row) => row.hash);
+  } catch (error) {
+    const code = (error as { code?: string }).code;
+    // 42P01 undefined_table, 3F000 invalid_schema_name
+    if (code === '42P01' || code === '3F000') return [];
+
+    throw error;
+  }
+}
+
+export interface LedgerComparison {
+  applied: number;
+  expected: number;
+  missing: string[];
+  unknown: string[];
+}
+
+/** Compares by hash, not by count: equal totals can still be different migrations. */
+export function compareLedger(journal: ReturnType<typeof readJournal>, appliedHashes: string[]): LedgerComparison {
+  const appliedSet = new Set(appliedHashes);
+  const journalSet = new Set(journal.map((entry) => entry.hash));
+
+  return {
+    applied: appliedHashes.length,
+    expected: journal.length,
+    missing: journal.filter((entry) => !appliedSet.has(entry.hash)).map((entry) => entry.tag),
+    unknown: appliedHashes.filter((hash) => !journalSet.has(hash))
+  };
+}
+
+const invokedDirectly = fileURLToPath(import.meta.url) === resolve(process.argv[1] ?? '');
+
+if (invokedDirectly) {
+  const mode = process.argv[2] ?? 'report';
+  const connectionString = process.env.DATABASE_URL ?? process.env.PRIVATE_DATABASE_URL ?? '';
+
+  if (!connectionString) {
+    console.error('DATABASE_URL or PRIVATE_DATABASE_URL is required');
+    process.exit(1);
+  }
+
+  const sql = postgres(connectionString, { max: 1 });
+
+  try {
+    const journal = readJournal();
+    const applied = await readAppliedHashes(sql);
+    const result = compareLedger(journal, applied);
+
+    if (mode === 'count') {
+      process.stdout.write(String(result.applied));
+    } else {
+      console.log(`applied: ${result.applied}  expected: ${result.expected}`);
+
+      if (result.missing.length > 0) console.log('not applied:', result.missing.join(', '));
+
+      // A recorded hash with no journal entry means a migration file was edited
+      // or removed after it ran. Worth surfacing, but it does not mean the
+      // pending migrations failed, so it should not fail a deploy.
+      if (result.unknown.length > 0) {
+        console.warn(`warning: ${result.unknown.length} recorded migration(s) no longer match a file in the journal`);
+      }
+
+      if (mode === 'verify' && result.missing.length > 0) {
+        console.error('\nSome migrations in the journal were not applied.');
+        process.exit(1);
+      }
+    }
+  } finally {
+    await sql.end();
+  }
+}


### PR DESCRIPTION
## Why

Migrations have been applied to production by hand. That is how `drizzle-kit push` came to be used there — and push applies DDL while skipping a migration's data steps, which is what left `lesson_language_history` mid-migration and took lesson saving down (#1041).

Two workflows: one applies migrations on merge, one proves they are safe before merge.

## `db-migrate.yml` — applies on merge

Triggers on a push to `main` that touches `packages/db/src/migrations/**`, plus `workflow_dispatch` for manual runs.

- **Gated by `environment: production`**, matching `deploy-storybook` and `deploy-embeds`, so required reviewers apply if configured.
- **`concurrency` with `cancel-in-progress: false`** — two migrations never run at once, and one is never cancelled midway.
- **Verifies rather than trusting the exit code.** `drizzle-kit migrate` reports `migrations applied successfully` even when it applied *nothing* — that happened on this database, where every entry sorted below the ledger's newest timestamp and was silently skipped. The job records the applied count before and after, writes both to the job summary, and **fails if the final count does not match the journal**.

### Setup required before this can run

Add `PROD_DATABASE_URL` as a secret on the `production` environment. The job fails fast with a clear message if it is missing, rather than connecting somewhere unintended.

Recommended: configure **required reviewers** on that environment so a human approves before a migration touches production.

## `db-migration-check.yml` — verifies on PRs

Runs against a throwaway `postgres:16` service container. No production access, no secrets.

| Check | Catches |
|---|---|
| `drizzle-kit check` | broken journal/snapshot chain |
| apply all migrations to an empty database | a migration that cannot apply from scratch |
| apply them a second time | non-idempotent migrations |
| `generate` reports no schema changes | `schema.ts` drift not captured by a migration |
| ledger count equals journal length | a migration that silently did not apply |
| last journal entry is the newest, and not in the future | **a journal timestamp that makes drizzle skip later migrations** |

That last check is not hypothetical. #1034 carried a hand-written journal entry dated 2.4 days in the future; because drizzle only applies entries newer than the last applied one, every migration authored before that date would have been skipped without error. This rejects it at PR time.

The `generate` step passes `< /dev/null` and a 3-minute timeout, since it prompts interactively on ambiguous diffs and would otherwise hang with no TTY.

## Verification

- Both files parse as valid YAML; jobs, triggers, environment, concurrency and timeouts confirmed
- The journal guard was exercised against known-bad inputs and correctly rejects a count mismatch, a future-dated entry, and an out-of-order entry, while passing the real journal

## Not included

Applying migrations still requires someone to merge. If you would rather this ran automatically as part of the Render deploy instead of on merge, that is a different shape and worth deciding before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added automated production database migration runs when migration changes reach the main branch or are manually triggered.
  - Added migration tracking and verification to report pending or newly applied migrations.

- **Tests**
  - Added pull-request checks for migration consistency, idempotency, schema alignment, and migration history ordering.
  - Checks detect skipped or future-dated migrations and run only for database-related changes with read-only repository access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a production workflow that applies Drizzle migrations after migration changes reach `main`, plus a pull-request workflow that validates migration application, schema drift, ledger counts, and journal timestamps.
- Serializes production migration runs and gates them through the production environment.
- Applies migrations twice against disposable PostgreSQL during pull-request checks.
- Verifies the migration ledger against the checked-in journal.
- The production path omits the repository's required existing-database baseline reconciliation.

<h3>Confidence Score: 4/5</h3>

The production migration workflow should not merge until it reconciles the documented existing-database migration states before invoking Drizzle.

The new production path calls `drizzle-kit migrate` directly even though the repository's baseline logic documents that push-managed and pre-squash databases otherwise try to recreate existing schema objects and fail before pending migrations are applied; mutable action references add a separate non-blocking supply-chain concern.

**Files Needing Attention:** .github/workflows/db-migrate.yml

<details open><summary><h3>Security Review</h3></summary>

The production workflow references its setup actions through mutable major-version tags. Pinning those actions to reviewed commit SHAs would prevent an upstream tag change from substituting code inside the production-credentialed job.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/db-migrate.yml | Adds serialized, environment-gated production migration automation, but bypasses the existing baseline reconciliation required for push-managed and pre-squash databases. |
| .github/workflows/db-migration-check.yml | Adds useful disposable-database migration, drift, ledger, and timestamp checks; no independently blocking defect was established in this file. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Merge[Migration merged to main] --> Gate[Production environment approval]
  Gate --> Install[Install dependencies]
  Install --> CountBefore[Read production ledger]
  CountBefore --> Migrate[Run drizzle-kit migrate]
  Migrate --> CountAfter[Compare ledger with journal]
  Existing[(Existing production schema)] -. requires baseline adoption .-> Migrate
  Migrate -->|baseline appears pending| Collision[Existing table or type collision]
  Migrate -->|history reconciled| Applied[Pending migrations applied]
```

<sub>Reviews (1): Last reviewed commit: ["ci: apply database migrations on merge, ..."](https://github.com/classroomio/classroomio/commit/45f103ff32b745164164137a688033cf9b16334b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59766203)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Database model and access](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/database-model-and-access.md)

<!-- /greptile_comment -->