### PR TITLE
fix(dashboard): remaining fix for certificate UI elements overlap

### DIFF
--- a/apps/api/src/utils/certificate.ts
+++ b/apps/api/src/utils/certificate.ts
@@ -1,82 +1,25 @@
 import {
-  DEFAULT_CERTIFICATE_DESIGN,
+  CERTIFICATE_PDF_PAGE_OPTIONS,
+  CERTIFICATE_VIEWPORT,
   renderCertificate,
-  resolveTemplateId,
+  resolveCertificateDesign,
   type CertificateDesign,
   type CertificateRenderData
 } from '@cio/certificates';
 
-import {
-  getCloudflarePdfBuffer,
-  getCloudflarePngBuffer,
-  type PdfPageOptions,
-  type RenderViewport
-} from '@api/utils/cloudflare';
+import { getCloudflarePdfBuffer, getCloudflarePngBuffer } from '@api/utils/cloudflare';
 
-const CERTIFICATE_VIEWPORT: RenderViewport = { width: 1100, height: 780 };
-
-const CERTIFICATE_PDF_OPTIONS: PdfPageOptions = {
-  width: '1100px',
-  height: '780px',
-  landscape: true,
-  printBackground: true,
-  preferCSSPageSize: true,
-  margin: { top: '0px', right: '0px', bottom: '0px', left: '0px' }
-};
+export { resolveCertificateDesign };
 
 export interface CertificateRenderInput {
   design: CertificateDesign;
   data: CertificateRenderData;
 }
 
