### PR TITLE
fix: de-cluster analytics trend bar 

### DIFF
--- a/apps/dashboard/src/lib/features/analytics/components/trend-chart.svelte
+++ b/apps/dashboard/src/lib/features/analytics/components/trend-chart.svelte
@@ -15,13 +15,34 @@
   import { t } from '$lib/utils/functions/translations';
   import AnalyticsPanelCard from './analytics-panel-card.svelte';
   import type { LandingStatsData } from '../utils/types';
+  import { bucketSparkline, formatChartTooltipDate, getBucketSize, zeroFillRange } from '../utils/analytics-utils';
 
   interface Props {
     data: LandingStatsData | null;
     loading?: boolean;
+    range?: 7 | 30 | 90;
   }
 
-  let { data, loading = false }: Props = $props();
+  let { data, loading = false, range }: Props = $props();
+
+  let containerRef = $state<HTMLDivElement | null>(null);
+  let containerWidth = $state<number>(800);
+
+  $effect(() => {
+    const element = containerRef;
+    if (!element || !browser) return;
+
+    const measure = () => {
+      containerWidth = element.clientWidth || 800;
+    };
+
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  });
 
   const chartConfig = $derived({
     views: {
@@ -47,64 +68,60 @@
     }
   ]);
 
-  let chartData = $derived(
-    data?.sparkline.map((d) => {
-      const [year, month, day] = d.date.split('-');
-      const date = new Date(Number(year), Number(month) - 1, Number(day));
-      return { ...d, date };
-    })
-  );
+  const totalDays = $derived(range ?? 30);
+  const bucketSize = $derived(getBucketSize(totalDays, containerWidth || 800));
+
+  let chartData = $derived(bucketSparkline(zeroFillRange(data?.sparkline, totalDays), bucketSize));
 
   const hasData = $derived((chartData?.length ?? 0) > 0 && chartData?.some((r) => r.views > 0 || r.enrollments > 0));
 </script>
 
 <AnalyticsPanelCard title={$t('analytics.trend.heading')} description={$t('analytics.trend.description')}>
   {#snippet children()}
-    {#if loading && !chartData}
-      <div class="flex h-[280px] items-center justify-center">
-        <Spinner class="ui:text-muted-foreground size-6" />
-      </div>
-    {:else if browser && hasData && chartData}
-      {#await loadChart() then C}
-        <C.ChartContainer class="h-[280px] w-full" config={chartConfig}>
-          <C.BarChart
-            data={chartData}
-            xScale={C.scaleBand().padding(0.25)}
-            x="date"
-            axis="x"
-            seriesLayout="group"
-            legend
-            {series}
-            props={{
-              xAxis: {
-                format: (d: Date) =>
-                  d.toLocaleDateString('en-US', {
-                    month: 'short',
-                    day: 'numeric'
-                  })
-              }
-            }}
-          >
-            {#snippet tooltip()}
-              <C.Tooltip
-                labelFormatter={(d: Date) =>
-                  d.toLocaleDateString('en-US', {
-                    weekday: 'long',
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric'
-                  })}
-              />
-            {/snippet}
-          </C.BarChart>
-        </C.ChartContainer>
-      {/await}
-    {:else if hasData && chartData}
-      <div class="flex h-[280px] items-center justify-center">
-        <Spinner class="ui:text-muted-foreground size-6" />
-      </div>
-    {:else}
-      <Empty icon={TrendingUpIcon} title={$t('analytics.trend.empty')} class="h-[280px]" />
-    {/if}
+    <div bind:this={containerRef} class="w-full">
+      {#if loading && !chartData}
+        <div class="flex h-[280px] items-center justify-center">
+          <Spinner class="ui:text-muted-foreground size-6" />
+        </div>
+      {:else if browser && hasData && chartData}
+        {#await loadChart() then C}
+          <C.ChartContainer class="h-[280px] w-full" config={chartConfig}>
+            <C.BarChart
+              data={chartData}
+              xScale={C.scaleBand().padding(0.25)}
+              x="date"
+              axis="x"
+              seriesLayout="stack"
+              legend
+              {series}
+              props={{
+                xAxis: {
+                  format: (d: Date) =>
+                    d.toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric'
+                    })
+                }
+              }}
+            >
+              {#snippet tooltip()}
+                <C.Tooltip
+                  labelFormatter={(d: Date) => {
+                    const point = chartData?.find((p) => p.date.getTime() === d.getTime());
+                    return formatChartTooltipDate(d, point);
+                  }}
+                />
+              {/snippet}
+            </C.BarChart>
+          </C.ChartContainer>
+        {/await}
+      {:else if hasData && chartData}
+        <div class="flex h-[280px] items-center justify-center">
+          <Spinner class="ui:text-muted-foreground size-6" />
+        </div>
+      {:else}
+        <Empty icon={TrendingUpIcon} title={$t('analytics.trend.empty')} class="h-[280px]" />
+      {/if}
+    </div>
   {/snippet}
 </AnalyticsPanelCard>

--- a/apps/dashboard/src/lib/features/analytics/components/trend-chart.svelte
+++ b/apps/dashboard/src/lib/features/analytics/components/trend-chart.svelte
@@ -77,51 +77,49 @@
 </script>
 
 <AnalyticsPanelCard title={$t('analytics.trend.heading')} description={$t('analytics.trend.description')}>
-  {#snippet children()}
-    <div bind:this={containerRef} class="w-full">
-      {#if loading && !chartData}
-        <div class="flex h-[280px] items-center justify-center">
-          <Spinner class="ui:text-muted-foreground size-6" />
-        </div>
-      {:else if browser && hasData && chartData}
-        {#await loadChart() then C}
-          <C.ChartContainer class="h-[280px] w-full" config={chartConfig}>
-            <C.BarChart
-              data={chartData}
-              xScale={C.scaleBand().padding(0.25)}
-              x="date"
-              axis="x"
-              seriesLayout="stack"
-              legend
-              {series}
-              props={{
-                xAxis: {
-                  format: (d: Date) =>
-                    d.toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric'
-                    })
-                }
-              }}
-            >
-              {#snippet tooltip()}
-                <C.Tooltip
-                  labelFormatter={(d: Date) => {
-                    const point = chartData?.find((p) => p.date.getTime() === d.getTime());
-                    return formatChartTooltipDate(d, point);
-                  }}
-                />
-              {/snippet}
-            </C.BarChart>
-          </C.ChartContainer>
-        {/await}
-      {:else if hasData && chartData}
-        <div class="flex h-[280px] items-center justify-center">
-          <Spinner class="ui:text-muted-foreground size-6" />
-        </div>
-      {:else}
-        <Empty icon={TrendingUpIcon} title={$t('analytics.trend.empty')} class="h-[280px]" />
-      {/if}
-    </div>
-  {/snippet}
+  <div bind:this={containerRef} class="w-full">
+    {#if loading && !hasData}
+      <div class="flex h-[280px] items-center justify-center">
+        <Spinner class="ui:text-muted-foreground size-6" />
+      </div>
+    {:else if browser && hasData && chartData}
+      {#await loadChart() then C}
+        <C.ChartContainer class="h-[280px] w-full" config={chartConfig}>
+          <C.BarChart
+            data={chartData}
+            xScale={C.scaleBand().padding(0.25)}
+            x="date"
+            axis="x"
+            seriesLayout="stack"
+            legend
+            {series}
+            props={{
+              xAxis: {
+                format: (d: Date) =>
+                  d.toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric'
+                  })
+              }
+            }}
+          >
+            {#snippet tooltip()}
+              <C.Tooltip
+                labelFormatter={(d: Date) => {
+                  const point = chartData?.find((p) => p.date.getTime() === d.getTime());
+                  return formatChartTooltipDate(d, point);
+                }}
+              />
+            {/snippet}
+          </C.BarChart>
+        </C.ChartContainer>
+      {/await}
+    {:else if hasData && chartData}
+      <div class="flex h-[280px] items-center justify-center">
+        <Spinner class="ui:text-muted-foreground size-6" />
+      </div>
+    {:else}
+      <Empty icon={TrendingUpIcon} title={$t('analytics.trend.empty')} class="h-[280px]" />
+    {/if}
+  </div>
 </AnalyticsPanelCard>

--- a/apps/dashboard/src/lib/features/analytics/utils/analytics-utils.test.ts
+++ b/apps/dashboard/src/lib/features/analytics/utils/analytics-utils.test.ts
@@ -41,7 +41,7 @@ describe('bucketSparkline', () => {
       { date: '2026-09-03', views: 30, enrollments: 6 }
     ];
 
-    const filled = zeroFillRange(raw, 5, new Date(2026, 8, 5));
+    const filled = zeroFillRange(raw, 5, new Date(Date.UTC(2026, 8, 5, 12)));
 
     expect(filled).toHaveLength(5);
     expect(filled.map((p) => p.date)).toEqual(['2026-09-01', '2026-09-02', '2026-09-03', '2026-09-04', '2026-09-05']);
@@ -53,7 +53,7 @@ describe('bucketSparkline', () => {
   });
 
   it('returns a single all-zero day when no data is provided', () => {
-    const filled = zeroFillRange(null, 1, new Date(2026, 8, 5));
+    const filled = zeroFillRange(null, 1, new Date(Date.UTC(2026, 8, 5, 12)));
     expect(filled).toEqual([{ date: '2026-09-05', views: 0, enrollments: 0 }]);
   });
 

--- a/apps/dashboard/src/lib/features/analytics/utils/analytics-utils.test.ts
+++ b/apps/dashboard/src/lib/features/analytics/utils/analytics-utils.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bucketSparkline,
+  formatChartTooltipDate,
+  getBucketSize,
+  zeroFillRange,
+  type BucketedChartPoint,
+  type RawSparklinePoint
+} from './analytics-utils';
+
+describe('getBucketSize', () => {
+  it('returns 1 for 7 days regardless of width', () => {
+    expect(getBucketSize(7, 1200)).toBe(1);
+    expect(getBucketSize(7, 600)).toBe(1);
+    expect(getBucketSize(7, 320)).toBe(1);
+  });
+
+  it('adjusts bucket size for 30 days based on width', () => {
+    expect(getBucketSize(30, 900)).toBe(1);
+    expect(getBucketSize(30, 600)).toBe(2);
+    expect(getBucketSize(30, 400)).toBe(3);
+  });
+
+  it('adjusts bucket size for 90 days based on width', () => {
+    expect(getBucketSize(90, 1200)).toBe(5);
+    expect(getBucketSize(90, 800)).toBe(5);
+    expect(getBucketSize(90, 500)).toBe(7);
+    expect(getBucketSize(90, 350)).toBe(14);
+  });
+});
+
+describe('bucketSparkline', () => {
+  it('returns empty array when sparkline is empty or null', () => {
+    expect(bucketSparkline([], 3)).toEqual([]);
+    expect(bucketSparkline(null, 3)).toEqual([]);
+  });
+
+  it('zero-fills a full window, preserving real values and ordering', () => {
+    const raw: RawSparklinePoint[] = [
+      { date: '2026-09-01', views: 10, enrollments: 2 },
+      { date: '2026-09-03', views: 30, enrollments: 6 }
+    ];
+
+    const filled = zeroFillRange(raw, 5, new Date(2026, 8, 5));
+
+    expect(filled).toHaveLength(5);
+    expect(filled.map((p) => p.date)).toEqual(['2026-09-01', '2026-09-02', '2026-09-03', '2026-09-04', '2026-09-05']);
+    expect(filled[0]).toEqual({ date: '2026-09-01', views: 10, enrollments: 2 });
+    expect(filled[1]).toEqual({ date: '2026-09-02', views: 0, enrollments: 0 });
+    expect(filled[2]).toEqual({ date: '2026-09-03', views: 30, enrollments: 6 });
+    expect(filled[3]).toEqual({ date: '2026-09-04', views: 0, enrollments: 0 });
+    expect(filled[4]).toEqual({ date: '2026-09-05', views: 0, enrollments: 0 });
+  });
+
+  it('returns a single all-zero day when no data is provided', () => {
+    const filled = zeroFillRange(null, 1, new Date(2026, 8, 5));
+    expect(filled).toEqual([{ date: '2026-09-05', views: 0, enrollments: 0 }]);
+  });
+
+  it('returns an empty array for a non-positive window', () => {
+    expect(zeroFillRange([{ date: '2026-09-01', views: 1, enrollments: 0 }], 0)).toEqual([]);
+  });
+
+  it('returns an empty array when sparkline is empty or null', () => {
+    expect(bucketSparkline([], 3)).toEqual([]);
+    expect(bucketSparkline(null, 3)).toEqual([]);
+  });
+
+  it('preserves 1-day points when bucketSize is 1', () => {
+    const raw: RawSparklinePoint[] = [
+      { date: '2026-09-01', views: 10, enrollments: 2 },
+      { date: '2026-09-02', views: 20, enrollments: 4 }
+    ];
+
+    const bucketed = bucketSparkline(raw, 1);
+    expect(bucketed).toHaveLength(2);
+    expect(bucketed[0].views).toBe(10);
+    expect(bucketed[0].enrollments).toBe(2);
+    expect(bucketed[0].isSingleDay).toBe(true);
+  });
+
+  it('aggregates multiple days correctly when bucketSize > 1', () => {
+    const raw: RawSparklinePoint[] = [
+      { date: '2026-09-01', views: 10, enrollments: 2 },
+      { date: '2026-09-02', views: 20, enrollments: 4 },
+      { date: '2026-09-03', views: 30, enrollments: 6 },
+      { date: '2026-09-04', views: 40, enrollments: 8 }
+    ];
+
+    const bucketed = bucketSparkline(raw, 2);
+    expect(bucketed).toHaveLength(2);
+
+    expect(bucketed[0].views).toBe(30);
+    expect(bucketed[0].enrollments).toBe(6);
+    expect(bucketed[0].isSingleDay).toBe(false);
+    expect(bucketed[0].rawCount).toBe(2);
+
+    expect(bucketed[1].views).toBe(70);
+    expect(bucketed[1].enrollments).toBe(14);
+    expect(bucketed[1].isSingleDay).toBe(false);
+    expect(bucketed[1].rawCount).toBe(2);
+  });
+
+  it('handles partial remainder chunks at the end', () => {
+    const raw: RawSparklinePoint[] = [
+      { date: '2026-09-01', views: 10, enrollments: 1 },
+      { date: '2026-09-02', views: 20, enrollments: 2 },
+      { date: '2026-09-03', views: 30, enrollments: 3 }
+    ];
+
+    const bucketed = bucketSparkline(raw, 2);
+    expect(bucketed).toHaveLength(2);
+    expect(bucketed[0].rawCount).toBe(2);
+    expect(bucketed[1].rawCount).toBe(1);
+    expect(bucketed[1].isSingleDay).toBe(true);
+    expect(bucketed[1].views).toBe(30);
+  });
+});
+
+describe('formatChartTooltipDate', () => {
+  it('formats single day date', () => {
+    const d = new Date(2026, 8, 1); // Sep 1, 2026
+    const point: BucketedChartPoint = {
+      date: d,
+      endDate: d,
+      views: 10,
+      enrollments: 2,
+      isSingleDay: true,
+      rawCount: 1
+    };
+
+    const formatted = formatChartTooltipDate(d, point);
+    expect(formatted).toContain('Sep 1, 2026');
+  });
+
+  it('formats range across same month', () => {
+    const d1 = new Date(2026, 8, 1);
+    const d2 = new Date(2026, 8, 7);
+    const point: BucketedChartPoint = {
+      date: d1,
+      endDate: d2,
+      views: 70,
+      enrollments: 14,
+      isSingleDay: false,
+      rawCount: 7
+    };
+
+    const formatted = formatChartTooltipDate(d1, point);
+    expect(formatted).toBe('Sep 1 – 7, 2026');
+  });
+
+  it('formats range across different months', () => {
+    const d1 = new Date(2026, 7, 28); // Aug 28
+    const d2 = new Date(2026, 8, 3); // Sep 3
+    const point: BucketedChartPoint = {
+      date: d1,
+      endDate: d2,
+      views: 70,
+      enrollments: 14,
+      isSingleDay: false,
+      rawCount: 7
+    };
+
+    const formatted = formatChartTooltipDate(d1, point);
+    expect(formatted).toBe('Aug 28 – Sep 3, 2026');
+  });
+});

--- a/apps/dashboard/src/lib/features/analytics/utils/analytics-utils.ts
+++ b/apps/dashboard/src/lib/features/analytics/utils/analytics-utils.ts
@@ -1,0 +1,146 @@
+export type RawSparklinePoint = {
+  date: string;
+  views: number;
+  enrollments: number;
+};
+
+export type BucketedChartPoint = {
+  date: Date;
+  endDate: Date;
+  views: number;
+  enrollments: number;
+  isSingleDay: boolean;
+  rawCount: number;
+};
+
+export function getBucketSize(totalDays: number, containerWidth: number): number {
+  if (totalDays <= 7) return 1;
+
+  if (totalDays <= 31) {
+    if (containerWidth >= 800) return 2;
+    if (containerWidth >= 500) return 3;
+    return 4;
+  }
+
+  if (containerWidth >= 1000) return 4;
+  if (containerWidth >= 700) return 4;
+  if (containerWidth >= 450) return 5;
+  return 14;
+}
+
+export function zeroFillRange(
+  sparkline: RawSparklinePoint[] | undefined | null,
+  days: number,
+  endDate: Date = new Date()
+): RawSparklinePoint[] {
+  if (days <= 0) return [];
+
+  const byDate = new Map<string, RawSparklinePoint>();
+  sparkline?.forEach((point) => {
+    byDate.set(point.date, point);
+  });
+
+  const result: RawSparklinePoint[] = [];
+  const cursor = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate());
+
+  for (let i = days - 1; i >= 0; i--) {
+    const date = new Date(cursor);
+    date.setDate(cursor.getDate() - i);
+    const dateString = toDateString(date);
+    const real = byDate.get(dateString);
+
+    result.push(
+      real ?? {
+        date: dateString,
+        views: 0,
+        enrollments: 0
+      }
+    );
+  }
+
+  return result;
+}
+
+function toDateString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function bucketSparkline(
+  sparkline: RawSparklinePoint[] | undefined | null,
+  bucketSize: number
+): BucketedChartPoint[] {
+  if (!sparkline || sparkline.length === 0) return [];
+
+  if (bucketSize <= 1) {
+    return sparkline.map((d) => {
+      const [year, month, day] = d.date.split('-');
+      const date = new Date(Number(year), Number(month) - 1, Number(day));
+      return {
+        date,
+        endDate: date,
+        views: d.views,
+        enrollments: d.enrollments,
+        isSingleDay: true,
+        rawCount: 1
+      };
+    });
+  }
+
+  const result: BucketedChartPoint[] = [];
+
+  for (let i = 0; i < sparkline.length; i += bucketSize) {
+    const chunk = sparkline.slice(i, i + bucketSize);
+    const first = chunk[0];
+    const last = chunk[chunk.length - 1];
+
+    const [y1, m1, d1] = first.date.split('-');
+    const startDate = new Date(Number(y1), Number(m1) - 1, Number(d1));
+
+    const [y2, m2, d2] = last.date.split('-');
+    const endDate = new Date(Number(y2), Number(m2) - 1, Number(d2));
+
+    const views = chunk.reduce((sum, item) => sum + item.views, 0);
+    const enrollments = chunk.reduce((sum, item) => sum + item.enrollments, 0);
+
+    result.push({
+      date: startDate,
+      endDate,
+      views,
+      enrollments,
+      isSingleDay: chunk.length === 1,
+      rawCount: chunk.length
+    });
+  }
+
+  return result;
+}
+
+export function formatChartTooltipDate(date: Date, point?: BucketedChartPoint): string {
+  if (!point || point.isSingleDay) {
+    return date.toLocaleDateString('en-US', {
+      weekday: 'short',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+  }
+
+  const startFormatted = point.date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric'
+  });
+
+  const isSameMonth =
+    point.date.getMonth() === point.endDate.getMonth() && point.date.getFullYear() === point.endDate.getFullYear();
+
+  const endFormatted = point.endDate.toLocaleDateString('en-US', {
+    month: isSameMonth ? undefined : 'short',
+    day: 'numeric',
+    year: 'numeric'
+  });
+
+  return `${startFormatted} – ${endFormatted}`;
+}

--- a/apps/dashboard/src/lib/features/analytics/utils/analytics-utils.ts
+++ b/apps/dashboard/src/lib/features/analytics/utils/analytics-utils.ts
@@ -41,11 +41,13 @@ export function zeroFillRange(
   });
 
   const result: RawSparklinePoint[] = [];
-  const cursor = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate());
+  // Build the window from UTC calendar dates so day keys match the server's UTC
+  // analytics range (computed via toISOString().slice(0, 10)) regardless of the
+  // viewer's local timezone.
+  const cursor = Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate());
 
   for (let i = days - 1; i >= 0; i--) {
-    const date = new Date(cursor);
-    date.setDate(cursor.getDate() - i);
+    const date = new Date(cursor - i * 86400000);
     const dateString = toDateString(date);
     const real = byDate.get(dateString);
 
@@ -62,9 +64,9 @@ export function zeroFillRange(
 }
 
 function toDateString(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 }
 

--- a/apps/dashboard/src/routes/(app)/org/[slug]/analytics/+page.svelte
+++ b/apps/dashboard/src/routes/(app)/org/[slug]/analytics/+page.svelte
@@ -63,7 +63,7 @@
           </Tabs.List>
 
           <Tabs.Content value="overview" class="space-y-4">
-            <TrendChart data={analyticsApi.landing} loading={analyticsApi.loadingLanding} />
+            <TrendChart data={analyticsApi.landing} loading={analyticsApi.loadingLanding} range={analyticsApi.range} />
             <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
               <Funnel data={analyticsApi.funnel} loading={analyticsApi.loadingFunnel} />
               <PopularTypes data={analyticsApi.popularTypes} loading={analyticsApi.loadingPopularTypes} />


### PR DESCRIPTION
## What does this PR do?

Fixes the analytics trend bar being clustered together on the 90-day range and days silently missing from the axis.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #936 

## Demo
https://www.awesomescreenshot.com/video/56163199?key=057abfc1d809cf4f6493427453604bdc

<!-- Please upload a video here or attach a link to a video player like Awesome Screenshot or Loom to show the change in action. This speeds up reviews, especially for visual changes. -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- 90-day range, desktop (wide): open Analytics → Overview, select 90d; confirm bars group as 4 days per bar (not 3) and days with no activity still appear on the x-axis as zero-height bars.
- 90-day range, mobile/narrow: confirm the bucket falls back to the narrow-width case (5/14 days per bar) and stays readable.
- 30-day & 7-day ranges: switch both on desktop and mobile; confirm the day-per-bar grouping is unchanged (1 day per bar on wide 30-day, etc.).

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds responsive bucketing and zero-filling to the Analytics Overview trend chart, stacks its series, and formats bucket ranges in tooltips.
- Passes the selected 7/30/90-day range into TrendChart.
- Adds width-sensitive bucket sizing and daily gap filling.
- Adds utility coverage for bucketing, filling, and tooltip formatting.
- Introduces incorrect bucket mappings, a loading-state regression, and a UTC/local date-window mismatch.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until the incorrect grouping, initial loading-state regression, and UTC/local window mismatch are fixed.

Common range and width combinations produce unintended bucket sizes, absent initial data is rendered as an empty result while loading, and browser-local date reconstruction can omit valid UTC analytics points.

**Files Needing Attention:** apps/dashboard/src/lib/features/analytics/utils/analytics-utils.ts and apps/dashboard/src/lib/features/analytics/components/trend-chart.svelte

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/analytics/components/trend-chart.svelte | Adds responsive bucketing and stacked rendering, but synthesized chart data prevents the initial loading spinner from appearing. |
| apps/dashboard/src/lib/features/analytics/utils/analytics-utils.ts | Adds chart transformation utilities, with bucket mappings that contradict their tests and local-date window generation that can drop UTC boundary data. |
| apps/dashboard/src/lib/features/analytics/utils/analytics-utils.test.ts | Adds useful utility coverage, though its bucket-size expectations currently fail against the implementation and omit UTC-boundary coverage. |
| apps/dashboard/src/routes/(app)/org/[slug]/analytics/+page.svelte | Correctly forwards the selected analytics range to TrendChart. |

<sub>Reviews (1): Last reviewed commit: ["Changed the chart to stacked"](https://github.com/classroomio/classroomio/commit/5c274e273f8313676d73447db27f7d41a41df071) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59903618)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Analytics trend charts support readable data grouping based on the selected date range and available display space.
  - Missing dates are filled with zero values for more complete trend visualization.
  - Tooltips provide clearer formatting for single-day and multi-day ranges.
  - Trend series remain displayed as stacked bars.

- **Bug Fixes**
  - Improved chart loading behavior while analytics data is being retrieved.
  - Date handling now remains consistent across viewer time zones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->