### PR TITLE
fix(dashboard): show loading state before app reload

### DIFF
--- a/apps/dashboard/src/lib/features/app/app-version-notifier.svelte
+++ b/apps/dashboard/src/lib/features/app/app-version-notifier.svelte
@@ -3,6 +3,7 @@
   import { toast } from '@cio/ui/base/sonner';
   import { t } from '$lib/utils/functions/translations';
   import { onMount } from 'svelte';
+  import AppVersionReloadButton from './app-version-reload-button.svelte';
 
   const UPDATE_TOAST_ID = 'app-version-update';
 
@@ -12,11 +13,7 @@
       duration: Number.POSITIVE_INFINITY,
       position: 'bottom-right',
       description: t.get('common.app_update.description'),
-      actionButtonStyle: 'background: var(--primary); color: var(--primary-foreground);',
-      action: {
-        label: t.get('common.app_update.reload'),
-        onClick: () => location.reload()
-      }
+      action: AppVersionReloadButton
     });
   }
 

--- a/apps/dashboard/src/lib/features/app/app-version-reload-button.svelte
+++ b/apps/dashboard/src/lib/features/app/app-version-reload-button.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { Button } from '@cio/ui/base/button';
+  import { t } from '$lib/utils/functions/translations';
+
+  let loading = $state(false);
+
+  function handleReload() {
+    if (loading) {
+      return;
+    }
+
+    loading = true;
+    setTimeout(() => location.reload());
+  }
+</script>
+
+<Button size="xs" {loading} onclick={handleReload}>{$t('common.app_update.reload')}</Button>


### PR DESCRIPTION
## What does this PR do?

- Replaces the app-update toast action with the shared primary Button component.
- Uses component-local state to disable the Reload button and show its standard spinner after click.
- Reloads on the next event-loop turn so the loading state is rendered first.

Follow-up to #1002.

## Demo

The notification appears when SvelteKit detects a newly deployed app version or a Vite preload error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Trigger the app-version update notification.
- Confirm the Reload action uses the active primary theme color.
- Click Reload and confirm the button disables and shows its loading spinner before the page reloads.

## Checklist

### Required

- [x] Filled out the How to test section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits (no additional comments needed)
- [x] Ran the dashboard production build
- [ ] Checked for warnings, there are none (the build has existing unrelated Svelte warnings)
- [x] Removed all console.logs
- [x] Branch is based on the latest origin/main
- [x] My changes do not cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the ClassroomIO Contributor License Agreement
- [x] This PR does not change pnpm-lock.yaml, workflows, or publish config

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the ClassroomIO Docs if changes were necessary (not necessary)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the app-update toast’s action object with a shared primary Button component and adds local loading state before reloading.
- Introduces a dedicated app-version reload button with duplicate-click protection.
- Uses the shared Button’s loading and disabled behavior.
- Defers the reload with a zero-delay timer, although that does not guarantee the loading frame is presented.

<h3>Confidence Score: 4/5</h3>

The loading-state timing should be fixed before merging because the reload can still start before the updated button is visibly presented.

The component integration and Button loading contract are sound, but the new scheduling mechanism does not guarantee the visible loading state that this fix is intended to provide.

**Files Needing Attention:** apps/dashboard/src/lib/features/app/app-version-reload-button.svelte

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/app/app-version-notifier.svelte | Replaces the styled Sonner action object with a supported component-valued action. |
| apps/dashboard/src/lib/features/app/app-version-reload-button.svelte | Adds the shared loading button and reload handler, but the zero-delay timer does not reliably ensure the spinner is visibly rendered before navigation. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): show loading state befor..."](https://github.com/classroomio/classroomio/commit/860b9f5e91ab92f074bb798e223e67639575a79d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60240170)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Administration dashboard](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/administration-dashboard.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the app update notification’s reload action with a dedicated button that displays a loading state and prevents repeated activation while the page reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->