### PR TITLE
feat(lesson): paginate version history by cursor and persist it in the URL

### DIFF
--- a/apps/api/src/routes/course/lesson.ts
+++ b/apps/api/src/routes/course/lesson.ts
@@ -345,8 +345,8 @@ export const lessonRouter = new Hono()
   )
   /**
    * GET /course/:courseId/lesson/:lessonId/history
-   * Gets lesson version history for a lesson and locale
-   * Query params: locale (required), endRange (optional, default 9)
+   * Gets one keyset page of lesson version history, newest first.
+   * Query params: locale (required), limit (optional, default 10), cursor (optional)
    * Requires authentication and course membership
    */
   .get(
@@ -358,8 +358,8 @@ export const lessonRouter = new Hono()
     async (c) => {
       try {
         const { lessonId } = c.req.valid('param');
-        const { locale, endRange } = c.req.valid('query');
-        const history = await getLessonHistoryService(lessonId, locale, endRange);
+        const { locale, limit, cursor } = c.req.valid('query');
+        const history = await getLessonHistoryService(lessonId, locale, limit, cursor);
 
         return c.json(
           {

--- a/apps/dashboard/src/lib/features/course/api/lesson.svelte.ts
+++ b/apps/dashboard/src/lib/features/course/api/lesson.svelte.ts
@@ -880,19 +880,15 @@ export class LessonApi extends BaseApiWithErrors {
   }
 
   /**
-   * Gets lesson version history for a lesson and locale
-   * @param courseId Course ID
-   * @param lessonId Lesson ID
-   * @param locale Locale
-   * @param endRange End range for pagination (0-indexed, inclusive)
-   * @returns Lesson history data or null on error
+   * Gets one page of lesson version history, newest first.
+   * @param cursor `nextCursor` from the previous page; omit for the first page.
    */
-  async getHistory(courseId: string, lessonId: string, locale: TLocale, endRange: number) {
+  async getHistory(courseId: string, lessonId: string, locale: TLocale, limit: number, cursor?: string) {
     return this.execute<GetLessonHistoryRequest>({
       requestFn: () =>
         classroomio.course[':courseId']['lesson'][':lessonId']['history'].$get({
           param: { courseId, lessonId },
-          query: { locale, endRange: endRange.toString() }
+          query: { locale, limit: limit.toString(), ...(cursor ? { cursor } : {}) }
         }),
       logContext: 'fetching lesson history'
     });

--- a/apps/dashboard/src/lib/features/course/components/lesson/lesson-version-history.svelte
+++ b/apps/dashboard/src/lib/features/course/components/lesson/lesson-version-history.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import { createEventDispatcher, onMount, untrack } from 'svelte';
+  import { replaceState } from '$app/navigation';
+  import { resolve } from '$app/paths';
+  import { page } from '$app/state';
   import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
   import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 
@@ -25,13 +28,19 @@
 
   let { open = false }: Props = $props();
 
+  const PAGE_SIZE = 10;
+  const VERSION_PARAM = 'version';
+
   let lessonHistory = $state<LessonVersionEntry[]>([]);
   let selectedVersion = $state<LessonVersionEntry | null>(null);
   let selectedVersionIndex = $state(0);
   let contentRestoreLoading = $state(false);
-  let versionsToFetch = $state(9);
   let isHistoryLoading = $state(false);
   let displayElement = $state<HTMLDivElement | null>(null);
+  let nextCursor = $state<string | null>(null);
+
+  /** Only offer "load more" once the server has said there is a next page. */
+  const canLoadMore = $derived(nextCursor !== null);
 
   const lessonId = $derived(lessonApi.lesson?.id ?? '');
   const lessonTitle = $derived(lessonApi.lesson?.title ?? '');
@@ -92,6 +101,7 @@
   }
 
   function handleDrawerClose() {
+    // The parent owns closing and clears both params in one navigation.
     dispatch('close');
   }
 
@@ -101,9 +111,38 @@
     }
   }
 
+  function readVersionIdFromUrl(): number | null {
+    const raw = page.url.searchParams.get(VERSION_PARAM);
+    if (!raw) return null;
+
+    const parsed = Number(raw);
+
+    return Number.isInteger(parsed) ? parsed : null;
+  }
+
+  /**
+   * Mirrors the open version into the URL so a reload reopens on the same entry.
+   * `replaceState` because picking through versions is browsing, not navigation — each
+   * click should not cost a Back press.
+   */
+  function syncVersionToUrl(versionId: number | null) {
+    const url = new URL(page.url);
+
+    if (versionId === null) {
+      url.searchParams.delete(VERSION_PARAM);
+    } else {
+      url.searchParams.set(VERSION_PARAM, String(versionId));
+    }
+
+    if (url.search === page.url.search) return;
+
+    replaceState(resolve(`${url.pathname}${url.search}${url.hash}`, {}), page.state);
+  }
+
   function updateContentVersion(version: LessonVersionEntry, index: number) {
     selectedVersionIndex = index;
     selectedVersion = version;
+    syncVersionToUrl(version.id || null);
   }
 
   function renderSelectedVersion(version: LessonVersionEntry) {
@@ -114,19 +153,23 @@
     displayElement.innerHTML = renderHtmlDiff(version.oldContent, version.newContent);
   }
 
-  async function fetchLessonHistory(currentLessonId: string, locale: TLocale, endRange: number) {
+  /**
+   * Loads one keyset page. `cursor` omitted starts over from the newest entry, so this
+   * doubles as the reload path when the lesson or locale changes.
+   */
+  async function fetchLessonHistory(currentLessonId: string, locale: TLocale, cursor?: string) {
     if (!courseApi.course?.id || !currentLessonId) return;
 
     try {
       isHistoryLoading = true;
-      const response = await lessonApi.getHistory(courseApi.course.id, currentLessonId, locale, endRange);
+      const response = await lessonApi.getHistory(courseApi.course.id, currentLessonId, locale, PAGE_SIZE, cursor);
 
       if (!response || !lessonApi.success || !response.data) {
         throw new Error('Failed to fetch lesson history');
       }
 
       const previousVersionId = selectedVersion?.id;
-      lessonHistory = response.data.map((item) => {
+      const pageEntries = response.data.items.map((item) => {
         const timestamp = item.timestamp ? new Date(item.timestamp) : new Date();
 
         return {
@@ -144,14 +187,27 @@
         };
       });
 
-      const previousIndex = previousVersionId
-        ? lessonHistory.findIndex((version) => version.id === previousVersionId)
-        : -1;
-      const nextIndex = previousIndex >= 0 ? previousIndex : 0;
-      const nextVersion = lessonHistory[nextIndex];
+      // Append: earlier pages stay put, so paging never re-transfers what is on screen.
+      lessonHistory = cursor ? [...lessonHistory, ...pageEntries] : pageEntries;
+      nextCursor = response.data.nextCursor
+        ? `${response.data.nextCursor.timestamp}|${response.data.nextCursor.id}`
+        : null;
 
-      if (nextVersion) {
-        updateContentVersion(nextVersion, nextIndex);
+      // Keep the reader where they were: prefer the version in the URL on first load,
+      // then whatever was already selected, then the newest entry.
+      const urlVersionId = cursor ? null : readVersionIdFromUrl();
+      const targetId = urlVersionId ?? previousVersionId;
+      const targetIndex = targetId ? lessonHistory.findIndex((version) => version.id === targetId) : -1;
+
+      if (targetIndex >= 0) {
+        updateContentVersion(lessonHistory[targetIndex], targetIndex);
+        return;
+      }
+
+      // A deep-linked version deeper than the loaded pages cannot be resolved yet; fall
+      // back to newest rather than leaving the panel blank.
+      if (!cursor && lessonHistory[0]) {
+        updateContentVersion(lessonHistory[0], 0);
       }
     } catch (error) {
       console.error(error);
@@ -185,16 +241,21 @@
   }
 
   function loadMoreHistory() {
-    versionsToFetch += 10;
+    if (!nextCursor || isHistoryLoading) return;
+
+    void fetchLessonHistory(lessonId, lessonApi.currentLocale, nextCursor);
   }
 
+  // Reload from the newest page whenever the lesson or locale changes. Paging is driven by
+  // the button instead, so the cursor is deliberately not a dependency here.
   $effect(() => {
     const currentLessonId = lessonId;
     const currentLocale = lessonApi.currentLocale;
-    const endRange = versionsToFetch;
 
     untrack(() => {
-      void fetchLessonHistory(currentLessonId, currentLocale, endRange);
+      lessonHistory = [];
+      nextCursor = null;
+      void fetchLessonHistory(currentLessonId, currentLocale);
     });
   });
 
@@ -238,7 +299,7 @@
         </div>
 
         {#if selectedVersionIndex !== 0 && selectedVersion}
-          <Button loading={contentRestoreLoading} onclick={restoreSelectedVersion}>
+          <Button variant="secondary" loading={contentRestoreLoading} onclick={restoreSelectedVersion}>
             {$t('course.navItem.lessons.version_history.restore_version')}
           </Button>
         {/if}
@@ -277,20 +338,17 @@
             <div class="space-y-1">
               {#each day.versions as version (version.id)}
                 {@const index = lessonHistory.indexOf(version)}
-                <button
-                  type="button"
+                <Button
                   onclick={() => updateContentVersion(version, index)}
-                  class="ui:hover:bg-accent flex w-full items-start gap-2 rounded-lg px-3 py-3 text-left transition-colors {index ===
-                  selectedVersionIndex
-                    ? 'ui:bg-accent'
-                    : ''}"
+                  variant={index === selectedVersionIndex ? 'secondary' : 'ghost'}
+                  class="h-full w-full text-left"
                 >
                   <ChevronRightIcon class="mt-0.5 shrink-0" size={16} />
                   <span class="min-w-0 flex-1">
                     <span class="flex items-center gap-2">
                       <span class="truncate text-sm font-medium">{formatVersionLabel(version)}</span>
                       {#if version.kind !== 'auto'}
-                        <Badge variant={version.kind === 'publish' ? 'success' : 'secondary'}>
+                        <Badge variant={version.kind === 'publish' ? 'default' : 'secondary'}>
                           {$t(`course.navItem.lessons.version_history.kind.${version.kind}`)}
                         </Badge>
                       {/if}
@@ -311,18 +369,20 @@
                       {/if}
                     </span>
                   </span>
-                </button>
+                </Button>
               {/each}
             </div>
           </section>
         {/each}
       </div>
 
-      <div class="ui:border-border shrink-0 border-t p-4">
-        <Button class="w-full" variant="outline" loading={isHistoryLoading} onclick={loadMoreHistory}>
-          {$t('course.navItem.lessons.version_history.fetch_more_versions')}
-        </Button>
-      </div>
+      {#if canLoadMore}
+        <div class="ui:border-border shrink-0 border-t p-4">
+          <Button class="w-full" variant="outline" loading={isHistoryLoading} onclick={loadMoreHistory}>
+            {$t('course.navItem.lessons.version_history.fetch_more_versions')}
+          </Button>
+        </div>
+      {/if}
     </div>
   </aside>
 {/if}

--- a/apps/dashboard/src/lib/features/course/components/lesson/lesson-version-history.svelte
+++ b/apps/dashboard/src/lib/features/course/components/lesson/lesson-version-history.svelte
@@ -38,6 +38,7 @@
   let isHistoryLoading = $state(false);
   let displayElement = $state<HTMLDivElement | null>(null);
   let nextCursor = $state<string | null>(null);
+  let requestedVersionId: number | null = null;
   /**
    * Bumped on every reload so an in-flight request for a previous lesson or locale cannot
    * write its rows over the current ones when it lands late.
@@ -144,9 +145,14 @@
     replaceState(resolve(`${url.pathname}${url.search}${url.hash}`, {}), page.state);
   }
 
-  function updateContentVersion(version: LessonVersionEntry, index: number) {
+  function selectContentVersion(version: LessonVersionEntry, index: number) {
     selectedVersionIndex = index;
     selectedVersion = version;
+  }
+
+  function updateContentVersion(version: LessonVersionEntry, index: number) {
+    requestedVersionId = null;
+    selectContentVersion(version, index);
     syncVersionToUrl(version.id || null);
   }
 
@@ -204,11 +210,10 @@
         ? `${response.data.nextCursor.timestamp}|${response.data.nextCursor.id}`
         : null;
 
-      // Keep the reader where they were: prefer the version in the URL on first load,
-      // then whatever was already selected, then the newest entry.
-      const urlVersionId = cursor ? null : readVersionIdFromUrl();
-      const targetId = urlVersionId ?? previousVersionId;
-      const targetIndex = targetId ? lessonHistory.findIndex((version) => version.id === targetId) : -1;
+      // Keep searching appended pages for a deep-linked version. Until it is found,
+      // the newest entry is only a visual fallback and must not replace the requested ID.
+      const targetVersionId = requestedVersionId ?? previousVersionId;
+      const targetIndex = targetVersionId ? lessonHistory.findIndex((version) => version.id === targetVersionId) : -1;
 
       if (targetIndex >= 0) {
         updateContentVersion(lessonHistory[targetIndex], targetIndex);
@@ -218,7 +223,11 @@
       // A deep-linked version deeper than the loaded pages cannot be resolved yet; fall
       // back to newest rather than leaving the panel blank.
       if (!cursor && lessonHistory[0]) {
-        updateContentVersion(lessonHistory[0], 0);
+        if (requestedVersionId === null) {
+          updateContentVersion(lessonHistory[0], 0);
+        } else {
+          selectContentVersion(lessonHistory[0], 0);
+        }
       }
     } catch (error) {
       if (requestId !== historyRequestId) return;
@@ -273,6 +282,7 @@
       nextCursor = null;
       selectedVersion = null;
       selectedVersionIndex = 0;
+      requestedVersionId = readVersionIdFromUrl();
       void fetchLessonHistory(currentLessonId, currentLocale);
     });
   });

--- a/apps/dashboard/src/lib/features/course/components/lesson/lesson-version-history.svelte
+++ b/apps/dashboard/src/lib/features/course/components/lesson/lesson-version-history.svelte
@@ -38,6 +38,11 @@
   let isHistoryLoading = $state(false);
   let displayElement = $state<HTMLDivElement | null>(null);
   let nextCursor = $state<string | null>(null);
+  /**
+   * Bumped on every reload so an in-flight request for a previous lesson or locale cannot
+   * write its rows over the current ones when it lands late.
+   */
+  let historyRequestId = 0;
 
   /** Only offer "load more" once the server has said there is a next page. */
   const canLoadMore = $derived(nextCursor !== null);
@@ -160,9 +165,15 @@
   async function fetchLessonHistory(currentLessonId: string, locale: TLocale, cursor?: string) {
     if (!courseApi.course?.id || !currentLessonId) return;
 
+    const requestId = historyRequestId;
+
     try {
       isHistoryLoading = true;
       const response = await lessonApi.getHistory(courseApi.course.id, currentLessonId, locale, PAGE_SIZE, cursor);
+
+      // The lesson or locale changed while this was in flight; its rows belong to a list
+      // the reader has already left.
+      if (requestId !== historyRequestId) return;
 
       if (!response || !lessonApi.success || !response.data) {
         throw new Error('Failed to fetch lesson history');
@@ -210,10 +221,14 @@
         updateContentVersion(lessonHistory[0], 0);
       }
     } catch (error) {
+      if (requestId !== historyRequestId) return;
+
       console.error(error);
       snackbar.error('Failed to fetch history');
     } finally {
-      isHistoryLoading = false;
+      if (requestId === historyRequestId) {
+        isHistoryLoading = false;
+      }
     }
   }
 
@@ -253,8 +268,11 @@
     const currentLocale = lessonApi.currentLocale;
 
     untrack(() => {
+      historyRequestId += 1;
       lessonHistory = [];
       nextCursor = null;
+      selectedVersion = null;
+      selectedVersionIndex = 0;
       void fetchLessonHistory(currentLessonId, currentLocale);
     });
   });

--- a/apps/dashboard/src/lib/features/course/pages/lesson.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/lesson.svelte
@@ -81,9 +81,14 @@
     })
   );
 
+  const HISTORY_PARAM = 'history';
+  const VERSION_PARAM = 'version';
+
   let prevModeParam = $state<string | null>(null);
   let isDeletingLesson = $state(false);
-  let isVersionDrawerOpen = $state(false);
+  // Derived from the URL so a reload reopens the drawer. The URL is the single source of
+  // truth; nothing sets this directly.
+  const isVersionDrawerOpen = $derived($page.url.searchParams.get(HISTORY_PARAM) === 'open');
   // eslint-disable-next-line svelte/prefer-writable-derived -- must be writable: cleared before intentional navigations and bound to UnsavedChanges
   let hasUnsavedChanges = $state(false);
 
@@ -135,6 +140,21 @@
     params.set('mode', value);
     goto(resolve(`${$page.url.pathname}?${params.toString()}`, {}), { replaceState: false });
   }
+  /** Closing drops the selected version too, so both params move in one navigation. */
+  function setHistoryQueryParam(isOpen: boolean) {
+    const params = new SvelteURLSearchParams($page.url.searchParams);
+
+    if (isOpen) {
+      params.set(HISTORY_PARAM, 'open');
+    } else {
+      params.delete(HISTORY_PARAM);
+      params.delete(VERSION_PARAM);
+    }
+
+    const query = params.toString();
+    goto(resolve(query ? `${$page.url.pathname}?${query}` : $page.url.pathname, {}), { replaceState: false });
+  }
+
   function setTabQueryParam(value: string) {
     const params = new SvelteURLSearchParams($page.url.searchParams);
     params.set('tab', value);
@@ -152,7 +172,7 @@
   }
 
   const refetchDataAfterVersionRestore = async () => {
-    isVersionDrawerOpen = false;
+    setHistoryQueryParam(false);
     if (courseId && browser) {
       setModeQueryParam('view');
 
@@ -479,8 +499,8 @@
         </div>
 
         <IconButton
-          class="hidden lg:inline-flex"
-          onclick={() => (isVersionDrawerOpen = true)}
+          class="inline-flex"
+          onclick={() => setHistoryQueryParam(true)}
           aria-label={$t('course.navItem.lessons.version_history.title')}
           tooltip={$t('course.navItem.lessons.version_history.title')}
           tooltipSide="bottom"
@@ -488,7 +508,7 @@
           <HistoryIcon size={20} />
         </IconButton>
 
-        <RefreshPageData onRefresh={() => lessonApi.get(courseId, lessonId)} />
+        <RefreshPageData class="hidden lg:inline-flex" onRefresh={() => lessonApi.get(courseId, lessonId)} />
       </RoleBasedSecurity>
 
       <LanguageSelector />
@@ -645,7 +665,7 @@
 {#if isVersionDrawerOpen}
   <LessonVersionHistory
     open={isVersionDrawerOpen}
-    on:close={() => (isVersionDrawerOpen = false)}
+    on:close={() => setHistoryQueryParam(false)}
     on:restore={refetchDataAfterVersionRestore}
   />
 {/if}

--- a/apps/dashboard/src/lib/features/course/pages/lesson.svelte
+++ b/apps/dashboard/src/lib/features/course/pages/lesson.svelte
@@ -152,7 +152,7 @@
     }
 
     const query = params.toString();
-    goto(resolve(query ? `${$page.url.pathname}?${query}` : $page.url.pathname, {}), { replaceState: false });
+    return goto(resolve(query ? `${$page.url.pathname}?${query}` : $page.url.pathname, {}), { replaceState: false });
   }
 
   function setTabQueryParam(value: string) {
@@ -172,7 +172,8 @@
   }
 
   const refetchDataAfterVersionRestore = async () => {
-    setHistoryQueryParam(false);
+    await setHistoryQueryParam(false);
+
     if (courseId && browser) {
       setModeQueryParam('view');
 

--- a/packages/core/src/services/lesson/lesson.ts
+++ b/packages/core/src/services/lesson/lesson.ts
@@ -14,6 +14,7 @@ import {
   getLessonCommentsByLessonIdPaginated,
   getLessonCompletion,
   getLessonVersionHistory,
+  type TLessonVersionCursor,
   getLessonVideoProgress,
   getLessonVideoProgressForLesson,
   getLessonsByCourseId,
@@ -701,16 +702,30 @@ export async function updateLessonWatchProgressService(
   }
 }
 
+function parseLessonVersionCursor(cursor?: string): TLessonVersionCursor | undefined {
+  if (!cursor) return undefined;
+
+  const separatorIndex = cursor.lastIndexOf('|');
+  if (separatorIndex <= 0) return undefined;
+
+  const timestamp = cursor.slice(0, separatorIndex);
+  const id = Number(cursor.slice(separatorIndex + 1));
+
+  if (!timestamp || !Number.isInteger(id)) return undefined;
+
+  return { timestamp, id };
+}
+
 /**
- * Gets lesson version history for a lesson and locale
- * @param lessonId Lesson ID
- * @param locale Locale
- * @param endRange End range for pagination (0-indexed, inclusive)
- * @returns Array of lesson version history entries
+ * Gets one keyset page of lesson version history.
+ *
+ * @param cursor Serialized `<iso timestamp>|<id>` from the previous page's `nextCursor`.
+ *   Malformed input is treated as absent so a hand-edited URL restarts at the newest page
+ *   rather than erroring.
  */
-export async function getLessonHistoryService(lessonId: string, locale: string, endRange: number) {
+export async function getLessonHistoryService(lessonId: string, locale: string, limit: number, cursor?: string) {
   try {
-    return getLessonVersionHistory(lessonId, locale, endRange);
+    return getLessonVersionHistory(lessonId, locale, limit, parseLessonVersionCursor(cursor));
   } catch (error) {
     throw new AppError(
       error instanceof Error ? error.message : 'Failed to get lesson history',

--- a/packages/core/src/services/lesson/lesson.ts
+++ b/packages/core/src/services/lesson/lesson.ts
@@ -713,6 +713,11 @@ function parseLessonVersionCursor(cursor?: string): TLessonVersionCursor | undef
 
   if (!timestamp || !Number.isInteger(id)) return undefined;
 
+  // The timestamp is interpolated into a Postgres timestamp comparison, so it has to be a
+  // real date here. Without this check a cursor like `garbage|5` reaches the driver and
+  // fails the query with a 500 instead of restarting at the newest page.
+  if (Number.isNaN(new Date(timestamp).getTime())) return undefined;
+
   return { timestamp, id };
 }
 

--- a/packages/db/src/queries/lesson/version.ts
+++ b/packages/db/src/queries/lesson/version.ts
@@ -2,9 +2,21 @@ import * as schema from '@db/schema';
 
 import type { TLessonLanguageHistory, TLessonVersion, TNewLessonLanguageHistory } from '@db/types';
 import type { TLessonVersionKind } from '@cio/utils/constants/lesson-version';
-import { and, desc, eq, getTableColumns, sql } from 'drizzle-orm';
+import { and, desc, eq, getTableColumns, lt, or, sql } from 'drizzle-orm';
 
 import { db, type DbOrTxClient } from '@db/drizzle';
+
+/** Keyset cursor: the (timestamp, id) of the last row already returned. */
+export type TLessonVersionCursor = {
+  timestamp: string;
+  id: number;
+};
+
+export type TLessonVersionPage = {
+  items: TLessonVersion[];
+  /** Null when the last page has been reached. */
+  nextCursor: TLessonVersionCursor | null;
+};
 
 /**
  * Newest snapshot plus how long ago it happened, used to decide whether an
@@ -239,18 +251,52 @@ export async function sealLatestLessonVersionsForCourse(courseId: string, dbClie
 export async function getLessonVersionHistory(
   lessonId: string,
   locale: string,
-  endRange: number
-): Promise<TLessonVersion[]> {
+  limit: number,
+  cursor?: TLessonVersionCursor
+): Promise<TLessonVersionPage> {
   try {
-    const result = await db
+    // Keyset, not offset: the list is ordered by (timestamp, id) and rows are only ever
+    // appended at the newest end, so seeking past the last row read is stable under
+    // concurrent edits and costs the same at page 1 and page 50.
+    const olderThanCursor = cursor
+      ? or(
+          lt(schema.lessonVersions.timestamp, cursor.timestamp),
+          and(eq(schema.lessonVersions.timestamp, cursor.timestamp), lt(schema.lessonVersions.id, cursor.id))
+        )
+      : undefined;
+
+    const rows = await db
       .select()
       .from(schema.lessonVersions)
-      .where(and(eq(schema.lessonVersions.lessonId, lessonId), eq(schema.lessonVersions.locale, locale as any)))
+      .where(
+        and(
+          eq(schema.lessonVersions.lessonId, lessonId),
+          eq(schema.lessonVersions.locale, locale as any),
+          olderThanCursor
+        )
+      )
       .orderBy(desc(schema.lessonVersions.timestamp), desc(schema.lessonVersions.id))
-      .limit(endRange + 1);
+      // One extra row is the has-more probe; it is trimmed before returning.
+      .limit(limit + 1);
 
-    if (result.length > 0) {
-      return result;
+    if (rows.length > 0) {
+      const hasMore = rows.length > limit;
+      const items = hasMore ? rows.slice(0, limit) : rows;
+      const last = items[items.length - 1];
+      // `lessonVersions` is a view, so its columns type as nullable. Without both keys
+      // there is no stable seek point, so stop rather than hand back a broken cursor.
+      const canSeekPastLast = hasMore && last?.timestamp != null && last?.id != null;
+
+      return {
+        items,
+        nextCursor: canSeekPastLast ? { timestamp: last.timestamp!, id: last.id! } : null
+      };
+    }
+
+    // A cursor that ran past the end has no fallback to offer — the synthesized
+    // current-content row below belongs to the first page only.
+    if (cursor) {
+      return { items: [], nextCursor: null };
     }
 
     // Older lessons may not have a history row yet. Expose their current content
@@ -262,7 +308,7 @@ export async function getLessonVersionHistory(
       .limit(1);
 
     if (!currentLanguage) {
-      return [];
+      return { items: [], nextCursor: null };
     }
 
     const now = new Date().toISOString();
@@ -283,7 +329,7 @@ export async function getLessonVersionHistory(
       lessonId: currentLanguage.lessonId
     };
 
-    return [currentVersion];
+    return { items: [currentVersion], nextCursor: null };
   } catch (error) {
     console.error('getLessonVersionHistory error:', error);
     throw new Error(

--- a/packages/utils/src/validation/lesson/lesson.ts
+++ b/packages/utils/src/validation/lesson/lesson.ts
@@ -80,7 +80,9 @@ export type TLessonHistoryParam = z.infer<typeof ZLessonHistoryParam>;
 
 export const ZLessonHistoryQuery = z.object({
   locale: z.string().min(1),
-  endRange: z.string().transform(Number).pipe(z.number().int().min(0))
+  limit: z.string().transform(Number).pipe(z.number().int().min(1).max(50)).default(10),
+  /** Keyset cursor from the previous page, formatted `<iso timestamp>|<id>`. */
+  cursor: z.string().min(1).optional()
 });
 export type TLessonHistoryQuery = z.infer<typeof ZLessonHistoryQuery>;
 export type TLessonListQuery = z.infer<typeof ZLessonListQuery>;


### PR DESCRIPTION
## What does this PR do?

Lesson version history loaded by refetching a growing window. `endRange` started at 9 and grew by 10 per click, and each "load more" re-requested the whole list from the top — the query had no offset or cursor, just `.limit(endRange + 1)`. On a lesson with 100 versions that transfers all 100 again to reveal 10, and each row carries both `oldContent` and `newContent`, so the payload is lesson bodies, not ids.

This replaces it with **keyset pagination**. The list is already ordered by `(timestamp, id)` and rows are only ever appended at the newest end, so seeking past the last row read is stable under concurrent edits and costs the same on page 1 as on page 50. The endpoint now takes `limit` + an opaque `cursor` and returns `{ items, nextCursor }`; the client appends pages rather than replacing them.

**Two bugs fall out of the old shape and are fixed here:**

- **"Load more" never hid.** It rendered unconditionally with no has-more check, so a lesson with 3 versions offered a button that refetched the same 3 rows forever, spinner and all. Now gated on `nextCursor`.
- **The `limit + 1` probe was dead.** It's the standard "fetch one extra to detect a next page" trick, but nothing read it — so the signal it exists to provide was discarded, which is likely why the button was never gated. It now produces `nextCursor`.

**URL persistence.** `?history=open` reopens the drawer on reload and `?version=<id>` reselects the entry. `isVersionDrawerOpen` is `$derived` from the query string rather than shadowing it in local state, so there's one source of truth and no syncing effect. Picking a version uses `replaceState` — browsing versions isn't navigation and shouldn't cost a Back press — while opening/closing uses `goto` like the neighbouring `mode` and `tab` params, so Back closes the drawer. Closing clears both params in a single navigation.

### Reviewer notes

- **No migration, no schema change.** The existing `lesson_language_history_language_timestamp_idx` on `(lesson_language_id ASC, timestamp DESC)` already supports the seek on its leading columns. The `id` tiebreaker isn't in the index, which only matters for rows sharing an identical timestamp.
- `TLessonVersionCursor`/`TLessonVersionPage` are new exported types on the query; `getLessonVersionHistory` changes its return shape from `TLessonVersion[]` to a page object. Its only caller is `getLessonHistoryService`.
- A malformed cursor is treated as absent, so a hand-edited URL restarts at the newest page instead of erroring. A cursor past the end returns an empty page rather than the synthesized current-content row, which belongs to the first page only.
- `lessonVersions` is a view, so its columns type as nullable; the cursor is only emitted when both keys are present rather than handing back a broken seek point.
- This branch also carries small in-flight styling tweaks to the same component (Button/Badge variants) that were already in the working tree. They are not mine and are unrelated to pagination — happy to strip them if you'd rather they land separately.

**Known gap:** a `?version=` pointing deeper than the loaded pages can't be resolved yet and falls back to the newest entry. Fixing it needs an `around=<id>` seek on the endpoint; worth doing only if links to old versions get shared.

## Demo

Not applicable — no new UI. Behaviour change only: the "Load more" button now disappears on the last page, and the drawer survives a reload.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

Commands run locally on Node 20.19.3, all green:

```bash
export PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH"
pnpm --filter @cio/api^... build && pnpm --filter @cio/api build
pnpm --filter @cio/dashboard build
cd apps/api && pnpm vitest run     # 181 passed, 19 files
pnpm format:check
```

**Pagination, walked against seeded data** (a lesson with 4 versions, `limit=2`):

| Page | ids | nextCursor |
|---|---|---|
| 1 | 231, 230 | present |
| 2 | 229, 228 | `null` (last page) |

No duplicates, strictly descending, and the `null` on the last page is what hides the button.

Edge cases verified against the running API:

| Input | Result |
|---|---|
| `cursor=garbage` | falls back to the newest page |
| `cursor` past the end | empty items, no next page |
| `limit=60` | HTTP 400 (max 50) |
| no `limit` | defaults to 10 |

**Manual UI steps:**

1. Open a lesson, click Version history → URL gains `?history=open`.
2. Click a version → URL gains `&version=<id>`.
3. Reload → drawer reopens on that same version.
4. Back → drawer closes (version clicks don't stack history entries).
5. Close → both params disappear together.
6. To see paging with few versions, temporarily set `PAGE_SIZE = 2` in `lesson-version-history.svelte`: 2 rows + a Load more button, which vanishes after the second click.

Note the click-through was **not** verified in a browser — the API half is proven end to end, the drawer's visual behaviour on reload is not.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lesson version history now loads in pages with a “Load more” option.
  - History drawers and selected versions can be reopened through shared URLs.
  - Reloading a shared version restores the relevant history view.

- **Improvements**
  - History requests support configurable page sizes, defaulting to 10 entries.
  - Invalid history links safely restart from the latest entries.
  - History controls remain accessible on smaller screens.
  - Refresh controls are streamlined on smaller displays.
  - Stale history requests no longer overwrite newer results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces growing-window lesson version-history requests with cursor pagination and persists drawer and selected-version state in the URL.
- Adds a `(timestamp, id)` keyset cursor and paged API response.
- Appends history pages in the dashboard and hides “Load more” at the end.
- Reopens the drawer and restores first-page selections from URL parameters.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until malformed cursors are handled safely and stale history requests are prevented from populating or restoring the wrong locale.

The new endpoint can return a server error for structurally valid cursors with invalid timestamps, while uncancelled overlapping drawer requests can overwrite current history with results captured for a previous locale.

**Files Needing Attention:** packages/core/src/services/lesson/lesson.ts; apps/dashboard/src/lib/features/course/components/lesson/lesson-version-history.svelte

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/src/queries/lesson/version.ts | Implements deterministic keyset pagination and a limit-plus-one next-page probe; unchecked cursor timestamps can still reach its database predicates. |
| packages/core/src/services/lesson/lesson.ts | Parses the opaque cursor but does not validate its timestamp, allowing malformed values to turn a recoverable request into a server error. |
| apps/dashboard/src/lib/features/course/components/lesson/lesson-version-history.svelte | Adds append-based pagination and URL-selected versions, but overlapping locale requests can commit stale history into the drawer. |
| apps/dashboard/src/lib/features/course/pages/lesson.svelte | Makes drawer state URL-derived and adds push-state open and close navigation while preserving other query parameters. |
| apps/dashboard/src/lib/features/course/api/lesson.svelte.ts | Updates the typed dashboard request to send limit and optional cursor values. |
| apps/api/src/routes/course/lesson.ts | Passes validated pagination parameters from the history route to the lesson service. |
| packages/utils/src/validation/lesson/lesson.ts | Bounds page size but permits any nonempty cursor string, relying on the incomplete service parser for validity. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User
  participant Drawer as Version history drawer
  participant API as Lesson history API
  participant DB as PostgreSQL
  User->>Drawer: Open history
  Drawer->>API: GET history(limit)
  API->>DB: ORDER BY timestamp DESC, id DESC LIMIT limit+1
  DB-->>API: Rows
  API-->>Drawer: items + nextCursor
  User->>Drawer: Load more
  Drawer->>API: GET history(limit, cursor)
  API->>DB: Seek before (timestamp, id)
  DB-->>API: Older rows
  API-->>Drawer: Append items + nextCursor
```

<sub>Reviews (1): Last reviewed commit: ["feat(lesson): paginate version history b..."](https://github.com/classroomio/classroomio/commit/4389edd7a45dc0ee1369f04d5530e765d02f028d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60240865)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->