### PR TITLE
feat(dashboard): improve LMS navigation

### DIFF
--- a/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-navigation.svelte
+++ b/apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-navigation.svelte
@@ -144,10 +144,7 @@
         url: getNavItemRoute(id, 'marks'),
         isActive: (path || page.url.pathname) === getNavItemRoute(id, 'marks'),
         show() {
-          if (courseApi.course?.type === 'LIVE_CLASS') {
-            return isStudent ? ($currentOrg.customization?.['course']?.['grading'] ?? false) : true;
-          }
-          return false;
+          return isStudent ? ($currentOrg.customization?.['course']?.['grading'] ?? false) : true;
         },
         icon: getNavIcon(NAV_IDS.MARKS)
       },

--- a/apps/dashboard/src/lib/features/ui/navigation/lms-header.svelte
+++ b/apps/dashboard/src/lib/features/ui/navigation/lms-header.svelte
@@ -9,6 +9,7 @@
   import RefreshCcwIcon from '@lucide/svelte/icons/refresh-ccw';
   import * as Empty from '@cio/ui/base/empty';
   import VisitOrgSiteBtn from '../visit-org-site-btn.svelte';
+  import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
 
   interface Props {
     hideSearch?: boolean;
@@ -32,7 +33,7 @@
     <span class="grow"></span>
 
     {#if !hideSearch}
-      <VisitOrgSiteBtn variant="outline" labelKey="lms.view_landing_page" pathname="/" />
+      <VisitOrgSiteBtn variant="outline" labelKey="lms.view_landing_page" pathname="/" icon={ExternalLinkIcon} />
 
       <Search scope="lms" />
 

--- a/apps/dashboard/src/lib/features/ui/visit-org-site-btn.svelte
+++ b/apps/dashboard/src/lib/features/ui/visit-org-site-btn.svelte
@@ -2,6 +2,7 @@
   import { browser } from '$app/environment';
   import { Button, type ButtonVariant } from '@cio/ui/base/button';
   import SquareArrowOutUpRight from '@lucide/svelte/icons/square-arrow-out-up-right';
+  import type { Component } from 'svelte';
 
   import { TENANT_ROOT_DOMAIN } from '@cio/utils/constants';
   import { currentOrg, currentOrgDomain } from '$lib/utils/store/org';
@@ -16,6 +17,7 @@
     variant?: ButtonVariant;
     forceSubdomain?: boolean;
     pathname?: string;
+    icon?: Component;
   }
 
   let {
@@ -24,7 +26,8 @@
     labelKey = 'settings.subheadings.view_site',
     variant = 'default',
     forceSubdomain = false,
-    pathname
+    pathname,
+    icon: Icon = SquareArrowOutUpRight
   }: Props = $props();
 
   let href = $derived.by(() => {
@@ -58,5 +61,5 @@
       {/if}
     </span>
   {/if}
-  <SquareArrowOutUpRight class="custom" />
+  <Icon class="custom" />
 </Button>

--- a/apps/dashboard/src/lib/utils/translations/da.json
+++ b/apps/dashboard/src/lib/utils/translations/da.json
@@ -504,7 +504,7 @@
     "go_to_my_learning": "Gå til Min Læring"
   },
   "lms_navigation": {
-    "home": "Hjem",
+    "home": "Dashboard",
     "my_learning": "Min Læring",
     "certificates": "Certifikater",
     "exercise": "Motion",
@@ -5162,7 +5162,7 @@
     "toggle_failed": "Kunne ikke opdatere invitationslinket"
   },
   "lms": {
-    "view_landing_page": "Se landingssiden"
+    "view_landing_page": "Hjem"
   },
   "notifications": {
     "title": "Notifikationer",

--- a/apps/dashboard/src/lib/utils/translations/de.json
+++ b/apps/dashboard/src/lib/utils/translations/de.json
@@ -504,7 +504,7 @@
     "go_to_my_learning": "Zu Mein Lernen"
   },
   "lms_navigation": {
-    "home": "Zuhause",
+    "home": "Dashboard",
     "my_learning": "Mein Lernen",
     "certificates": "Zertifikate",
     "exercise": "Übung",
@@ -5162,7 +5162,7 @@
     "toggle_failed": "Der Einladungslink konnte nicht aktualisiert werden."
   },
   "lms": {
-    "view_landing_page": "Landingpage ansehen"
+    "view_landing_page": "Startseite"
   },
   "notifications": {
     "title": "Benachrichtigungen",

--- a/apps/dashboard/src/lib/utils/translations/en.json
+++ b/apps/dashboard/src/lib/utils/translations/en.json
@@ -4184,7 +4184,7 @@
     }
   },
   "lms_navigation": {
-    "home": "Home",
+    "home": "Dashboard",
     "my_learning": "My Learning",
     "certificates": "Certificates",
     "exercise": "Exercise",
@@ -4195,7 +4195,7 @@
     "cohorts": "Cohorts"
   },
   "lms": {
-    "view_landing_page": "View landing page"
+    "view_landing_page": "Home"
   },
   "my_learning": {
     "heading": "My Learning",

--- a/apps/dashboard/src/lib/utils/translations/es.json
+++ b/apps/dashboard/src/lib/utils/translations/es.json
@@ -504,7 +504,7 @@
     "go_to_my_learning": "Ir a Mi aprendizaje"
   },
   "lms_navigation": {
-    "home": "Inicio",
+    "home": "Panel",
     "my_learning": "Mi aprendizaje",
     "certificates": "Certificados",
     "exercise": "Ejercicio",
@@ -5162,7 +5162,7 @@
     "toggle_failed": "No se pudo actualizar el enlace de invitación"
   },
   "lms": {
-    "view_landing_page": "Ver página de inicio"
+    "view_landing_page": "Inicio"
   },
   "notifications": {
     "title": "Notificaciones",

--- a/apps/dashboard/src/lib/utils/translations/fr.json
+++ b/apps/dashboard/src/lib/utils/translations/fr.json
@@ -504,7 +504,7 @@
     "go_to_my_learning": "Aller à Mon apprentissage"
   },
   "lms_navigation": {
-    "home": "Accueil",
+    "home": "Tableau de bord",
     "my_learning": "Mon apprentissage",
     "certificates": "Certificats",
     "exercise": "Exercice",
@@ -5162,7 +5162,7 @@
     "toggle_failed": "Impossible de mettre à jour le lien d'invitation"
   },
   "lms": {
-    "view_landing_page": "Afficher la page d'accueil"
+    "view_landing_page": "Accueil"
   },
   "notifications": {
     "title": "Notifications",

--- a/apps/dashboard/src/lib/utils/translations/hi.json
+++ b/apps/dashboard/src/lib/utils/translations/hi.json
@@ -504,7 +504,7 @@
     "go_to_my_learning": "मेरी सीख पर जाएँ"
   },
   "lms_navigation": {
-    "home": "घर",
+    "home": "डैशबोर्ड",
     "my_learning": "मेरी सीख",
     "certificates": "प्रमाणपत्र",
     "exercise": "व्यायाम",
@@ -5162,7 +5162,7 @@
     "toggle_failed": "आमंत्रण लिंक अपडेट नहीं हो सका"
   },
   "lms": {
-    "view_landing_page": "लैंडिंग पेज देखें"
+    "view_landing_page": "मुखपृष्ठ"
   },
   "notifications": {
     "title": "सूचनाएं",

--- a/apps/dashboard/src/lib/utils/translations/pl.json
+++ b/apps/dashboard/src/lib/utils/translations/pl.json
@@ -504,7 +504,7 @@
     "go_to_my_learning": "Przejdź do Moja nauka"
   },
   "lms_navigation": {
-    "home": "Dom",
+    "home": "Panel",
     "my_learning": "Moja nauka",
     "certificates": "Certyfikaty",
     "exercise": "Ćwicz",
@@ -5162,7 +5162,7 @@
     "toggle_failed": "Nie można zaktualizować linku z zaproszeniem"
   },
   "lms": {
-    "view_landing_page": "Wyświetl stronę docelową"
+    "view_landing_page": "Strona główna"
   },
   "notifications": {
     "title": "Powiadomienia",

--- a/apps/dashboard/src/lib/utils/translations/pt.json
+++ b/apps/dashboard/src/lib/utils/translations/pt.json
@@ -504,7 +504,7 @@
     "go_to_my_learning": "Ir para Meu aprendizado"
   },
   "lms_navigation": {
-    "home": "Página inicial",
+    "home": "Painel",
     "my_learning": "Meu aprendizado",
     "certificates": "Certificados",
     "exercise": "Exercício",
@@ -5162,7 +5162,7 @@
     "toggle_failed": "Não foi possível atualizar o link de convite"
   },
   "lms": {
-    "view_landing_page": "Ver página inicial"
+    "view_landing_page": "Início"
   },
   "notifications": {
     "title": "Notificações",

--- a/apps/dashboard/src/lib/utils/translations/ru.json
+++ b/apps/dashboard/src/lib/utils/translations/ru.json
@@ -504,7 +504,7 @@
     "go_to_my_learning": "Перейти к Моему обучению"
   },
   "lms_navigation": {
-    "home": "Главная",
+    "home": "Панель управления",
     "my_learning": "Мое обучение",
     "certificates": "Сертификаты",
     "exercise": "Упражнение",
@@ -5162,7 +5162,7 @@
     "toggle_failed": "Не удалось обновить ссылку-приглашение"
   },
   "lms": {
-    "view_landing_page": "Посмотреть целевую страницу"
+    "view_landing_page": "Главная"
   },
   "notifications": {
     "title": "Уведомления",

--- a/apps/dashboard/src/lib/utils/translations/vi.json
+++ b/apps/dashboard/src/lib/utils/translations/vi.json
@@ -504,7 +504,7 @@
     "go_to_my_learning": "Đi tới Học tập của tôi"
   },
   "lms_navigation": {
-    "home": "Trang chủ",
+    "home": "Bảng điều khiển",
     "my_learning": "Học tập của tôi",
     "certificates": "Chứng chỉ",
     "exercise": "tập thể dục",
@@ -5162,7 +5162,7 @@
     "toggle_failed": "Không thể cập nhật liên kết mời"
   },
   "lms": {
-    "view_landing_page": "Xem trang đích"
+    "view_landing_page": "Trang chủ"
   },
   "notifications": {
     "title": "Thông báo",

--- a/packages/db/src/migrations/0014_add_display_order_to_course.sql
+++ b/packages/db/src/migrations/0014_add_display_order_to_course.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "course" ADD COLUMN "display_order" integer;
+ALTER TABLE "course" ADD COLUMN IF NOT EXISTS "display_order" integer;


### PR DESCRIPTION
## Summary
- rename the LMS sidebar Home item to Dashboard across all supported locales
- rename the landing-page top-nav action to Home and use the Lucide external-link icon
- expose Marks in the course sidebar for every course type while preserving student grading visibility settings
- make the display_order course migration idempotent

## Verification
- pnpm translate
- pnpm format:changed
- pnpm format:check
- pnpm --filter @cio/api^... build && pnpm --filter @cio/api build
- pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates LMS navigation terminology and icons, exposes course marks across course types while retaining the learner grading setting, and makes the display-order migration tolerant of a pre-existing column.
- Renames LMS Home to Dashboard and the organization-site action to Home across supported locales.
- Allows an injected Lucide icon in the organization-site button.
- Removes the `LIVE_CLASS` restriction from Marks navigation.
- Makes migration 0014 skip creation when `display_order` already exists.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking recommendation to detect incompatible pre-existing `display_order` columns during database adoption.

The navigation, icon, and localization changes align with existing routes and repository conventions; the remaining concern is that the migration can silently preserve schema drift when a same-named column has the wrong definition.

**Files Needing Attention:** packages/db/src/migrations/0014_add_display_order_to_course.sql

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/course/components/sidebar/course-sidebar-navigation.svelte | Broadens Marks navigation to every course type while preserving the existing learner customization gate. |
| apps/dashboard/src/lib/features/ui/visit-org-site-btn.svelte | Adds a typed, overridable icon component using an established Svelte 5 pattern. |
| apps/dashboard/src/lib/features/ui/navigation/lms-header.svelte | Uses the Lucide external-link icon for the organization Home action. |
| packages/db/src/migrations/0014_add_display_order_to_course.sql | Makes column creation idempotent but does not detect an incompatible pre-existing column definition. |

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): update LMS navigation"](https://github.com/classroomio/classroomio/commit/500a17dc330ce58d5f67b8cc67d4ab7854aa37c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60389732)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Administration dashboard](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/administration-dashboard.md)
- Knowledge Base — [Database model and access](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/database-model-and-access.md)
- Knowledge Base — [Restore lesson saves for adopted databases](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/reverts/incident-mitigation_1041-20260903-lesson-save-outage-83ff45e.md)
</details>


<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Marks are now available across all course types when permitted by existing access settings.
  * Added an external-link icon to the organization site button.

* **Localization**
  * Updated LMS navigation labels across supported languages to distinguish “Dashboard” and “Home” more clearly.

* **Bug Fixes**
  * Improved database update reliability when the course display-order field already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->