### PR TITLE
feat: add PathIcon moving icon for learning paths sidebar

### DIFF
--- a/packages/ui/src/custom/moving-icons/index.ts
+++ b/packages/ui/src/custom/moving-icons/index.ts
@@ -23,6 +23,7 @@ export { default as LessonIcon } from './lesson.svelte';
 export { default as MarksIcon } from './marks.svelte';
 export { default as MoneyIcon } from './money.svelte';
 export { default as NewsFeedIcon } from './news-feed.svelte';
+export { default as PathIcon } from './path.svelte';
 export { default as PeopleIcon } from './people.svelte';
 export { default as PersonIcon } from './person.svelte';
 export { default as PremiumIcon } from './premium.svelte';

--- a/packages/ui/src/custom/moving-icons/path.svelte
+++ b/packages/ui/src/custom/moving-icons/path.svelte
@@ -1,0 +1,96 @@
+<script>
+  /**
+   * @typedef {Object} Props
+   * @property {string} [color]
+   * @property {number} [size]
+   * @property {number} [strokeWidth]
+   * @property {boolean} [isHovered]
+   * @property {string} [class]
+   */
+
+  /** @type {Props} */
+  let { color = 'currentColor', size = 24, strokeWidth = 2, isHovered = false, class: className = '' } = $props();
+
+  function handleMouseEnter() {
+    isHovered = true;
+
+    setTimeout(() => {
+      isHovered = false;
+    }, 800);
+  }
+</script>
+
+<div class={className} aria-label="path" role="img" onmouseenter={handleMouseEnter}>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    stroke-width={strokeWidth}
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="path-icon"
+    class:animate={isHovered}
+  >
+    <circle cx="6" cy="19" r="3" class="circle-1" />
+    <circle cx="18" cy="5" r="3" class="circle-2" />
+    <path d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15" class="line" />
+  </svg>
+</div>
+
+<style>
+  div {
+    display: inline-block;
+  }
+  .line {
+    stroke-dasharray: 50;
+    stroke-dashoffset: 0;
+  }
+
+  .path-icon.animate .circle-1 {
+    animation: circle1Animation 0.4s ease-out forwards;
+  }
+
+  .path-icon.animate .circle-2 {
+    animation: circle2Animation 0.4s ease-out forwards;
+  }
+
+  .path-icon.animate .line {
+    animation: lineAnimation 0.8s forwards;
+  }
+
+  @keyframes circle1Animation {
+    0%,
+    50% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+
+  @keyframes circle2Animation {
+    0%,
+    50% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+
+  @keyframes lineAnimation {
+    0%,
+    50% {
+      stroke-dashoffset: 50;
+    }
+    15% {
+      stroke-dashoffset: 50;
+    }
+    100% {
+      stroke-dashoffset: 0;
+    }
+  }
+</style>

--- a/prd/learning-paths/README.md
+++ b/prd/learning-paths/README.md
@@ -228,7 +228,7 @@ Public (org-site loaders, no auth): list ACTIVE paths for landing/catalog; get p
 
 Follow CLAUDE.md conventions: types in `features/learning-path/utils/types.ts` inferred from the API, API classes in `features/learning-path/api/*.svelte.ts`, thin components, all copy in `en.json` under `"learningPath"`, `ui:` prefix for theme colors.
 
-- **Admin**: nav item in `org-navigation.ts` after Courses; routes `org/[slug]/paths/+page.svelte` and `paths/[id]/{setup,courses,people,analytics,landing,certificate,settings}` with a `PathSidebar` mirroring the course sidebar pattern. Reuse `Item.*`, `PercentRingProgress`, `Field.*`, existing drag-reorder approach from lesson ordering if present.
+- **Admin**: nav item in `org-navigation.ts` after Courses using `PathIcon` from `@cio/ui/custom/moving-icons`; routes `org/[slug]/paths/+page.svelte` and `paths/[id]/{setup,courses,people,analytics,landing,certificate,settings}` with a `PathSidebar` mirroring the course sidebar pattern. Reuse `Item.*`, `PercentRingProgress`, `Field.*`, existing drag-reorder approach from lesson ordering if present.
 - **LMS**: `lms/paths` + `lms/paths/[id]`; path ribbon injected in the course layout when course ∈ caller's path; reuse `course-progress-card` math for per-course %.
 - **Public**: paths section added to org landing themes (start `minimal`), `(org-site)/paths` and `(org-site)/path/[slug]` mirroring the courses equivalents; reuse `CourseSectionNav`, `CourseSocialProof`, `CourseCurriculum`-style rows, `CoursePricing` card, `LandingButton`, footer.
 


### PR DESCRIPTION
## Summary

- Added new `PathIcon` moving icon (`packages/ui/src/custom/moving-icons/path.svelte`) with hover-triggered animation: two circles fade in and a dashed path draws itself.
- Updated learning paths PRD to specify `PathIcon` as the icon for the org sidebar nav item.

## Changes

- **New file**: `packages/ui/src/custom/moving-icons/path.svelte` — animated icon matching the existing moving icon contract (`isHovered` prop, 800ms timeout).
- **Updated**: `packages/ui/src/custom/moving-icons/index.ts` — added `PathIcon` export.
- **Updated**: `prd/learning-paths/README.md` — specified `PathIcon` for the admin sidebar nav item.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds and exports an animated `PathIcon` and updates the learning-path specification to select it for the admin sidebar.
- Adds the path drawing and circle fade animations.
- Exposes `PathIcon` through the moving-icons barrel.
- Documents its intended learning-path navigation usage.

<h3>Confidence Score: 4/5</h3>

The implementation is functionally low risk, but the explicit repository requirement against inline SVG icons must be satisfied before merging.

The icon’s export and animation contract are consistent with the package, but the new Svelte component directly embeds SVG markup contrary to a repository-wide rule.

**Files Needing Attention:** packages/ui/src/custom/moving-icons/path.svelte

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/custom/moving-icons/path.svelte | Adds the animated path icon, but its inline SVG violates the repository’s Svelte icon rule. |
| packages/ui/src/custom/moving-icons/index.ts | Exports `PathIcon` consistently with the existing moving-icon components. |
| prd/learning-paths/README.md | Documents `PathIcon` as the intended admin sidebar icon. |

<sub>Reviews (1): Last reviewed commit: ["feat: add PathIcon moving icon for learn..."](https://github.com/classroomio/classroomio/commit/9ada949ca2a28a09c8536db7c86357d3ade6dbc8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60921294)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - When reviewing Svelte files in this repository, fl... ([source](https://app.greptile.com/classroomio/github/classroomio/classroomio/-/custom-context?memory=4b590445-9781-44fd-8397-1a5bc38a89a0))

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new animated path icon for use in navigation and interfaces.
  * The icon supports customizable color, size, stroke width, styling, and hover animation.
  * Updated the Learning Paths navigation guidance to use the new icon after Courses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->