-/**
- * Coerces a stored `course.certificate` JSONB blob (legacy or current) into a
- * complete `CertificateDesign` suitable for `renderCertificate`.
- */
-export function resolveCertificateDesign(stored: unknown): CertificateDesign {
-  const blob = stored && typeof stored === 'object' ? (stored as Record<string, unknown>) : {};
-  const legacyTheme = typeof blob.theme === 'string' ? (blob.theme as string) : undefined;
-  const storedDesign =
-    blob.design && typeof blob.design === 'object' ? (blob.design as Partial<CertificateDesign>) : undefined;
-
-  const templateId = resolveTemplateId(storedDesign?.templateId ?? legacyTheme);
-
-  const accentColor =
-    storedDesign?.accentColor && /^#[0-9a-fA-F]{6}$/.test(storedDesign.accentColor)
-      ? storedDesign.accentColor
-      : DEFAULT_CERTIFICATE_DESIGN.accentColor;
-
-  const storedSignatories = Array.isArray(storedDesign?.signatories) ? storedDesign?.signatories : undefined;
-
-  const signatories: CertificateDesign['signatories'] = [
-    {
-      name: storedSignatories?.[0]?.name ?? DEFAULT_CERTIFICATE_DESIGN.signatories[0].name,
-      role: storedSignatories?.[0]?.role ?? DEFAULT_CERTIFICATE_DESIGN.signatories[0].role,
-      enabled: storedSignatories?.[0]?.enabled ?? DEFAULT_CERTIFICATE_DESIGN.signatories[0].enabled,
-      signatureUrl: storedSignatories?.[0]?.signatureUrl
-    },
-    {
-      name: storedSignatories?.[1]?.name ?? DEFAULT_CERTIFICATE_DESIGN.signatories[1].name,
-      role: storedSignatories?.[1]?.role ?? DEFAULT_CERTIFICATE_DESIGN.signatories[1].role,
-      enabled: storedSignatories?.[1]?.enabled ?? DEFAULT_CERTIFICATE_DESIGN.signatories[1].enabled,
-      signatureUrl: storedSignatories?.[1]?.signatureUrl
-    }
-  ];
-
-  return {
-    templateId,
-    accentColor,
-    subtitle: storedDesign?.subtitle ?? DEFAULT_CERTIFICATE_DESIGN.subtitle,
-    descriptionOverride: storedDesign?.descriptionOverride,
-    signatories,
-    idFormat: storedDesign?.idFormat ?? DEFAULT_CERTIFICATE_DESIGN.idFormat
-  };
-}
-
 export async function generateCertificatePdf(input: CertificateRenderInput) {
   const { html, styles } = renderCertificate(input.design, input.data);
 
-  return getCloudflarePdfBuffer(html, styles, CERTIFICATE_VIEWPORT, CERTIFICATE_PDF_OPTIONS);
+  return getCloudflarePdfBuffer(html, styles, CERTIFICATE_VIEWPORT, CERTIFICATE_PDF_PAGE_OPTIONS);
 }
 
 export async function generateCertificatePng(input: CertificateRenderInput) {

--- a/apps/api/src/utils/cloudflare.ts
+++ b/apps/api/src/utils/cloudflare.ts
@@ -1,5 +1,5 @@
 import { CLOUDFLARE } from '@api/constants';
-import { FONTS_READY_CLASS, FONTS_READY_SELECTOR } from '@cio/certificates';
+import { CERTIFICATE_VIEWPORT, FONTS_READY_CLASS, FONTS_READY_SELECTOR } from '@cio/certificates';
 
 export type RenderViewport = {
   width: number;
@@ -15,8 +15,6 @@ export type PdfPageOptions = {
   preferCSSPageSize?: boolean;
   margin?: { top?: string; right?: string; bottom?: string; left?: string };
 };
-
-const DEFAULT_VIEWPORT: RenderViewport = { width: 1100, height: 780 };
 
 interface CloudflareRenderPayload {
   html: string;
@@ -125,7 +123,7 @@ export const getCloudflarePdfBuffer = async (
 export const getCloudflarePngBuffer = async (
   html: string,
   styles?: string,
-  viewport: RenderViewport = { width: 1100, height: 780, deviceScaleFactor: 2 }
+  viewport: RenderViewport = { ...CERTIFICATE_VIEWPORT, deviceScaleFactor: 2 }
 ): Promise<Buffer> => {
   return renderCloudflareBrowserDocument('screenshot', {
     html,

--- a/apps/dashboard/src/lib/features/course/components/ceritficate/certificate-design.svelte
+++ b/apps/dashboard/src/lib/features/course/components/ceritficate/certificate-design.svelte
@@ -10,12 +10,7 @@
 
   import { courseApi } from '$features/course/api';
   import { currentOrg, isFreePlan } from '$lib/utils/store/org';
-  import {
-    CERTIFICATE_TEMPLATES,
-    DEFAULT_CERTIFICATE_DESIGN,
-    type CertificateDesign,
-    resolveTemplateId
-  } from '@cio/certificates';
+  import { CERTIFICATE_TEMPLATES, type CertificateDesign, resolveCertificateDesign } from '@cio/certificates';
 
   type Props = {
     errors?: Record<string, string>;
@@ -23,33 +18,7 @@
 
   let { errors: _errors }: Props = $props();
 
-  const design: CertificateDesign = $derived.by(() => {
-    const certificate = courseApi.course?.certificate;
-    const stored = certificate?.design as Partial<CertificateDesign> | undefined;
-    const legacyTheme = certificate?.theme as string | undefined;
-
-    return {
-      templateId: resolveTemplateId(stored?.templateId ?? legacyTheme),
-      accentColor: stored?.accentColor ?? DEFAULT_CERTIFICATE_DESIGN.accentColor,
-      subtitle: stored?.subtitle ?? DEFAULT_CERTIFICATE_DESIGN.subtitle,
-      descriptionOverride: stored?.descriptionOverride,
-      signatories: [
-        {
-          name: stored?.signatories?.[0]?.name ?? DEFAULT_CERTIFICATE_DESIGN.signatories[0].name,
-          role: stored?.signatories?.[0]?.role ?? DEFAULT_CERTIFICATE_DESIGN.signatories[0].role,
-          enabled: stored?.signatories?.[0]?.enabled ?? DEFAULT_CERTIFICATE_DESIGN.signatories[0].enabled,
-          signatureUrl: stored?.signatories?.[0]?.signatureUrl
-        },
-        {
-          name: stored?.signatories?.[1]?.name ?? DEFAULT_CERTIFICATE_DESIGN.signatories[1].name,
-          role: stored?.signatories?.[1]?.role ?? DEFAULT_CERTIFICATE_DESIGN.signatories[1].role,
-          enabled: stored?.signatories?.[1]?.enabled ?? DEFAULT_CERTIFICATE_DESIGN.signatories[1].enabled,
-          signatureUrl: stored?.signatories?.[1]?.signatureUrl
-        }
-      ],
-      idFormat: stored?.idFormat ?? DEFAULT_CERTIFICATE_DESIGN.idFormat
-    };
-  });
+  const design: CertificateDesign = $derived(resolveCertificateDesign(courseApi.course?.certificate));
 
   const previewData = $derived({
     recipientName: 'Eleanor Vance',

--- a/apps/dashboard/src/lib/features/course/components/ceritficate/editor/store/certificate-editor.store.svelte.ts
+++ b/apps/dashboard/src/lib/features/course/components/ceritficate/editor/store/certificate-editor.store.svelte.ts
@@ -1,6 +1,6 @@
 import {
   DEFAULT_CERTIFICATE_DESIGN,
-  resolveTemplateId,
+  resolveCertificateDesign,
   type CertificateDesign,
   type CertificateTemplateId
 } from '@cio/certificates';
@@ -84,21 +84,7 @@ function fromDraft(draft: CertificateEditorDraft): CertificateDesign {
 }
 
 function readStoredDesign(): CertificateDesign {
-  const certificate = courseApi.course?.certificate;
-  const stored = certificate?.design as Partial<CertificateDesign> | undefined;
-  const legacyTheme = certificate?.theme;
-
-  return {
-    templateId: resolveTemplateId(stored?.templateId ?? legacyTheme),
-    accentColor: stored?.accentColor ?? DEFAULT_CERTIFICATE_DESIGN.accentColor,
-    subtitle: stored?.subtitle ?? DEFAULT_CERTIFICATE_DESIGN.subtitle,
-    descriptionOverride: stored?.descriptionOverride,
-    signatories: [
-      toDraftSignatory(stored?.signatories?.[0], DEFAULT_CERTIFICATE_DESIGN.signatories[0]),
-      toDraftSignatory(stored?.signatories?.[1], DEFAULT_CERTIFICATE_DESIGN.signatories[1])
-    ],
-    idFormat: stored?.idFormat ?? DEFAULT_CERTIFICATE_DESIGN.idFormat
-  };
+  return resolveCertificateDesign(courseApi.course?.certificate);
 }
 
 class CertificateEditorStore {

--- a/packages/certificates/src/constants.ts
+++ b/packages/certificates/src/constants.ts
@@ -1,5 +1,22 @@
 import type { CertificateDesign, CertificateTemplateId, CertificateTemplateMeta } from './types';
 
+export const CERTIFICATE_WIDTH = 1100;
+export const CERTIFICATE_HEIGHT = 780;
+
+export const CERTIFICATE_VIEWPORT = {
+  width: CERTIFICATE_WIDTH,
+  height: CERTIFICATE_HEIGHT
+} as const;
+
+export const CERTIFICATE_PDF_PAGE_OPTIONS = {
+  width: `${CERTIFICATE_WIDTH}px`,
+  height: `${CERTIFICATE_HEIGHT}px`,
+  landscape: true,
+  printBackground: true,
+  preferCSSPageSize: true,
+  margin: { top: '0px', right: '0px', bottom: '0px', left: '0px' }
+} as const;
+
 export const ACCENT_COLORS = ['#7a1f1f', '#1e3a8a', '#ff4500', '#d4af37', '#0a0a0a', '#065f46'] as const;
 
 export type AccentColor = (typeof ACCENT_COLORS)[number];

--- a/packages/certificates/src/font-metrics.ts
+++ b/packages/certificates/src/font-metrics.ts
@@ -151,7 +151,13 @@ function getCharAdvanceRatio(char: string, profile: FontAdvanceProfile): number 
   return profile.defaultRatio;
 }
 
-function measureTextWidth(text: string, fontSize: number, profile: FontAdvanceProfile, letterSpacingEm = 0): number {
+function measureTextWidth(
+  text: string,
+  fontSize: number,
+  profile: FontAdvanceProfile,
+  letterSpacingEm = 0,
+  advanceMultiplier = 1.0
+): number {
   if (!text) return 0;
 
   const chars = splitGraphemes(text);
@@ -159,7 +165,7 @@ function measureTextWidth(text: string, fontSize: number, profile: FontAdvancePr
 
   let total = 0;
   for (const char of chars) {
-    total += getCharAdvanceRatio(char, profile) * fontSize;
+    total += getCharAdvanceRatio(char, profile) * advanceMultiplier * fontSize;
   }
 
   const trackingPerGap = letterSpacingEm * fontSize;
@@ -178,6 +184,27 @@ export interface FitFontSizeOptions {
   allowWrap?: boolean;
   letterSpacingEm?: number;
   textTransform?: 'none' | 'uppercase' | 'lowercase';
+  fontWeight?: number | 'normal' | 'bold' | 'black';
+  fontStyle?: 'normal' | 'italic';
+}
+
+function getWeightAdvanceMultiplier(fontWeight?: number | string): number {
+  if (!fontWeight) return 1.0;
+  if (fontWeight === 'black' || (typeof fontWeight === 'number' && fontWeight >= 900)) {
+    return 1.3;
+  }
+  if (fontWeight === 'bold' || (typeof fontWeight === 'number' && fontWeight >= 700)) {
+    return 1.12;
+  }
+  if (typeof fontWeight === 'number' && fontWeight >= 600) {
+    return 1.06;
+  }
+  return 1.0;
+}
+
+function getStyleAdvanceMultiplier(fontStyle?: string): number {
+  if (fontStyle === 'italic') return 1.1;
+  return 1.0;
 }
 
 // In-memory LRU-like cache for font size calculations
@@ -207,15 +234,19 @@ export function computeFitFontSize(text: string | undefined | null, options: Fit
   const allowWrap = options.allowWrap !== false;
   const letterSpacingEm = options.letterSpacingEm ?? 0;
   const profile = FONT_PROFILES[options.fontFamily] ?? FONT_PROFILES['Cormorant Garamond'];
+  const advanceMultiplier =
+    getWeightAdvanceMultiplier(options.fontWeight) * getStyleAdvanceMultiplier(options.fontStyle);
 
-  const cacheKey = `${transformedText}|${options.fontFamily}|${options.maxWidth}|${options.maxHeight}|${basePx}|${minPx}|${lineHeight}|${allowWrap}|${letterSpacingEm}`;
+  const cacheKey = `${transformedText}|${options.fontFamily}|${options.maxWidth}|${options.maxHeight}|${basePx}|${minPx}|${lineHeight}|${allowWrap}|${letterSpacingEm}|${options.fontWeight}|${options.fontStyle}`;
   const cached = FIT_CACHE.get(cacheKey);
   if (cached !== undefined) return cached;
 
   function doesFit(fontSize: number): boolean {
+    const descenderSlack = lineHeight < 1.25 ? Math.ceil(fontSize * (1.25 - lineHeight)) : 0;
+
     if (!allowWrap) {
-      const singleLineWidth = measureTextWidth(transformedText, fontSize, profile, letterSpacingEm);
-      const singleLineHeight = fontSize * lineHeight;
+      const singleLineWidth = measureTextWidth(transformedText, fontSize, profile, letterSpacingEm, advanceMultiplier);
+      const singleLineHeight = fontSize * lineHeight + descenderSlack;
       return singleLineWidth <= options.maxWidth && singleLineHeight <= options.maxHeight;
     }
 
@@ -224,11 +255,11 @@ export function computeFitFontSize(text: string | undefined | null, options: Fit
     let currentLineWidth = 0;
     let lineCount = 1;
     const trackingPerGap = letterSpacingEm * fontSize;
-    const spaceWidth = measureTextWidth(' ', fontSize, profile, letterSpacingEm);
+    const spaceWidth = measureTextWidth(' ', fontSize, profile, letterSpacingEm, advanceMultiplier);
 
     for (let i = 0; i < words.length; i++) {
       const word = words[i];
-      const wordWidth = measureTextWidth(word, fontSize, profile, letterSpacingEm);
+      const wordWidth = measureTextWidth(word, fontSize, profile, letterSpacingEm, advanceMultiplier);
 
       if (currentLineWidth > 0) {
         // Between words on the same line, account for tracking gaps around the space
@@ -250,7 +281,7 @@ export function computeFitFontSize(text: string | undefined | null, options: Fit
         let charLineWidth = 0;
         for (let j = 0; j < chars.length; j++) {
           const char = chars[j];
-          const charAdvance = getCharAdvanceRatio(char, profile) * fontSize;
+          const charAdvance = getCharAdvanceRatio(char, profile) * advanceMultiplier * fontSize;
           const charGap = charLineWidth > 0 ? trackingPerGap : 0;
           if (charLineWidth > 0 && charLineWidth + charGap + charAdvance > options.maxWidth) {
             lineCount += 1;
@@ -263,7 +294,7 @@ export function computeFitFontSize(text: string | undefined | null, options: Fit
       }
     }
 
-    const totalHeight = lineCount * fontSize * lineHeight;
+    const totalHeight = lineCount * fontSize * lineHeight + descenderSlack;
     return totalHeight <= options.maxHeight;
   }
 

--- a/packages/certificates/src/index.ts
+++ b/packages/certificates/src/index.ts
@@ -5,12 +5,19 @@ export {
   type CertificateRenderResult,
   type CertificateSignatory,
   type CertificateTemplateId,
-  type CertificateTemplateMeta
+  type CertificateTemplateMeta,
+  type StoredCertificateDesign,
+  type StoredCertificateRecord,
+  type StoredCertificateSignatory
 } from './types';
 
 export {
   ACCENT_COLORS,
+  CERTIFICATE_HEIGHT,
+  CERTIFICATE_PDF_PAGE_OPTIONS,
   CERTIFICATE_TEMPLATES,
+  CERTIFICATE_VIEWPORT,
+  CERTIFICATE_WIDTH,
   DEFAULT_ACCENT_COLOR,
   DEFAULT_CERTIFICATE_DESIGN,
   FONTS_READY_CLASS,
@@ -19,7 +26,7 @@ export {
   type AccentColor
 } from './constants';
 
-export { renderCertificate, renderCertificateDocument, resolveTemplateId } from './render';
+export { renderCertificate, renderCertificateDocument, resolveCertificateDesign, resolveTemplateId } from './render';
 export {
   computeFitFontSize,
   computeFieldFontSizes,

--- a/packages/certificates/src/render.ts
+++ b/packages/certificates/src/render.ts
@@ -1,5 +1,11 @@
-import { FONTS_READY_CLASS, LEGACY_THEME_MAP } from './constants';
-import type { CertificateDesign, CertificateRenderData, CertificateRenderResult, CertificateTemplateId } from './types';
+import { CERTIFICATE_WIDTH, DEFAULT_CERTIFICATE_DESIGN, FONTS_READY_CLASS, LEGACY_THEME_MAP } from './constants';
+import type {
+  CertificateDesign,
+  CertificateRenderData,
+  CertificateRenderResult,
+  CertificateTemplateId,
+  StoredCertificateRecord
+} from './types';
 import { CERTIFICATE_TEMPLATE_IDS } from './types';
 import { renderBrutalist } from './templates/brutalist';
 import { renderClassique } from './templates/classique';
@@ -28,6 +34,47 @@ export function resolveTemplateId(value: string | undefined | null): Certificate
   return 'classique';
 }
 
+/**
+ * Coerces a stored `course.certificate` record, resolving legacy themes and
+ * missing fields into a complete `CertificateDesign` suitable for `renderCertificate`.
+ */
+export function resolveCertificateDesign(stored?: StoredCertificateRecord | null): CertificateDesign {
+  const design = stored?.design;
+  const legacyTheme = stored?.theme ?? undefined;
+  const templateId = resolveTemplateId(design?.templateId ?? legacyTheme);
+
+  const accentColor =
+    design?.accentColor && /^#[0-9a-fA-F]{6}$/.test(design.accentColor)
+      ? design.accentColor
+      : DEFAULT_CERTIFICATE_DESIGN.accentColor;
+
+  const storedSignatories = Array.isArray(design?.signatories) ? design.signatories : undefined;
+
+  const signatories: CertificateDesign['signatories'] = [
+    {
+      name: storedSignatories?.[0]?.name ?? DEFAULT_CERTIFICATE_DESIGN.signatories[0].name,
+      role: storedSignatories?.[0]?.role ?? DEFAULT_CERTIFICATE_DESIGN.signatories[0].role,
+      enabled: storedSignatories?.[0]?.enabled ?? DEFAULT_CERTIFICATE_DESIGN.signatories[0].enabled,
+      signatureUrl: storedSignatories?.[0]?.signatureUrl
+    },
+    {
+      name: storedSignatories?.[1]?.name ?? DEFAULT_CERTIFICATE_DESIGN.signatories[1].name,
+      role: storedSignatories?.[1]?.role ?? DEFAULT_CERTIFICATE_DESIGN.signatories[1].role,
+      enabled: storedSignatories?.[1]?.enabled ?? DEFAULT_CERTIFICATE_DESIGN.signatories[1].enabled,
+      signatureUrl: storedSignatories?.[1]?.signatureUrl
+    }
+  ];
+
+  return {
+    templateId,
+    accentColor,
+    subtitle: design?.subtitle ?? DEFAULT_CERTIFICATE_DESIGN.subtitle,
+    descriptionOverride: design?.descriptionOverride,
+    signatories,
+    idFormat: design?.idFormat ?? DEFAULT_CERTIFICATE_DESIGN.idFormat
+  };
+}
+
 export function renderCertificate(design: CertificateDesign, data: CertificateRenderData): CertificateRenderResult {
   const templateId = resolveTemplateId(design.templateId);
   const renderer = RENDERERS[templateId];
@@ -37,7 +84,7 @@ export function renderCertificate(design: CertificateDesign, data: CertificateRe
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=1100,initial-scale=1.0">
+  <meta name="viewport" content="width=${CERTIFICATE_WIDTH},initial-scale=1.0">
   <title>Certificate</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/packages/certificates/src/templates/brutalist.ts
+++ b/packages/certificates/src/templates/brutalist.ts
@@ -1,3 +1,4 @@
+import { CERTIFICATE_WIDTH } from '../constants';
 import { CERTIFICATE_FONTS } from '../font-metrics';
 import { escapeHtml, prepareCertificateRenderContext, renderSignatoryBlock, type TemplateRenderer } from './shared';
 
@@ -6,9 +7,11 @@ const FONTS = {
   mono: CERTIFICATE_FONTS.jetbrainsMono
 } as const;
 
+const certPaddingHorizontal = 45;
+const certPaddingX = certPaddingHorizontal * 2;
 const dateRowItemWidth = 180;
 const subtitleRowItemWidth = 300;
-const courseRowItemWidth = 1100 - 90 - dateRowItemWidth - subtitleRowItemWidth; // 1100px total - 90px margins - dateRowItemWidth - subtitleRowItemWidth
+const courseRowItemWidth = CERTIFICATE_WIDTH - certPaddingX - dateRowItemWidth - subtitleRowItemWidth;
 const metaRowCellPaddingHorizontal = 18;
 const metaRowCellPaddingVertical = 14;
 const metaRowCellPaddingX = metaRowCellPaddingHorizontal * 2;
@@ -16,6 +19,8 @@ const metaRowCellPaddingY = metaRowCellPaddingVertical * 2;
 const certIdPaddingHorizontal = 10;
 const certIdPaddingVertical = 6;
 const recipientPaddingLeft = 16;
+const numMaxWidth = CERTIFICATE_WIDTH - certPaddingX;
+const footerColumnWidth = CERTIFICATE_WIDTH / 2 - certPaddingX;
 
 const metaRowItemData = {
   maxHeight: 73 - metaRowCellPaddingY,
@@ -44,6 +49,15 @@ const FIELDS = {
     basePx: 11,
     allowWrap: false,
     textTransform: 'uppercase' as const
+  },
+  num: {
+    maxWidth: numMaxWidth,
+    maxHeight: 120,
+    fontFamily: FONTS.mono,
+    basePx: 120,
+    fontWeight: 700 as const,
+    allowWrap: false,
+    letterSpacingEm: -0.04
   },
   date: {
     maxWidth: dateRowItemWidth - metaRowCellPaddingX,
@@ -75,11 +89,30 @@ const FIELDS = {
     lineHeight: 1.35,
     letterSpacingEm: 0.02,
     allowWrap: true
+  },
+  signatoryName: {
+    maxWidth: footerColumnWidth,
+    maxHeight: 28,
+    fontFamily: FONTS.display,
+    basePx: 18,
+    allowWrap: false,
+    letterSpacingEm: -0.01,
+    textTransform: 'uppercase' as const
+  },
+  signatoryRole: {
+    maxWidth: footerColumnWidth,
+    maxHeight: 24,
+    fontFamily: FONTS.mono,
+    basePx: 9,
+    lineHeight: 1.2,
+    letterSpacingEm: 0.22,
+    allowWrap: true,
+    textTransform: 'uppercase' as const
   }
 } as const;
 
 export const renderBrutalist: TemplateRenderer = ({ design, data }) => {
-  const { accent, subtitle, description, signatoryOne, signatoryTwo, idDigits, fontSizes } =
+  const { accent, subtitle, description, signatoryOne, signatoryTwo, idDigits, fontSizes, roleMinHeight } =
     prepareCertificateRenderContext(design, data, FIELDS);
 
   const metaRowFontSize = Math.min(fontSizes.date, fontSizes.course, fontSizes.subtitle);
@@ -143,7 +176,7 @@ export const renderBrutalist: TemplateRenderer = ({ design, data }) => {
       display: flex;
       justify-content: space-between;
       align-items: flex-start;
-      padding: 35px 45px 0;
+      padding: 35px ${certPaddingHorizontal}px 0;
       margin-bottom: 10px;
       position: relative;
       z-index: 2;
@@ -166,20 +199,22 @@ export const renderBrutalist: TemplateRenderer = ({ design, data }) => {
       overflow-wrap: break-word;
     }
     .t-brutalist .title-block {
-      padding: 8px 45px 0;
+      padding: 8px ${certPaddingHorizontal}px 0;
       margin-bottom: 25px;
       position: relative;
       z-index: 2;
       flex-shrink: 0;
     }
     .t-brutalist .num {
-      font-family: '${FONTS.mono}', monospace;
-      font-size: 120px;
-      font-weight: 700;
+      font-family: '${FIELDS.num.fontFamily}', monospace;
+      font-size: ${fontSizes.num}px;
+      font-weight: ${FIELDS.num.fontWeight};
       line-height: 1;
-      max-height: 120px;
+      max-height: ${FIELDS.num.maxHeight}px;
+      max-width: ${numMaxWidth}px;
       color: ${accent};
-      letter-spacing: -0.04em;
+      letter-spacing: ${FIELDS.num.letterSpacingEm}em;
+      overflow-wrap: break-word;
     }
     .t-brutalist .num span { color: #000; }
     .t-brutalist .meta-row {
@@ -187,7 +222,7 @@ export const renderBrutalist: TemplateRenderer = ({ design, data }) => {
       grid-template-columns: ${dateRowItemWidth}px ${courseRowItemWidth}px ${subtitleRowItemWidth}px;
       border-top: 4px solid ${accent};
       border-bottom: 2px solid #000;
-      margin: 0 45px 0px;
+      margin: 0 ${certPaddingHorizontal}px;
       position: relative;
       z-index: 2;
       flex-shrink: 0;
@@ -218,7 +253,7 @@ export const renderBrutalist: TemplateRenderer = ({ design, data }) => {
       word-break: normal;
     }
     .t-brutalist .recipient-block {
-      padding: 0 45px;
+      padding: 0 ${certPaddingHorizontal}px;
       margin-bottom: 30px;
       position: relative;
       z-index: 2;
@@ -274,23 +309,33 @@ export const renderBrutalist: TemplateRenderer = ({ design, data }) => {
       z-index: 2;
     }
     .t-brutalist .footer > div {
-      padding: 14px 45px;
+      padding: 14px ${certPaddingHorizontal}px;
       font-family: '${FONTS.mono}', monospace;
     }
     .t-brutalist .footer > div:first-child { border-right: 2px solid #000; }
     .t-brutalist .footer .lbl {
-      font-size: 9px;
-      letter-spacing: 0.22em;
+      font-family: '${FIELDS.signatoryRole.fontFamily}', monospace;
+      font-size: ${fontSizes.signatoryRole}px;
+      line-height: ${FIELDS.signatoryRole.lineHeight};
+      letter-spacing: ${FIELDS.signatoryRole.letterSpacingEm}em;
       color: #666;
-      text-transform: uppercase;
-      margin-bottom: 2px;
+      text-transform: ${FIELDS.signatoryRole.textTransform};
+      margin-bottom: 6px;
+      max-width: ${footerColumnWidth}px;
+      min-height: ${roleMinHeight}px;
+      max-height: ${FIELDS.signatoryRole.maxHeight}px;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
       overflow-wrap: break-word;
     }
     .t-brutalist .footer .name {
-      font-family: '${FONTS.display}', sans-serif;
-      font-size: 18px;
-      text-transform: uppercase;
-      letter-spacing: -0.01em;
+      font-family: '${FIELDS.signatoryName.fontFamily}', sans-serif;
+      font-size: ${fontSizes.signatoryName}px;
+      text-transform: ${FIELDS.signatoryName.textTransform};
+      letter-spacing: ${FIELDS.signatoryName.letterSpacingEm}em;
+      max-width: ${footerColumnWidth}px;
+      max-height: ${FIELDS.signatoryName.maxHeight}px;
       overflow-wrap: break-word;
     }
     .t-brutalist .stamp {

--- a/packages/certificates/src/templates/classique.ts
+++ b/packages/certificates/src/templates/classique.ts
@@ -1,3 +1,4 @@
+import { CERTIFICATE_WIDTH } from '../constants';
 import { CERTIFICATE_FONTS } from '../font-metrics';
 import {
   escapeHtml,
@@ -13,7 +14,12 @@ const FONTS = {
   heading: CERTIFICATE_FONTS.cinzel
 } as const;
 
+const certPadding = 55;
 const recipientPaddingBottom = 14;
+const sealSide = 108;
+const footerGap = 30;
+const signatoryColumnWidth = (CERTIFICATE_WIDTH - certPadding * 2 - footerGap * 2 - sealSide) / 2;
+const sealLabelMaxWidth = 85;
 
 const FIELDS = {
   org: {
@@ -31,6 +37,8 @@ const FIELDS = {
     fontFamily: FONTS.display,
     basePx: 62,
     lineHeight: 1.15,
+    fontStyle: 'italic' as const,
+    fontWeight: 400 as const,
     allowWrap: true
   },
   subtitle: {
@@ -56,12 +64,40 @@ const FIELDS = {
     fontFamily: FONTS.serif,
     basePx: 16,
     lineHeight: 1.45,
+    fontStyle: 'italic' as const,
     allowWrap: true
+  },
+  signatoryName: {
+    maxWidth: signatoryColumnWidth,
+    maxHeight: 28,
+    fontFamily: FONTS.display,
+    basePx: 18,
+    fontStyle: 'italic' as const,
+    allowWrap: false
+  },
+  signatoryRole: {
+    maxWidth: signatoryColumnWidth,
+    maxHeight: 26,
+    fontFamily: FONTS.heading,
+    basePx: 10,
+    lineHeight: 1.2,
+    letterSpacingEm: 0.25,
+    allowWrap: true,
+    textTransform: 'uppercase' as const
+  },
+  sealLabel: {
+    maxWidth: sealLabelMaxWidth,
+    maxHeight: 14,
+    fontFamily: FONTS.heading,
+    basePx: 8,
+    allowWrap: false,
+    letterSpacingEm: 0.15,
+    textTransform: 'uppercase' as const
   }
 } as const;
 
 export const renderClassique: TemplateRenderer = ({ design, data }) => {
-  const { accent, subtitle, description, signatoryOne, signatoryTwo, year, fontSizes } =
+  const { accent, subtitle, description, signatoryOne, signatoryTwo, year, fontSizes, roleMinHeight } =
     prepareCertificateRenderContext(design, data, FIELDS);
 
   const body = `
@@ -96,7 +132,7 @@ export const renderClassique: TemplateRenderer = ({ design, data }) => {
     .t-classique {
       background: #faf6ec;
       color: #2a1810;
-      padding: 55px;
+      padding: ${certPadding}px;
       font-family: '${FONTS.serif}', serif;
       display: flex;
       flex-direction: column;
@@ -158,8 +194,8 @@ export const renderClassique: TemplateRenderer = ({ design, data }) => {
     .t-classique .title {
       text-align: center;
       font-family: '${FIELDS.title.fontFamily}', serif;
-      font-weight: 400;
-      font-style: italic;
+      font-weight: ${FIELDS.title.fontWeight};
+      font-style: ${FIELDS.title.fontStyle};
       line-height: ${FIELDS.title.lineHeight};
       color: #2a1810;
       max-width: ${FIELDS.title.maxWidth}px;
@@ -216,7 +252,8 @@ export const renderClassique: TemplateRenderer = ({ design, data }) => {
     }
     .t-classique .description {
       text-align: center;
-      font-style: italic;
+      font-family: '${FIELDS.description.fontFamily}', serif;
+      font-style: ${FIELDS.description.fontStyle};
       color: #3a2515;
       margin-top: 6px;
       line-height: ${FIELDS.description.lineHeight};
@@ -232,8 +269,8 @@ export const renderClassique: TemplateRenderer = ({ design, data }) => {
       width: 100%;
       display: grid;
       grid-template-columns: 1fr auto 1fr;
-      align-items: end;
-      gap: 30px;
+      align-items: start;
+      gap: ${footerGap}px;
       position: relative;
       z-index: 1;
       margin-bottom: 52px;
@@ -245,23 +282,34 @@ export const renderClassique: TemplateRenderer = ({ design, data }) => {
       padding-top: 4px;
     }
     .t-classique .sig .name {
-      font-family: '${FONTS.display}', serif;
-      font-size: 18px;
-      font-style: italic;
+      font-family: '${FIELDS.signatoryName.fontFamily}', serif;
+      font-size: ${fontSizes.signatoryName}px;
+      font-style: ${FIELDS.signatoryName.fontStyle};
+      min-height: ${FIELDS.signatoryName.maxHeight}px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      max-width: ${signatoryColumnWidth}px;
       overflow-wrap: break-word;
+      word-break: normal;
     }
     .t-classique .sig .label {
-      font-family: '${FONTS.heading}', serif;
-      font-size: 10px;
-      letter-spacing: 0.25em;
+      font-family: '${FIELDS.signatoryRole.fontFamily}', serif;
+      font-size: ${fontSizes.signatoryRole}px;
+      line-height: ${FIELDS.signatoryRole.lineHeight};
+      letter-spacing: ${FIELDS.signatoryRole.letterSpacingEm}em;
       color: ${accent};
-      text-transform: uppercase;
-      margin-top: 2px;
+      text-transform: ${FIELDS.signatoryRole.textTransform};
+      margin-top: 4px;
+      max-width: ${signatoryColumnWidth}px;
+      min-height: ${roleMinHeight}px;
+      max-height: ${FIELDS.signatoryRole.maxHeight}px;
       overflow-wrap: break-word;
     }
     .t-classique .seal {
-      width: 108px;
-      height: 108px;
+      align-self: center;
+      width: ${sealSide}px;
+      height: ${sealSide}px;
       border: 2px solid ${accent};
       border-radius: 50%;
       display: flex;
@@ -289,12 +337,14 @@ export const renderClassique: TemplateRenderer = ({ design, data }) => {
       line-height: 1;
     }
     .t-classique .seal .lbl {
-      font-family: '${FONTS.heading}', serif;
-      font-size: 8px;
-      letter-spacing: 0.15em;
+      font-family: '${FIELDS.sealLabel.fontFamily}', serif;
+      font-size: ${fontSizes.sealLabel}px;
+      letter-spacing: ${FIELDS.sealLabel.letterSpacingEm}em;
+      text-transform: ${FIELDS.sealLabel.textTransform};
       margin-top: 2px;
       line-height: 1;
-      max-width: 85px;
+      max-width: ${FIELDS.sealLabel.maxWidth}px;
+      max-height: ${FIELDS.sealLabel.maxHeight}px;
       overflow-wrap: break-word;
     }
   `;

--- a/packages/certificates/src/templates/minimal.ts
+++ b/packages/certificates/src/templates/minimal.ts
@@ -1,3 +1,4 @@
+import { CERTIFICATE_WIDTH } from '../constants';
 import { CERTIFICATE_FONTS } from '../font-metrics';
 import {
   escapeHtml,
@@ -20,6 +21,9 @@ const subtitleTotalDecorationWidth = (subtitleDecorationLineWidth + subtitleDeco
 const recipientRowPaddingBottom = 14;
 const recipientNumColumnWidth = 120;
 const recipientRowGap = 30;
+const certPaddingHorizontal = 100;
+const footerGap = 30;
+const footerColumnWidth = (CERTIFICATE_WIDTH - certPaddingHorizontal * 2 - borderLeftWidth - footerGap * 3) / 4;
 
 const FIELDS = {
   org: {
@@ -56,7 +60,17 @@ const FIELDS = {
     basePx: 68,
     lineHeight: 1.05,
     letterSpacingEm: -0.01,
+    fontStyle: 'italic' as const,
+    fontWeight: 300 as const,
     allowWrap: true
+  },
+  recipientNum: {
+    maxWidth: recipientNumColumnWidth,
+    maxHeight: 20,
+    fontFamily: FONTS.mono,
+    basePx: 14,
+    allowWrap: false,
+    letterSpacingEm: 0.1
   },
   recipient: {
     maxWidth: 900 - borderLeftWidth - recipientNumColumnWidth - recipientRowGap,
@@ -74,15 +88,31 @@ const FIELDS = {
     basePx: 16,
     lineHeight: 1.6,
     allowWrap: true
+  },
+  footerValue: {
+    maxWidth: footerColumnWidth,
+    maxHeight: 40,
+    fontFamily: FONTS.serif,
+    basePx: 20,
+    lineHeight: 1.1,
+    fontWeight: 500 as const,
+    allowWrap: true
+  },
+  signatoryRole: {
+    maxWidth: footerColumnWidth,
+    maxHeight: 24,
+    fontFamily: FONTS.mono,
+    basePx: 9,
+    lineHeight: 1.2,
+    letterSpacingEm: 0.25,
+    allowWrap: true,
+    textTransform: 'uppercase' as const
   }
 } as const;
 
 export const renderMinimal: TemplateRenderer = ({ design, data }) => {
-  const { accent, subtitle, description, signatoryOne, signatoryTwo, fontSizes } = prepareCertificateRenderContext(
-    design,
-    data,
-    FIELDS
-  );
+  const { accent, subtitle, description, signatoryOne, signatoryTwo, fontSizes, roleMinHeight } =
+    prepareCertificateRenderContext(design, data, FIELDS);
 
   const body = `
     <div class="cert t-minimal">
@@ -116,7 +146,7 @@ export const renderMinimal: TemplateRenderer = ({ design, data }) => {
     .t-minimal {
       background: #fff;
       color: #0a0a0a;
-      padding: 80px 100px;
+      padding: 80px ${certPaddingHorizontal}px;
       font-family: '${FONTS.sans}', sans-serif;
       display: flex;
       flex-direction: column;
@@ -180,11 +210,11 @@ export const renderMinimal: TemplateRenderer = ({ design, data }) => {
     }
     .t-minimal .title {
       font-family: '${FIELDS.title.fontFamily}', serif;
-      font-weight: 300;
-      font-style: italic;
+      font-weight: ${FIELDS.title.fontWeight};
+      font-style: ${FIELDS.title.fontStyle};
       line-height: ${FIELDS.title.lineHeight};
       letter-spacing: ${FIELDS.title.letterSpacingEm}em;
-      margin-bottom: 50px;
+      margin-bottom: 38px;
       max-width: ${FIELDS.title.maxWidth}px;
       max-height: ${FIELDS.title.maxHeight}px;
       overflow-wrap: break-word;
@@ -206,11 +236,13 @@ export const renderMinimal: TemplateRenderer = ({ design, data }) => {
       margin-bottom: 14px;
     }
     .t-minimal .recipient-row .num {
-      font-family: '${FONTS.mono}', monospace;
-      font-size: 14px;
+      font-family: '${FIELDS.recipientNum.fontFamily}', monospace;
+      font-size: ${fontSizes.recipientNum}px;
       color: ${accent};
       padding-bottom: ${recipientRowPaddingBottom}px;
-      letter-spacing: 0.1em;
+      letter-spacing: ${FIELDS.recipientNum.letterSpacingEm}em;
+      max-width: ${recipientNumColumnWidth}px;
+      max-height: ${FIELDS.recipientNum.maxHeight}px;
       overflow-wrap: break-word;
     }
     .t-minimal .recipient {
@@ -237,8 +269,8 @@ export const renderMinimal: TemplateRenderer = ({ design, data }) => {
       flex-shrink: 0;
       display: grid;
       grid-template-columns: 1fr 1fr 1fr 1fr;
-      align-items: end;
-      gap: 30px;
+      align-items: start;
+      gap: ${footerGap}px;
       padding-top: 20px;
       border-top: 1px solid #0a0a0a;
       font-family: '${FONTS.mono}', monospace;
@@ -252,18 +284,28 @@ export const renderMinimal: TemplateRenderer = ({ design, data }) => {
       justify-content: flex-start;
     }
     .t-minimal .footer .k {
-      font-size: 9px;
-      letter-spacing: 0.25em;
-      text-transform: uppercase;
+      font-family: '${FIELDS.signatoryRole.fontFamily}', monospace;
+      font-size: ${fontSizes.signatoryRole}px;
+      line-height: ${FIELDS.signatoryRole.lineHeight};
+      letter-spacing: ${FIELDS.signatoryRole.letterSpacingEm}em;
+      text-transform: ${FIELDS.signatoryRole.textTransform};
       color: #999;
-      margin-bottom: 4px;
+      margin-bottom: 6px;
+      max-width: ${footerColumnWidth}px;
+      min-height: ${roleMinHeight}px;
+      max-height: ${FIELDS.signatoryRole.maxHeight}px;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
       overflow-wrap: break-word;
     }
     .t-minimal .footer .v {
-      font-family: '${FONTS.serif}', serif;
-      font-size: 20px;
-      font-weight: 500;
-      line-height: 1.1;
+      font-family: '${FIELDS.footerValue.fontFamily}', serif;
+      font-size: ${fontSizes.footerValue}px;
+      font-weight: ${FIELDS.footerValue.fontWeight};
+      line-height: ${FIELDS.footerValue.lineHeight};
+      max-width: ${footerColumnWidth}px;
+      max-height: ${FIELDS.footerValue.maxHeight}px;
       overflow-wrap: break-word;
     }
     .t-minimal .footer .ref .k { color: ${accent}; }

--- a/packages/certificates/src/templates/noir.ts
+++ b/packages/certificates/src/templates/noir.ts
@@ -1,3 +1,4 @@
+import { CERTIFICATE_WIDTH } from '../constants';
 import { CERTIFICATE_FONTS } from '../font-metrics';
 import {
   escapeHtml,
@@ -17,7 +18,11 @@ const FONTS = {
 const subtitleDecorationLineWidth = 50;
 const subtitleDecorationGap = 14;
 const subtitleTotalDecorationWidth = (subtitleDecorationLineWidth + subtitleDecorationGap) * 2;
+const certPadding = 55;
 const recipientPaddingBottom = 14;
+const medalWidth = 108;
+const footerGap = 30;
+const signatoryColumnWidth = (CERTIFICATE_WIDTH - certPadding * 2 - footerGap * 2 - medalWidth) / 2;
 
 const FIELDS = {
   org: {
@@ -53,6 +58,8 @@ const FIELDS = {
     fontFamily: FONTS.display,
     basePx: 62,
     lineHeight: 1.15,
+    fontStyle: 'italic' as const,
+    fontWeight: 400 as const,
     allowWrap: true
   },
   subtitle: {
@@ -78,12 +85,31 @@ const FIELDS = {
     fontFamily: FONTS.serif,
     basePx: 16,
     lineHeight: 1.45,
+    fontStyle: 'italic' as const,
     allowWrap: true
+  },
+  signatoryName: {
+    maxWidth: signatoryColumnWidth,
+    maxHeight: 28,
+    fontFamily: FONTS.display,
+    basePx: 18,
+    fontStyle: 'italic' as const,
+    allowWrap: false
+  },
+  signatoryRole: {
+    maxWidth: signatoryColumnWidth,
+    maxHeight: 26,
+    fontFamily: FONTS.heading,
+    basePx: 10,
+    lineHeight: 1.2,
+    letterSpacingEm: 0.25,
+    allowWrap: true,
+    textTransform: 'uppercase' as const
   }
 } as const;
 
 export const renderNoir: TemplateRenderer = ({ design, data }) => {
-  const { accent, subtitle, description, signatoryOne, signatoryTwo, year, fontSizes } =
+  const { accent, subtitle, description, signatoryOne, signatoryTwo, year, fontSizes, roleMinHeight } =
     prepareCertificateRenderContext(design, data, FIELDS);
 
   const accentDeep = shadeColor(accent, -30);
@@ -135,7 +161,7 @@ export const renderNoir: TemplateRenderer = ({ design, data }) => {
     .t-noir {
       background: #0e0e0e;
       color: #f5f1e8;
-      padding: 55px;
+      padding: ${certPadding}px;
       font-family: '${FONTS.serif}', serif;
       background-image:
         radial-gradient(circle at 30% 20%, ${accent}14, transparent 50%),
@@ -241,8 +267,8 @@ export const renderNoir: TemplateRenderer = ({ design, data }) => {
     .t-noir .title {
       text-align: center;
       font-family: '${FIELDS.title.fontFamily}', serif;
-      font-weight: 400;
-      font-style: italic;
+      font-weight: ${FIELDS.title.fontWeight};
+      font-style: ${FIELDS.title.fontStyle};
       line-height: ${FIELDS.title.lineHeight};
       color: #f5f1e8;
       max-width: ${FIELDS.title.maxWidth}px;
@@ -312,7 +338,7 @@ export const renderNoir: TemplateRenderer = ({ design, data }) => {
     .t-noir .description {
       text-align: center;
       font-family: '${FIELDS.description.fontFamily}', serif;
-      font-style: italic;
+      font-style: ${FIELDS.description.fontStyle};
       color: #c9b88c;
       margin-top: 6px;
       line-height: ${FIELDS.description.lineHeight};
@@ -327,8 +353,8 @@ export const renderNoir: TemplateRenderer = ({ design, data }) => {
       width: 100%;
       display: grid;
       grid-template-columns: 1fr auto 1fr;
-      align-items: end;
-      gap: 30px;
+      align-items: start;
+      gap: ${footerGap}px;
       position: relative;
       z-index: 1;
       margin-bottom: 52px;
@@ -340,24 +366,35 @@ export const renderNoir: TemplateRenderer = ({ design, data }) => {
       padding-top: 4px;
     }
     .t-noir .sig .name {
-      font-family: '${FONTS.display}', serif;
-      font-size: 18px;
-      font-style: italic;
+      font-family: '${FIELDS.signatoryName.fontFamily}', serif;
+      font-size: ${fontSizes.signatoryName}px;
+      font-style: ${FIELDS.signatoryName.fontStyle};
       color: #f5f1e8;
+      min-height: ${FIELDS.signatoryName.maxHeight}px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      max-width: ${signatoryColumnWidth}px;
       overflow-wrap: break-word;
+      word-break: normal;
     }
     .t-noir .sig .label {
-      font-family: '${FONTS.heading}', serif;
-      font-size: 10px;
-      letter-spacing: 0.25em;
+      font-family: '${FIELDS.signatoryRole.fontFamily}', serif;
+      font-size: ${fontSizes.signatoryRole}px;
+      line-height: ${FIELDS.signatoryRole.lineHeight};
+      letter-spacing: ${FIELDS.signatoryRole.letterSpacingEm}em;
       color: ${accent};
-      text-transform: uppercase;
-      margin-top: 2px;
+      text-transform: ${FIELDS.signatoryRole.textTransform};
+      margin-top: 4px;
+      max-width: ${signatoryColumnWidth}px;
+      min-height: ${roleMinHeight}px;
+      max-height: ${FIELDS.signatoryRole.maxHeight}px;
       overflow-wrap: break-word;
     }
     .t-noir .medal {
-      width: 108px;
-      height: 108px;
+      align-self: center;
+      width: ${medalWidth}px;
+      height: ${medalWidth}px;
       border-radius: 50%;
       background: radial-gradient(circle, ${accent} 0%, ${accentDeep} 100%);
       display: flex;

--- a/packages/certificates/src/templates/poster.ts
+++ b/packages/certificates/src/templates/poster.ts
@@ -18,6 +18,9 @@ const orgPillPaddingVertical = 5;
 const recipientBoxPaddingHorizontal = 30;
 const recipientBoxPaddingVertical = 24;
 const descriptionPaddingBottom = 8;
+const bottomGridMaxWidth = 780;
+const bottomGridGap = 30;
+const bottomGridColumnWidth = (bottomGridMaxWidth - bottomGridGap * 2) / 3;
 
 const FIELDS = {
   org: {
@@ -45,7 +48,8 @@ const FIELDS = {
     basePx: 140,
     lineHeight: 0.95,
     letterSpacingEm: -0.03,
-    allowWrap: true
+    allowWrap: true,
+    fontWeight: 900 as const
   },
   subtitle: {
     maxWidth: 800,
@@ -53,6 +57,7 @@ const FIELDS = {
     fontFamily: FONTS.display,
     basePx: 32,
     lineHeight: 1.0,
+    fontStyle: 'italic' as const,
     allowWrap: false
   },
   recipient: {
@@ -61,7 +66,8 @@ const FIELDS = {
     fontFamily: FONTS.display,
     basePx: 54,
     lineHeight: 1.0,
-    allowWrap: true
+    allowWrap: true,
+    fontWeight: 700 as const
   },
   description: {
     maxWidth: 720,
@@ -70,12 +76,31 @@ const FIELDS = {
     basePx: 15,
     lineHeight: 1.55,
     allowWrap: true
+  },
+  footerValue: {
+    maxWidth: bottomGridColumnWidth,
+    maxHeight: 52,
+    fontFamily: FONTS.display,
+    basePx: 22,
+    lineHeight: 1.1,
+    allowWrap: true,
+    fontWeight: 700 as const
+  },
+  signatoryRole: {
+    maxWidth: bottomGridColumnWidth,
+    maxHeight: 24,
+    fontFamily: FONTS.mono,
+    basePx: 9,
+    lineHeight: 1.2,
+    letterSpacingEm: 0.2,
+    allowWrap: true,
+    textTransform: 'uppercase' as const
   }
 } as const;
 
 export const renderPoster: TemplateRenderer = ({ design, data }) => {
   const certMeta = `${data.certificateId} / ${data.date}`;
-  const { accent, subtitle, description, signatoryOne, signatoryTwo, year, fontSizes } =
+  const { accent, subtitle, description, signatoryOne, signatoryTwo, year, fontSizes, roleMinHeight } =
     prepareCertificateRenderContext(design, data, FIELDS, {
       certMeta
     });
@@ -203,13 +228,12 @@ export const renderPoster: TemplateRenderer = ({ design, data }) => {
     }
     .t-poster .title {
       font-family: '${FIELDS.title.fontFamily}', serif;
-      font-weight: 900;
+      font-weight: ${FIELDS.title.fontWeight};
       line-height: ${FIELDS.title.lineHeight};
       letter-spacing: ${FIELDS.title.letterSpacingEm}em;
       color: #1a1a1a;
       margin-bottom: 20px;
       max-width: ${FIELDS.title.maxWidth}px;
-      max-height: ${FIELDS.title.maxHeight}px;
       overflow-wrap: break-word;
       word-break: normal;
     }
@@ -220,13 +244,12 @@ export const renderPoster: TemplateRenderer = ({ design, data }) => {
     }
     .t-poster .subtitle {
       font-family: '${FIELDS.subtitle.fontFamily}', serif;
-      font-style: italic;
+      font-style: ${FIELDS.subtitle.fontStyle};
       font-weight: 400;
       line-height: ${FIELDS.subtitle.lineHeight};
       margin-bottom: 30px;
       color: #1a1a1a;
       max-width: ${FIELDS.subtitle.maxWidth}px;
-      max-height: ${FIELDS.subtitle.maxHeight}px;
       overflow-wrap: break-word;
     }
     .t-poster .recipient-box {
@@ -251,7 +274,7 @@ export const renderPoster: TemplateRenderer = ({ design, data }) => {
     }
     .t-poster .recipient {
       font-family: '${FIELDS.recipient.fontFamily}', serif;
-      font-weight: 700;
+      font-weight: ${FIELDS.recipient.fontWeight};
       line-height: ${FIELDS.recipient.lineHeight};
       letter-spacing: -0.02em;
       max-width: ${FIELDS.recipient.maxWidth}px;
@@ -282,10 +305,10 @@ export const renderPoster: TemplateRenderer = ({ design, data }) => {
     .t-poster .bottom-grid {
       display: grid;
       grid-template-columns: 1fr 1fr 1fr;
-      align-items: end;
-      gap: 30px;
+      align-items: start;
+      gap: ${bottomGridGap}px;
       flex: 1;
-      max-width: 780px;
+      max-width: ${bottomGridMaxWidth}px;
       font-family: '${FONTS.mono}', monospace;
     }
     .t-poster .footer-section .sig-content,
@@ -297,18 +320,29 @@ export const renderPoster: TemplateRenderer = ({ design, data }) => {
       justify-content: flex-start;
     }
     .t-poster .footer-section .k {
-      font-size: 9px;
-      letter-spacing: 0.2em;
-      text-transform: uppercase;
+      font-family: '${FIELDS.signatoryRole.fontFamily}', monospace;
+      font-size: ${fontSizes.signatoryRole}px;
+      line-height: ${FIELDS.signatoryRole.lineHeight};
+      letter-spacing: ${FIELDS.signatoryRole.letterSpacingEm}em;
+      text-transform: ${FIELDS.signatoryRole.textTransform};
       color: #4a4a4a;
-      margin-bottom: 2px;
+      margin-bottom: 6px;
+      max-width: ${bottomGridColumnWidth}px;
+      min-height: ${roleMinHeight}px;
+      max-height: ${FIELDS.signatoryRole.maxHeight}px;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
       overflow-wrap: break-word;
     }
     .t-poster .footer-section .v {
-      font-family: '${FONTS.display}', serif;
-      font-size: 22px;
-      font-weight: 700;
+      font-family: '${FIELDS.footerValue.fontFamily}', serif;
+      font-size: ${fontSizes.footerValue}px;
+      font-weight: ${FIELDS.footerValue.fontWeight};
+      line-height: ${FIELDS.footerValue.lineHeight};
       color: #1a1a1a;
+      max-width: ${bottomGridColumnWidth}px;
+      max-height: ${FIELDS.footerValue.maxHeight}px;
       overflow-wrap: break-word;
     }
     .t-poster .corner-num {

--- a/packages/certificates/src/templates/shared.ts
+++ b/packages/certificates/src/templates/shared.ts
@@ -1,5 +1,6 @@
 import type { CertificateDesign, CertificateRenderData, CertificateSignatory } from '../types';
-import { computeFieldFontSizes, type FitFontSizeOptions } from '../font-metrics';
+import { CERTIFICATE_HEIGHT, CERTIFICATE_WIDTH } from '../constants';
+import { computeFieldFontSizes, computeFitFontSize, type FitFontSizeOptions } from '../font-metrics';
 
 export function escapeHtml(input: unknown): string {
   return String(input ?? '').replace(/[&<>"']/g, (char) => {
@@ -25,6 +26,10 @@ export function getYear(value: string | undefined | null): string {
   return String(new Date().getFullYear());
 }
 
+export function getCertificateIdDigits(value: string | undefined | null): string {
+  return String(value ?? '').match(/\d+/)?.[0] ?? '00';
+}
+
 export function shadeColor(hex: string, percent: number): string {
   const normalized = hex.startsWith('#') ? hex.slice(1) : hex;
   if (normalized.length !== 6) return hex;
@@ -40,6 +45,47 @@ export function shadeColor(hex: string, percent: number): string {
   const next = (red << 16) | (green << 8) | blue;
 
   return '#' + next.toString(16).padStart(6, '0');
+}
+
+export function doesFieldWrap(text: string | undefined | null, fieldOptions: FitFontSizeOptions): boolean {
+  if (!text) return false;
+  const singleLineSize = computeFitFontSize(text, { ...fieldOptions, allowWrap: false });
+  return singleLineSize < fieldOptions.basePx;
+}
+
+export function getActiveSignatories(signatories?: (CertificateSignatory | undefined)[]): CertificateSignatory[] {
+  return (signatories ?? []).filter((sig): sig is CertificateSignatory => Boolean(sig && sig.enabled !== false));
+}
+
+export function getPositionalSignatories(
+  signatories?: [CertificateSignatory?, CertificateSignatory?] | CertificateSignatory[]
+): [CertificateSignatory | undefined, CertificateSignatory | undefined] {
+  const [rawOne, rawTwo] = signatories ?? [];
+  const signatoryOne = rawOne && rawOne.enabled !== false ? rawOne : undefined;
+  const signatoryTwo = rawTwo && rawTwo.enabled !== false ? rawTwo : undefined;
+  return [signatoryOne, signatoryTwo];
+}
+
+function getLongestSignatoryValue(signatories: CertificateSignatory[], field: 'name' | 'role'): string {
+  if (signatories.length === 0) return '';
+  return [...signatories].sort((a, b) => (b[field]?.length ?? 0) - (a[field]?.length ?? 0))[0]?.[field] ?? '';
+}
+
+export function doesAnySignatoryRoleWrap(
+  signatories: CertificateSignatory[] | undefined,
+  fieldOptions: FitFontSizeOptions
+): boolean {
+  return getActiveSignatories(signatories).some((sig) => doesFieldWrap(sig.role, fieldOptions));
+}
+
+export function getFooterCandidateValues(
+  signatories: CertificateSignatory[] | undefined,
+  data: CertificateRenderData
+): string[] {
+  const activeSignatories = getActiveSignatories(signatories);
+  return [...activeSignatories.map((sig) => sig.name), data.date, data.certificateId].filter((val): val is string =>
+    Boolean(val)
+  );
 }
 
 export interface TemplateRenderArgs {
@@ -63,9 +109,19 @@ export interface PreparedTemplateRender<K extends string = string> {
   year: string;
   idDigits: string;
   fontSizes: Record<K, number>;
+  anyRoleWraps: boolean;
+  roleMinHeight: number;
 }
 
 export function getDefaultCertificateFieldValues(design: CertificateDesign, data: CertificateRenderData) {
+  const [signatoryOne, signatoryTwo] = getPositionalSignatories(design.signatories);
+  const idDigits = getCertificateIdDigits(data.certificateId);
+  const activeSignatories = getActiveSignatories(design.signatories);
+  const longestSignatoryName = getLongestSignatoryValue(activeSignatories, 'name');
+  const longestSignatoryRole = getLongestSignatoryValue(activeSignatories, 'role');
+  const footerCandidates = getFooterCandidateValues(design.signatories, data);
+  const longestFooterValue = footerCandidates.sort((a, b) => b.length - a.length)[0] ?? data.date;
+
   return {
     org: data.orgName,
     title: data.courseName,
@@ -75,7 +131,17 @@ export function getDefaultCertificateFieldValues(design: CertificateDesign, data
     description: design.descriptionOverride || data.courseDescription,
     certId: data.certificateId,
     certMeta: `${data.certificateId} · ${data.date}`,
-    date: data.date
+    date: data.date,
+    signatoryName: longestSignatoryName,
+    signatoryRole: longestSignatoryRole,
+    signatoryOneName: signatoryOne?.name ?? '',
+    signatoryOneRole: signatoryOne?.role ?? '',
+    signatoryTwoName: signatoryTwo?.name ?? '',
+    signatoryTwoRole: signatoryTwo?.role ?? '',
+    sealLabel: data.certificateId,
+    recipientNum: data.certificateId,
+    num: `№${idDigits}`,
+    footerValue: longestFooterValue
   };
 }
 
@@ -87,6 +153,29 @@ export type CustomFieldValues<K extends string> = [Exclude<K, DefaultCertificate
       customValues: Record<Exclude<K, DefaultCertificateFieldKey>, string | undefined | null> &
         Partial<Record<K, string | undefined | null>>
     ];
+
+const SIGNATORY_FIELD_PROPS = {
+  signatoryName: 'name',
+  signatoryRole: 'role'
+} as const satisfies Record<
+  DefaultCertificateFieldKey & ('signatoryName' | 'signatoryRole'),
+  keyof Pick<CertificateSignatory, 'name' | 'role'>
+>;
+
+const SIGNATORY_ROLE_KEY = 'signatoryRole' as const satisfies DefaultCertificateFieldKey;
+
+type SignatorySharedField = keyof typeof SIGNATORY_FIELD_PROPS;
+
+function isSignatorySharedField(key: string): key is SignatorySharedField {
+  return key in SIGNATORY_FIELD_PROPS;
+}
+
+function computeMinFitFontSize(options: FitFontSizeOptions, values: Array<string | undefined | null>): number {
+  const activeValues = values.filter((val): val is string => Boolean(val));
+  if (activeValues.length === 0) return options.basePx;
+
+  return Math.min(...activeValues.map((val) => computeFitFontSize(val, options)));
+}
 
 /**
  * Normalizes design/data values and computes all field font sizes in a single step.
@@ -100,18 +189,49 @@ export function prepareCertificateRenderContext<K extends string>(
   const accent = design.accentColor;
   const subtitle = design.subtitle ?? '';
   const description = design.descriptionOverride || data.courseDescription;
-  const [signatoryOne, signatoryTwo] = design.signatories;
+  const [signatoryOne, signatoryTwo] = getPositionalSignatories(design.signatories);
   const year = getYear(data.date);
-  const idDigits = data.certificateId.match(/\d+/)?.[0] ?? '00';
+  const idDigits = getCertificateIdDigits(data.certificateId);
 
   const defaultFieldValues = getDefaultCertificateFieldValues(design, data);
 
   const allFieldValues = {
     ...defaultFieldValues,
     ...customValues
-  } as Record<K, string | undefined | null>;
+  } as Record<DefaultCertificateFieldKey | K, string | undefined | null>;
 
-  const fontSizes = computeFieldFontSizes(fieldDefinitions, allFieldValues);
+  const activeSignatories = getActiveSignatories(design.signatories);
+
+  const fontSizes = {} as Record<K, number>;
+  for (const key in fieldDefinitions) {
+    const isCustom = Boolean(customValues && key in customValues);
+    const signatoryProp = isSignatorySharedField(key) ? SIGNATORY_FIELD_PROPS[key] : null;
+
+    if (signatoryProp && !isCustom && activeSignatories.length > 0) {
+      fontSizes[key] = computeMinFitFontSize(
+        fieldDefinitions[key],
+        activeSignatories.map((sig) => sig[signatoryProp])
+      );
+    } else if (key === ('footerValue' satisfies DefaultCertificateFieldKey) && !isCustom) {
+      fontSizes[key] = computeMinFitFontSize(fieldDefinitions[key], getFooterCandidateValues(design.signatories, data));
+    } else {
+      fontSizes[key] = computeFitFontSize(allFieldValues[key], fieldDefinitions[key]);
+    }
+  }
+
+  const signatoryRoleField = (fieldDefinitions as Partial<Record<DefaultCertificateFieldKey, FitFontSizeOptions>>)[
+    SIGNATORY_ROLE_KEY
+  ];
+  const isCustomRole = Boolean(customValues && SIGNATORY_ROLE_KEY in customValues);
+  const anyRoleWraps = signatoryRoleField
+    ? isCustomRole
+      ? doesFieldWrap(allFieldValues[SIGNATORY_ROLE_KEY], signatoryRoleField)
+      : doesAnySignatoryRoleWrap(design.signatories, signatoryRoleField)
+    : false;
+  const roleSingleLineHeight = signatoryRoleField
+    ? Math.ceil(signatoryRoleField.basePx * (signatoryRoleField.lineHeight ?? 1.2))
+    : 0;
+  const roleMinHeight = anyRoleWraps && signatoryRoleField ? signatoryRoleField.maxHeight : roleSingleLineHeight;
 
   return {
     accent,
@@ -121,7 +241,9 @@ export function prepareCertificateRenderContext<K extends string>(
     signatoryTwo,
     year,
     idDigits,
-    fontSizes
+    fontSizes,
+    anyRoleWraps,
+    roleMinHeight
   };
 }
 
@@ -237,19 +359,19 @@ export const FONTS_LINK_HREF =
 
 export const BASE_STYLES = `
   @page {
-    size: 1100px 780px;
+    size: ${CERTIFICATE_WIDTH}px ${CERTIFICATE_HEIGHT}px;
     margin: 0;
   }
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-  html, body { width: 1100px; height: 780px; margin: 0; padding: 0; overflow: hidden; background: transparent; }
+  html, body { width: ${CERTIFICATE_WIDTH}px; height: ${CERTIFICATE_HEIGHT}px; margin: 0; padding: 0; overflow: hidden; background: transparent; }
   body {
     -webkit-font-smoothing: antialiased;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
   }
   .cert {
-    width: 1100px;
-    height: 780px;
+    width: ${CERTIFICATE_WIDTH}px;
+    height: ${CERTIFICATE_HEIGHT}px;
     position: relative;
     overflow: hidden;
     box-shadow: inset 0 0 0 3px rgba(0,0,0,0.12);

--- a/packages/certificates/src/types.ts
+++ b/packages/certificates/src/types.ts
@@ -17,6 +17,35 @@ export interface CertificateDesign {
   idFormat?: string;
 }
 
+export interface StoredCertificateSignatory {
+  name?: string;
+  role?: string;
+  enabled?: boolean;
+  signatureUrl?: string;
+}
+
+export interface StoredCertificateDesign {
+  templateId?: CertificateTemplateId | string;
+  accentColor?: string;
+  subtitle?: string;
+  descriptionOverride?: string;
+  signatories?:
+    | [StoredCertificateSignatory?, StoredCertificateSignatory?]
+    | StoredCertificateSignatory[]
+    | readonly StoredCertificateSignatory[];
+  idFormat?: string;
+}
+
+/**
+ * Shape of certificate metadata persisted in the database (e.g. `course.certificate`).
+ */
+export interface StoredCertificateRecord {
+  isDownloadable?: boolean;
+  theme?: string | null;
+  design?: StoredCertificateDesign | null;
+  [key: string]: unknown;
+}
+
 export interface CertificateRenderData {
   recipientName: string;
   courseName: string;


### PR DESCRIPTION


## What does this PR do?
This PR stops the use of fixed font sizes for signatory, footer, seal, and Brutalist certificate-number text. And now calculates those font sizes based on the content.

Patch Fix for #868 

## Demo
[Demo](https://www.awesomescreenshot.com/video/56209905?key=17e070702f3ab6379a0d2f8b091d591d)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?
- Preview a certificate for a user with a long signatory, footer, seal, and Brutalist certificate-number text.
- Observe text elements don't overlap each other.


## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Certificate previews and generated PDFs now use consistent dimensions and page settings.
  - Certificate templates have improved spacing, alignment, typography, wrapping, and signatory/footer layouts.
  - Text sizing better accommodates different font weights, styles, and longer content.
  - Certificate fields—including recipient numbers, signatories, roles, seals, and footer details—render more consistently across templates.
  - Existing certificate designs and legacy theme data continue to resolve with appropriate defaults.
  - Shared certificate settings help maintain consistent rendering across previews, exports, and templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes certificate dimensions and stored-design resolution, then extends the shared font-fitting system so certificate numbers, signatories, footer values, and a seal label scale with their content across the five templates.

- Adds weight, style, descender, wrapping, and shared-footer considerations to font-size calculation.
- Updates template geometry and typography for long dynamic values.
- Reuses shared certificate viewport and PDF settings in API rendering.
- Aligns dashboard preview/editor design resolution with API rendering.
- The shared fitting behavior would benefit from explicit long-content regression coverage, and the Minimal template contains one duplicate CSS rule.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with non-blocking follow-up recommended for font-fitting regression coverage and duplicate CSS cleanup.

No concrete rendering, build, compatibility, or security failure was established; the remaining findings concern maintainability and protection against future typography regressions.

**Files Needing Attention:** packages/certificates/src/font-metrics.ts, packages/certificates/src/templates/minimal.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/certificates/src/font-metrics.ts | Extends estimated text fitting for weight, italic style, and descender space; the heuristic-heavy behavior lacks regression tests. |
| packages/certificates/src/templates/shared.ts | Centralizes active-signatory selection, shared footer sizing, wrap detection, and aligned role-height calculation. |
| packages/certificates/src/templates/brutalist.ts | Dynamically sizes the large certificate number and both signatory fields using geometry consistent with its grid. |
| packages/certificates/src/templates/classique.ts | Dynamically sizes signatories and the certificate-ID seal label while aligning footer tracks. |
| packages/certificates/src/templates/minimal.ts | Dynamically sizes certificate/footer values and roles, but introduces a duplicate header-area CSS rule. |
| packages/certificates/src/templates/noir.ts | Adds shared dynamic signatory sizing and aligned footer geometry. |
| packages/certificates/src/templates/poster.ts | Adds dynamic footer typography and role alignment for the three-column footer. |
| packages/certificates/src/render.ts | Moves stored certificate-design normalization into the shared package and centralizes certificate width usage. |
| apps/api/src/utils/certificate.ts | Reuses shared viewport, PDF options, and design resolution without changing output dimensions. |
| apps/dashboard/src/lib/features/course/components/ceritficate/certificate-design.svelte | Replaces local certificate-design reconstruction with the shared resolver. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Stored course certificate design] --> B[resolveCertificateDesign]
  B --> C[Shared template renderer]
  D[Recipient and course data] --> C
  C --> E[Font fitting and footer sizing]
  E --> F[Classique]
  E --> G[Brutalist]
  E --> H[Noir]
  E --> I[Poster]
  E --> J[Minimal]
  F --> K[Dashboard preview]
  G --> K
  H --> K
  I --> K
  J --> K
  F --> L[API PDF or PNG]
  G --> L
  H --> L
  I --> L
  J --> L
```

<sub>Reviews (1): Last reviewed commit: ["fix: use computed font sizes for certifi..."](https://github.com/classroomio/classroomio/commit/a69a11d0a16d5d920b69a44a09bd6f8e70e4de5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60407143)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Analytics and certificates](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/analytics-and-certificates.md)

<!-- /greptile_comment -->