### PR TITLE
fix(ui): fire live input changes on typing and fix onblur binding (#1018)

### DIFF
--- a/packages/ui/src/custom/input-field/input-field.svelte
+++ b/packages/ui/src/custom/input-field/input-field.svelte
@@ -4,6 +4,8 @@
   import { Input, type InputProps } from '../../base/input';
 
   type InputOnChangeEvent = Parameters<NonNullable<InputProps['onchange']>>[0];
+  type InputOnInputEvent = Parameters<NonNullable<InputProps['oninput']>>[0];
+  type InputOnBlurEvent = Parameters<NonNullable<InputProps['onblur']>>[0];
 
   interface Props {
     label?: string;
@@ -28,7 +30,9 @@
     /** Stable hook for Playwright (`data-testid`). Prefer over CSS classes or translated labels. */
     testId?: string;
     onchange?: (e: InputOnChangeEvent) => void;
-    onInputChange?: (e: InputOnChangeEvent) => void;
+    onblur?: (e: InputOnBlurEvent) => void;
+    oninput?: (e: InputOnInputEvent) => void;
+    onInputChange?: (e: InputOnInputEvent | InputOnChangeEvent) => void;
     labelAction?: import('svelte').Snippet;
   }
 
@@ -54,6 +58,8 @@
     autoComplete = true,
     testId,
     onchange = () => {},
+    onblur = () => {},
+    oninput = () => {},
     onInputChange = () => {},
     labelAction
   }: Props = $props();
@@ -66,14 +72,21 @@
     }
   });
 
-  // Handle input change event
-  function handleInputChange(e: InputOnChangeEvent) {
+  // Handle live input event (typing, pasting, speech-to-text)
+  function handleInput(e: InputOnInputEvent) {
+    oninput(e);
+    onInputChange(e);
+  }
+
+  // Handle commit / change event
+  function handleChange(e: InputOnChangeEvent) {
+    onchange(e);
     onInputChange(e);
   }
 
   // Handle blur event
-  function handleBlur(e: InputOnChangeEvent) {
-    onchange(e);
+  function handleBlur(e: InputOnBlurEvent) {
+    onblur(e);
   }
 </script>
 
@@ -105,7 +118,8 @@
     autocomplete={autoComplete ? 'on' : 'off'}
     aria-invalid={errorMessage ? 'true' : undefined}
     onkeydown={onKeyDown}
-    onchange={handleInputChange}
+    oninput={handleInput}
+    onchange={handleChange}
     onblur={handleBlur}
   />
 


### PR DESCRIPTION
## Summary
Fixes #1018.

### Problem
Previously, `InputField` mapped `onInputChange` exclusively to the native `<input>` `onchange` event. In standard browser behavior, `change` events only fire when an input loses focus (blur) or Enter is pressed. Furthermore, `onblur` was invoking `onchange(e)`. As a result:
- Keystrokes during active typing never dispatched `onInputChange` or updated live bound state / dirty state.
- Live features relying on `onInputChange` (live slug generation, validation, dirty-state indicators) were postponed until blur.

### Solution
1. **Live Input Event Dispatch**: Wired `oninput` on `<Input>` to `handleInput()`, invoking both `oninput(e)` and `onInputChange(e)` on every keystroke.
2. **Proper Blur & Change Separation**:
   - `oninput` triggers live input updates (`oninput` + `onInputChange`).
   - `onchange` triggers commit updates (`onchange` + `onInputChange`).
   - `onblur` triggers blur updates (`onblur`).
3. **TypeScript Typing**: Added `InputOnInputEvent` and `InputOnBlurEvent` helper types to preserve strict type safety.

## Demo

https://github.com/classroomio/classroomio/issues/1018#issue-reproduction

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)

## How should this be tested?

1. Inspect `InputField` component usage or test rendering.
2. Type into the input field: confirm `onInputChange` is fired on each keystroke (not deferred to blur).
3. Blur the input field: confirm `onblur` fires properly without interfering with `onchange`.

## Checklist

### Required
- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] My changes don't cause any responsiveness issues
- [x] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Input fields now support separate callbacks for live input, committed changes, and blur events.
  * Existing input-change handling now accepts both live input and committed change events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR separates the shared input field’s live input, committed change, and blur callbacks.
- Adds typed `oninput` and `onblur` component properties.
- Dispatches `onInputChange` during both native input and change events.
- Correctly forwards blur events through `onblur` rather than `onchange`.
- Existing controlled numeric consumers need adjustment before receiving intermediate live values.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because live dispatch makes existing controlled numeric fields collapse an empty editing state to zero and may autosave that transient value.

The event separation is otherwise compatible with current callers, but globally forwarding every input event changes numeric editing behavior in a concrete user-facing and potentially persisted way.

**Files Needing Attention:** packages/ui/src/custom/input-field/input-field.svelte

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/custom/input-field/input-field.svelte | Introduces live input dispatch and separates change and blur handling, but exposes existing numeric consumers to destructive intermediate values. |

<sub>Reviews (1): Last reviewed commit: ["fix(ui): fire live input changes on typi..."](https://github.com/classroomio/classroomio/commit/aae885b030381538c71ac9788c37906816f32891) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60555570)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->