### PR TITLE
fix(dashboard): improve ui on sidebar footer and exercise due date

### DIFF
--- a/apps/dashboard/src/lib/features/course/components/exercise/update-description.svelte
+++ b/apps/dashboard/src/lib/features/course/components/exercise/update-description.svelte
@@ -74,7 +74,6 @@
       />
       <InputField
         label={$t('course.navItem.lessons.exercises.all_exercises.view_mode.due')}
-        className="w-50"
         type="datetime-local"
         value={$questionnaire.dueBy ?? ''}
         onchange={(e) => {

--- a/apps/dashboard/src/lib/features/course/components/exercise/update-description.svelte
+++ b/apps/dashboard/src/lib/features/course/components/exercise/update-description.svelte
@@ -75,6 +75,7 @@
       <InputField
         label={$t('course.navItem.lessons.exercises.all_exercises.view_mode.due')}
         type="datetime-local"
+        className="w-fit"
         value={$questionnaire.dueBy ?? ''}
         onchange={(e) => {
           $questionnaire.dueBy = e.currentTarget.value;

--- a/apps/dashboard/src/lib/features/ui/sidebar/footer/menu.svelte
+++ b/apps/dashboard/src/lib/features/ui/sidebar/footer/menu.svelte
@@ -67,7 +67,7 @@
 {/snippet}
 
 {#snippet themetoggle()}
-  <DropdownMenu.Label class="p-0 font-normal">
+  <DropdownMenu.Label class="font-normal">
     <ThemeToggle />
   </DropdownMenu.Label>
 {/snippet}

--- a/apps/dashboard/src/lib/features/ui/sidebar/footer/theme-toggle.svelte
+++ b/apps/dashboard/src/lib/features/ui/sidebar/footer/theme-toggle.svelte
@@ -26,11 +26,7 @@
     {#each themes as theme (theme.mode)}
       <Button
         size="icon-sm"
-        variant={activeMode === theme.mode ? 'outline' : 'ghost'}
-        class={[
-          'size-4 rounded-md p-1 transition-all duration-200',
-          activeMode === theme.mode && 'shadow-primary/20 shadow-lg'
-        ]}
+        variant={activeMode === theme.mode ? 'secondary' : 'outline'}
         title={theme.mode}
         onclick={() => handleThemeChange(theme.mode)}
       >

--- a/packages/ui/src/custom/input-field/input-field.svelte
+++ b/packages/ui/src/custom/input-field/input-field.svelte
@@ -2,7 +2,6 @@
   import { onMount } from 'svelte';
   import * as Field from '../../base/field';
   import { Input, type InputProps } from '../../base/input';
-  import { cn } from '../../tools';
 
   type InputOnChangeEvent = Parameters<NonNullable<InputProps['onchange']>>[0];
 
@@ -76,11 +75,9 @@
   function handleBlur(e: InputOnChangeEvent) {
     onchange(e);
   }
-
-  const isDateTimeType = $derived(Boolean(type && ['date', 'datetime-local', 'time', 'month', 'week'].includes(type)));
 </script>
 
-<Field.Field class={cn(isDateTimeType && 'ui:w-fit ui:*:w-auto', className)}>
+<Field.Field class={className}>
   {#if label}
     <div class="ui:flex ui:items-center ui:justify-between">
       <Field.Label for={name || 'input-field'} class={labelClassName} required={isRequired}>
@@ -91,7 +88,7 @@
   {/if}
 
   <Input
-    class={cn(isDateTimeType && 'ui:w-auto', inputClassName)}
+    class={inputClassName}
     bind:ref={inputRef}
     id={name || 'input-field'}
     data-testid={testId}

--- a/packages/ui/src/custom/input-field/input-field.svelte
+++ b/packages/ui/src/custom/input-field/input-field.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import * as Field from '../../base/field';
   import { Input, type InputProps } from '../../base/input';
+  import { cn } from '../../tools';
 
   type InputOnChangeEvent = Parameters<NonNullable<InputProps['onchange']>>[0];
 
@@ -75,9 +76,11 @@
   function handleBlur(e: InputOnChangeEvent) {
     onchange(e);
   }
+
+  const isDateTimeType = $derived(Boolean(type && ['date', 'datetime-local', 'time', 'month', 'week'].includes(type)));
 </script>
 
-<Field.Field class={className}>
+<Field.Field class={cn(isDateTimeType && 'ui:w-fit ui:*:w-auto', className)}>
   {#if label}
     <div class="ui:flex ui:items-center ui:justify-between">
       <Field.Label for={name || 'input-field'} class={labelClassName} required={isRequired}>
@@ -88,7 +91,7 @@
   {/if}
 
   <Input
-    class={inputClassName}
+    class={cn(isDateTimeType && 'ui:w-auto', inputClassName)}
     bind:ref={inputRef}
     id={name || 'input-field'}
     data-testid={testId}


### PR DESCRIPTION
## What does this PR do?

After update from a previous PR, the UI of the dashboard sidebar footer theme row and exercises description date input were not at there best. This PR fixes those.

## Demo

[Demo](https://www.awesomescreenshot.com/video/56213118?key=85558ede63c763ccbec3c9879baf0504)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

- Go to the dashboard and open the sidebar footer modal, then confirm the theme row looks good.
- Go to an exercise and confirm the due date input is not truncated.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adjusts dashboard form and sidebar-footer presentation:
- Removes the exercise due-date field’s local width class and introduces shared intrinsic sizing for date/time `InputField` variants.
- Restores standard dropdown-label padding around the theme selector.
- Enlarges theme controls and changes their active and inactive variants.
- The shared date/time sizing introduces a non-blocking layout regression for existing consumers that relied on full-width fields.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, although the shared date/time sizing should be narrowed to avoid non-blocking regressions in other forms.

The sidebar changes fit their existing dropdown constraints, but the shared `InputField` change makes existing date/time fields and their auxiliary content intrinsically sized rather than full width.

**Files Needing Attention:** packages/ui/src/custom/input-field/input-field.svelte

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/custom/input-field/input-field.svelte | Adds intrinsic sizing for all date/time fields, but globally changes existing full-width layouts and non-input children. |
| apps/dashboard/src/lib/features/course/components/exercise/update-description.svelte | Removes the due-date field’s local width class in favor of shared component sizing. |
| apps/dashboard/src/lib/features/ui/sidebar/footer/theme-toggle.svelte | Uses standard icon-button dimensions and clearer secondary/outline theme states. |
| apps/dashboard/src/lib/features/ui/sidebar/footer/menu.svelte | Restores the dropdown label’s standard padding around the theme selector. |

<sub>Reviews (1): Last reviewed commit: ["fix: improve ui on sidebar footer and ex..."](https://github.com/classroomio/classroomio/commit/2bdd5938932366b26a376e2d33b58abff40bc3f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60470792)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Adjusted the due-date field so its width fits its content.
  - Refined sidebar theme-toggle styling to better distinguish the active and inactive themes.
  - Updated spacing and visual styling in the theme selection menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->