### PR TITLE
fix(ui): trigger input changes while typing and fix onblur binding (#1018)

### DIFF
--- a/packages/ui/src/custom/input-field/input-field.svelte
+++ b/packages/ui/src/custom/input-field/input-field.svelte
@@ -4,6 +4,8 @@
   import { Input, type InputProps } from '../../base/input';
 
   type InputOnChangeEvent = Parameters<NonNullable<InputProps['onchange']>>[0];
+  type InputOnInputEvent = Parameters<NonNullable<InputProps['oninput']>>[0];
+  type InputOnBlurEvent = Parameters<NonNullable<InputProps['onblur']>>[0];
 
   interface Props {
     label?: string;
@@ -28,7 +30,9 @@
     /** Stable hook for Playwright (`data-testid`). Prefer over CSS classes or translated labels. */
     testId?: string;
     onchange?: (e: InputOnChangeEvent) => void;
-    onInputChange?: (e: InputOnChangeEvent) => void;
+    onblur?: (e: InputOnBlurEvent) => void;
+    oninput?: (e: InputOnInputEvent) => void;
+    onInputChange?: (e: InputOnInputEvent | InputOnChangeEvent) => void;
     labelAction?: import('svelte').Snippet;
   }
 
@@ -54,6 +58,8 @@
     autoComplete = true,
     testId,
     onchange = () => {},
+    onblur = () => {},
+    oninput = () => {},
     onInputChange = () => {},
     labelAction
   }: Props = $props();
@@ -66,14 +72,21 @@
     }
   });
 
-  // Handle input change event
-  function handleInputChange(e: InputOnChangeEvent) {
+  // Handle live input event (typing, pasting, speech-to-text)
+  function handleInput(e: InputOnInputEvent) {
+    oninput(e);
+    onInputChange(e);
+  }
+
+  // Handle commit / change event
+  function handleChange(e: InputOnChangeEvent) {
+    onchange(e);
     onInputChange(e);
   }
 
   // Handle blur event
-  function handleBlur(e: InputOnChangeEvent) {
-    onchange(e);
+  function handleBlur(e: InputOnBlurEvent) {
+    onblur(e);
   }
 </script>
 
@@ -105,7 +118,8 @@
     autocomplete={autoComplete ? 'on' : 'off'}
     aria-invalid={errorMessage ? 'true' : undefined}
     onkeydown={onKeyDown}
-    onchange={handleInputChange}
+    oninput={handleInput}
+    onchange={handleChange}
     onblur={handleBlur}
   />
 


### PR DESCRIPTION
## What does this PR do?

Currently, `InputField` only calls `onInputChange` inside `onchange`, which in browsers only fires on blur. Also, `handleBlur` was erroneously invoking `onchange` instead of `onblur`.

This PR fixes both:
- Binds `oninput` on the inner input to trigger live updates through both `oninput` and `onInputChange` as characters are typed/pasted.
- Preserves `onchange` to trigger `onchange` and `onInputChange` on commit.
- Correctly routes `onblur` to `onblur`.

Fixes #1018

## Demo

https://github.com/classroomio/classroomio/issues/1018#issue-reproduction

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)

## How should this be tested?

1. Focus any text field powered by `InputField` (e.g. course title/slug in settings or lesson editor).
2. Type text into the field.
3. Observe `onInputChange` callbacks fire in real time with each keystroke (triggering dirty state / title slug generation).
4. Verify blur callbacks trigger when the input loses focus.

## Checklist

### Required
- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] My changes don't cause any responsiveness issues
- [x] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description
