### PR TITLE
fix(dashboard): use learner domain for invite links

### DIFF
--- a/apps/dashboard/src/lib/features/cohort/components/invite-members-modal.svelte
+++ b/apps/dashboard/src/lib/features/cohort/components/invite-members-modal.svelte
@@ -19,6 +19,7 @@
   } from '$features/people/components';
   import { UpgradeBanner } from '$features/ui';
   import type { OrgStudent, Tutor } from '$features/people/utils/types';
+  import { buildResourceInviteLink } from '$features/people/utils/invite-link-utils';
   import type { OrgTeamMember } from '$lib/utils/types/org';
   import { cohortApi } from '../api';
 
@@ -37,6 +38,7 @@
   const isOpen = $derived(addPeopleParam === 'true');
   const selectedTutors = $derived(tutors.filter((tutor) => selectedIds.includes(tutor.id.toString())));
   const availableStudents = $derived.by(() => getAvailableStudents(orgApi.audience, cohortApi.members));
+  const inviteLink = $derived(buildResourceInviteLink(cohortApi.inviteLink?.token, $currentOrg));
   const INVITE_MODAL = 'course.navItem.people.invite_modal';
 
   function getTutors(team: OrgTeamMember[]) {
@@ -248,7 +250,7 @@
       <UnderlineTabs.Content value="link">
         <div class="space-y-6">
           <InviteLinkSection
-            link={cohortApi.inviteLink?.inviteLink ?? ''}
+            link={inviteLink}
             isRevoked={cohortApi.inviteLink?.isRevoked ?? false}
             isLoading={cohortApi.isLoading}
             joinCount={cohortApi.inviteLink?.joinCount}

--- a/apps/dashboard/src/lib/features/course/components/people/invitation-modal.svelte
+++ b/apps/dashboard/src/lib/features/course/components/people/invitation-modal.svelte
@@ -16,6 +16,7 @@
   import { profile } from '$lib/utils/store/user';
   import type { OrgTeamMember } from '$lib/utils/types/org';
   import type { OrgStudent, Tutor } from '$features/people/utils/types';
+  import { buildResourceInviteLink } from '$features/people/utils/invite-link-utils';
   import {
     TutorSelectSection,
     ExistingStudentsSection,
@@ -43,6 +44,7 @@
   let isLoadingStudents = $state(false);
   let activeTab = $state<'tutors' | 'students' | 'link'>('students');
   const availableStudents = $derived.by(() => getAvailableStudents(orgApi.audience, courseApi.group.people));
+  const inviteLink = $derived(buildResourceInviteLink(peopleApi.inviteLink?.token, $currentOrg));
 
   function getTutors(team: OrgTeamMember[]) {
     const existingTutors = courseApi?.group?.tutors || [];
@@ -255,7 +257,7 @@
       <UnderlineTabs.Content value="link">
         <div class="space-y-6">
           <InviteLinkSection
-            link={peopleApi.inviteLink?.inviteLink ?? ''}
+            link={inviteLink}
             isRevoked={peopleApi.inviteLink?.isRevoked ?? false}
             isLoading={peopleApi.isLoading}
             joinCount={peopleApi.inviteLink?.joinCount}

--- a/apps/dashboard/src/lib/features/people/utils/invite-link-utils.ts
+++ b/apps/dashboard/src/lib/features/people/utils/invite-link-utils.ts
@@ -1,0 +1,11 @@
+import { getOrgPublicUrl } from '$lib/utils/store/org';
+
+type OrgPublicUrlInput = Parameters<typeof getOrgPublicUrl>[0];
+
+export function buildResourceInviteLink(token: string | null | undefined, organization: OrgPublicUrlInput): string {
+  if (!token) {
+    return '';
+  }
+
+  return getOrgPublicUrl(organization, `/invite/r/${encodeURIComponent(token)}`);
+}


### PR DESCRIPTION
## What does this PR do?

Builds course and cohort shareable invite links from the invite token and the active organization public URL instead of displaying the API-provided admin URL. Verified custom domains are preferred, with the organization tenant subdomain and existing self-hosted/local behavior handled by `getOrgPublicUrl`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Open the People invite modal for a course and generate or copy its invite link. Confirm it uses the organization custom domain, or the organization tenant subdomain when no verified custom domain exists.
- Repeat for a cohort People invite modal.
- Confirm the `/invite/r/<token>` path is preserved and accepts the invite normally.

## Verification

- `pnpm format:check`
- `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`

## Checklist

- [x] Filled out the How to test section in this PR
- [x] Self-reviewed my own code
- [x] Ran the dashboard dependency and application builds
- [x] Removed all console logs introduced by this change
- [x] Rebased onto the latest `origin/main`
- [x] My changes do not cause responsiveness issues
- [x] No lockfile, workflow, publish configuration, database migration, or documentation changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invitation links in cohort and course member modals are now generated using the current organization’s public URL.
  - Invite links correctly include the invitation token and handle missing or empty tokens without displaying an invalid link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes course and cohort invite modals to construct learner-facing invite URLs from the API token and the active organization’s public origin.
- Adds a shared `buildResourceInviteLink` helper.
- Prefers verified custom domains or tenant subdomains through the existing organization URL resolver.
- Preserves the encoded `/invite/r/<token>` route and existing local/self-hosted behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with invite URLs preserving the existing route contract while switching to the organization’s learner-facing origin.

The shared backend contract always supplies the required token, URL encoding matches the existing server implementation, and the public invite route is supported across the organization origins selected by `getOrgPublicUrl`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/people/utils/invite-link-utils.ts | Adds a shared helper that combines an encoded invite token with the organization’s resolved public URL. |
| apps/dashboard/src/lib/features/course/components/people/invitation-modal.svelte | Uses the token-derived learner-domain URL in the course invitation modal. |
| apps/dashboard/src/lib/features/cohort/components/invite-members-modal.svelte | Uses the token-derived learner-domain URL in the cohort invitation modal. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  API[Course or cohort invite API] -->|Invite token| Helper[buildResourceInviteLink]
  Org[Active organization] -->|Custom domain or tenant configuration| Helper
  Helper --> Resolver[getOrgPublicUrl]
  Resolver --> URL[Learner origin + /invite/r/token]
  URL --> Route[Public invite route]
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): use learner domain for i..."](https://github.com/classroomio/classroomio/commit/baba9916a138340da395b2b8ac432b01eab18176) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60496679)</sub>

**Context used:**

- Knowledge Base — [Administration dashboard](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/administration-dashboard.md)

<!-- /greptile_comment -->