### PR TITLE
docs(events): add Zoho Writer webinar reference

### DIFF
--- a/prd/events/README.md
+++ b/prd/events/README.md
@@ -10,6 +10,7 @@ Reference products:
 
 - OpenAI Academy events: <https://academy.openai.com/public/events> — one `/events` catalog filtered by `All / Upcoming / Now / Past`, format badges (`LIVESTREAM`), topic tags, and a detail page with countdown, time range with timezone, delivery ("Online"), organizer, Register, and Add to calendar. Past events keep their page and gain slides/handouts.
 - Cursor Workshops: <https://cursor.com/workshops> — card grid with title, host ("By AJ Valenty" + headshot), upcoming date or duration; grouped into "Upcoming events" (Luma registration) and "On-demand sessions" (YouTube links, grouped by topic).
+- Zoho Writer webinars: <https://www.zoho.com/writer/webinars.html?src=workflow_webinar_wms_eu_banner> — a dedicated webinar library split into `Upcoming` and `Completed`, with region selection for localized scheduling. Completed webinar cards pair a concise outcome-focused summary with presenter names/headshots, recording duration, expandable details, and a direct `Watch Now` CTA; learn from this transition from scheduled programming to a browsable replay archive.
 - Ona's webinar pages: public event detail plus a lead-capture form before an on-demand recording.
 - Our differentiation: cards link to an **internal** event page (video + text + callout on the org's branded site) instead of sending visitors to YouTube/Luma. Admins can make the recording public or gate it with a native ClassroomIO Form; verified registration grants LMS access.
 


### PR DESCRIPTION
## Summary

- add Zoho Writer webinars to the Events PRD reference products
- capture learnings from its upcoming/completed split, regional scheduling, and replay archive cards

## Verification

- `pnpm format:changed`
- `pnpm format:check`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Zoho Writer webinars to the Events PRD’s reference products.
- Documents its upcoming/completed content split.
- Highlights regional scheduling and replay archive card patterns.

<h3>Confidence Score: 5/5</h3>

This documentation-only change appears safe to merge.

The addition is scoped to a reference-products list and introduces no runtime, security, or product-contract failure.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| prd/events/README.md | Adds a focused product reference consistent with the PRD’s existing reference-product section. |

<sub>Reviews (1): Last reviewed commit: ["docs(events): add Zoho Writer webinar re..."](https://github.com/classroomio/classroomio/commit/76a5b191a3b8d86d9127d8e55358c2b6c9052083) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60283655)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference to Zoho Writer’s webinar library, including its upcoming and completed sections, regional filtering, webinar details, and “Watch Now” action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->