### PR TITLE
docs: learner usage & lifecycle plan and prototype

### DIFF
--- a/prd/admin-controls-and-reporting/README.md
+++ b/prd/admin-controls-and-reporting/README.md
@@ -130,11 +130,31 @@ Rewrite `getOrganizationAudience` (line 740). Same shape out, new predicates in:
 - `lastActiveAt` — read `organizationmember.last_active_at` directly.
 - `inviteStatus` — join the latest `organization_invite` per email so status filters **in SQL**; keep `deriveAudienceMemberStatus` for the final mapping so one function still owns the rule.
 - `enrollment` — `EXISTS (SELECT 1 FROM groupmember gm JOIN "group" g ON g.id = gm.group_id WHERE gm.profile_id = profile.id AND g.organization_id = :orgId)`.
-- `completion` — aggregate `course_completion_record` per profile scoped to this org's courses. `completed` = ≥1 enrolment and every record `completed`; `in_progress` = ≥1 started; `not_started` = enrolled, nothing started.
+- `completion` — aggregate `course_completion_record` per profile scoped to this org's courses. Define the
+  **per-course** state first, then fold it into **one exclusive learner state by precedence**, because the
+  naive phrasing is not exclusive: "every record is completed" is vacuously true for a learner with no
+  records at all, so they would match `completed` and `not_started` simultaneously.
+
+  Per course: `completed` when a record exists with `status = 'completed'`; `in_progress` when a record
+  exists that is started but not completed; otherwise `not_started` (including no record).
+
+  Per learner, first match wins:
+  1. `not_started` — enrolled in ≥1 course and **no** course is `completed` or `in_progress`.
+  2. `completed` — enrolled in ≥1 course and **every** enrolled course is `completed`.
+  3. `in_progress` — everything else with ≥1 enrolment.
+
+  Learners with no enrolment at all match none of the three and are reachable only via
+  `enrollment=not_enrolled`. Encode this precedence in SQL as a single `CASE`, not three independent
+  predicates, so the buckets provably partition the population and the view counts sum to the total.
 
 New item fields: `lastLoginAt`, `lastActiveAt`, `status`, `enrolledCount`, `completedCount`, `progressPercent`. The count query and the row query must keep sharing one `whereClause`, as they do today.
 
-**Verify the plan on a seeded 20 000-row org before shipping.** Two lateral joins and two `EXISTS` subqueries per page is the kind of thing that is fine at 200 rows and not at 20 000. If the count query is the bottleneck, an approximate count above a threshold is an acceptable trade — but measure first.
+**Verify the plan on a seeded 20 000-row org before shipping.** Two lateral joins and two `EXISTS` subqueries per page is the kind of thing that is fine at 200 rows and not at 20 000. If the count query is the bottleneck, an approximate count is an acceptable trade **for the paginated list's own "N learners" display only** — measure first.
+
+**Approximation must never reach an authoritative count.** `GET /organization/audience/view-counts`, the
+"Select all N matching" affordance, the confirmation preview, and `expectedCount` are all exact, computed
+with the same `whereClause` as the action itself. An approximate `expectedCount` would either understate the
+blast radius the admin approved or fail the server's live-count check and `409` a legitimate action.
 
 No new route: `organization.ts:263` already validates with `ZGetAudienceQuery`, so widening the schema suffices.
 
@@ -161,7 +181,9 @@ const ZBulkAudienceTarget = z.discriminatedUnion('mode', [
   z.object({
     mode: z.literal('filter'),
     filter: ZGetAudienceQuery.omit({ page: true, limit: true, sortBy: true, sortOrder: true }),
-    expectedCount: z.number().int().positive()
+    // exact count AND a checksum of the ordered member ids the admin was shown
+    expectedCount: z.number().int().positive(),
+    expectedTargetHash: z.string().length(64)
   })
 ]);
 
@@ -173,22 +195,56 @@ export const ZBulkAudienceAction = z.object({
 ```
 
 - **`ids`** — explicit tick-box selection on the current page, capped at 500. Unchanged from what the UI does today.
-- **`filter`** — "apply to all N learners matching these filters". This is the mode this customer needs. `expectedCount` is what the admin was shown at confirmation time; if the server's live count differs (someone logged in between preview and apply), reject with a `409` and re-prompt rather than silently acting on a different set. That check is the difference between a safe bulk tool and an incident.
+- **`filter`** — "apply to all N learners matching these filters". This is the mode this customer needs.
+
+  **A matching count does not prove a matching target.** If one learner logs in and another goes dormant
+  between preview and apply, the count is identical and the *set* is not — the admin would silently act on
+  someone they never reviewed. So the preview returns both the exact `expectedCount` **and**
+  `expectedTargetHash`, a SHA-256 over the sorted member ids in the matched set. The action re-derives both
+  inside the transaction and rejects with `409` if either differs, returning the new count so the UI can
+  re-prompt. The hash is what makes the guarantee real; the count is what makes the error message readable.
 
 ### Service — `apps/api/src/services/organization/audience.ts`
 
 `applyBulkAudienceAction(orgId, data, actorProfileId)`:
 
 1. One `db.transaction` at this boundary.
-2. Resolve the target to member ids inside the transaction — for `filter` mode, run the same `whereClause` builder the list uses, so preview and apply cannot diverge. Re-check `expectedCount`.
+2. Resolve the target to member ids inside the transaction — for `filter` mode, run the same `whereClause` builder the list uses, so preview and apply cannot diverge. Re-check **both** `expectedCount` and `expectedTargetHash`; mismatch on either is a `409`, never a silent proceed.
 3. Reject any member that is not `roleId = STUDENT` in this org — authorization validated before any write.
-4. Apply the status change, or delete (also clearing the orphan `groupmember` rows, per Finding 2).
+4. Apply the status change, or remove the membership (also clearing the orphan `groupmember` rows, per
+   Finding 2).
 5. For `delete` and `deactivate`, revoke active invites via the existing `revokeActiveOrganizationInvitesByEmails`.
 6. Write `organization_member_audit` rows with the actor, action, reason, and filter snapshot.
 7. Commit, **then** fire side effects (notifications, cache invalidation).
-8. Return one shape: `{ requested, succeeded, failed: [{ memberId, reason }] }`. `AppError` with `ORG_AUDIENCE_BULK_*` codes.
+8. Return the contract below. `AppError` with `ORG_AUDIENCE_BULK_*` codes.
 
-**Above ~1 000 affected rows, enqueue instead of blocking.** A new `audience-bulk-action` job in `packages/jobs`, following the `enqueue/emails.ts` + `apps/jobs/src/workers` pattern, chunking into transactional batches and reporting progress. The route returns a job id the page polls. At this customer's scale this is not optional — a 12 000-row archive is not an HTTP request.
+**One response contract covers both the synchronous and the queued path**, so the client has a single branch
+rather than guessing from the status code:
+
+```ts
+type BulkAudienceActionResult =
+  | { mode: 'completed'; requested: number; succeeded: number; failed: { memberId: number; reason: string }[] }
+  | { mode: 'queued'; jobId: string; requested: number };
+```
+
+- **Threshold:** resolve the target inside the transaction, then take the queued path when the resolved
+  target exceeds **1 000 members**. The threshold is on the *resolved* count, not the requested one, so
+  `filter` mode cannot sneak past it. Define it as a single exported constant shared by API and dashboard.
+- **Queued path:** a new `audience-bulk-action` job in `packages/jobs`, following the `enqueue/emails.ts` +
+  `apps/jobs/src/workers` pattern, chunking into transactional batches. `GET /organization/audience/bulk-action/:jobId`
+  returns `{ state: 'queued' | 'running' | 'succeeded' | 'failed'; processed: number; total: number; result?: ... }`
+  where `result` on a terminal state is **the same `mode: 'completed'` payload** the synchronous path returns.
+  The UI renders the identical partial-failure summary either way.
+- At this customer's scale the queued path is not optional — a 12 000-row archive is not an HTTP request.
+
+**`delete` means "remove from this organization", not "erase this person".** It removes `organizationmember`
+and `groupmember` rows, revokes invites and writes audit rows. It deliberately leaves the `profile`, analytics
+events, submissions and completion records intact — the person may be a member of other orgs, and their
+submissions are referenced by other people's records. Say so in the confirmation copy and in the docs, so
+nobody reads it as a GDPR erasure. Account-level erasure is a different feature with a different design
+(`prd/account-deletion`); note that `deidentifyPageEventsForUser` anonymises page events only and is currently
+unused, so it is not a shortcut to erasure either. If this customer actually needs erasure, that is open
+question 1 and it routes elsewhere.
 
 **Queries** — `bulkUpdateOrganizationMemberStatus(orgId, memberIds, status, actorProfileId, tx?)`, `bulkDeleteOrganizationAudienceMembers(orgId, memberIds, tx?)`, `deleteGroupMembershipsForOrgMembers(orgId, profileIds, tx?)`. All take an optional `DbOrTxClient`, use it for every read and write, and never open a nested transaction when one is supplied. `catch` blocks log `console.error('<fn> error:', error)`.
 
@@ -197,10 +253,20 @@ export const ZBulkAudienceAction = z.object({
 ### Safety rails — part of the feature, not polish
 
 - **Archive-first.** Order the menu Archive → Deactivate → Delete, with Archive as the default emphasis. Archive is reversible, frees the seat (Finding 1), and preserves history; it is the right answer for almost every "remove them" instinct. Copy should say so.
-- **Delete is gated.** Permanent delete requires the member to already be `ARCHIVED`, or an explicit type-the-count confirmation. Do not let a mis-set filter plus one click destroy records.
+- **Delete is gated, and the server owns the gate.** Permanent delete requires **every** resolved member to
+  already be `ARCHIVED`; the service rejects the batch with `ORG_AUDIENCE_DELETE_NOT_ARCHIVED` otherwise, and
+  the check runs inside the transaction on the resolved set. Type-the-count confirmation is a **client-side
+  addition on top**, never an alternative to it — an "either/or" reading lets the UI permit a deletion the
+  service will refuse, or worse, lets typed confirmation stand in for the archive requirement. Archive first,
+  then delete, is the only path.
 - **Preview before apply.** For `filter` mode, the confirmation dialog states the exact count, shows a sample of affected learners, and offers **"Export this list first"** (reusing Phase 4) so the admin can circulate it for sign-off. This is the step that makes the loop safe, and it is the natural place export earns its keep.
 - **Guard the obvious mistake.** Never let "never logged in" silently sweep up learners invited in the last N days. Exclude recent joiners by default with a visible, overridable toggle.
-- **Undo window for archive.** Archive is reversible by design; surface a snackbar undo and keep `unarchive` a first-class action.
+- **Undo acts on the exact set that succeeded, never on the filter.** Re-running a filter to undo would hit a
+  different population — the action itself just changed who matches. The service persists the succeeded member
+  ids and returns an `undoToken` (opaque, single-use, expiring in ~15 minutes, scoped to actor and org) on
+  every reversible action. `POST /organization/audience/bulk-action/undo` takes that token and applies the
+  inverse status change to precisely those ids. Archive and deactivate are reversible; delete returns no
+  token, and the dialog says so.
 
 ### Frontend
 
@@ -246,7 +312,26 @@ Lifted from `features/course/utils/marks-utils.ts:151,190` and generalised: `dow
 
 The page holds 20 rows; the export needs all of them, and "all of them" here may be tens of thousands. A JSON-to-client round trip with a 5 000-row cap does not serve this customer.
 
-**`GET /organization/audience/export.csv` streams `text/csv` directly from the API** — same filter schema as the list minus pagination, keyset-paginated internally, `authMiddleware, orgTeamMemberMiddleware`. No row cap, constant memory, and the browser gets a real download. This is deliberately **not** an RPC data route (it returns a file, not a typed JSON envelope), so the single-return-type rule does not apply; it lives beside the RPC routes as a download endpoint.
+**`GET /organization/audience/export.csv` streams `text/csv` directly from the API** — keyset-paginated
+internally, `authMiddleware, orgTeamMemberMiddleware`. No row cap, constant memory, and the browser gets a
+real download. This is deliberately **not** an RPC data route (it returns a file, not a typed JSON envelope),
+so the single-return-type rule does not apply; it lives beside the RPC routes as a download endpoint.
+
+**Three export scopes, three explicit request shapes** — a filter-only endpoint cannot express "the 42 rows I
+ticked", and silently widening that to the whole filtered set would hand someone a different list than the
+one they asked for:
+
+| Scope | Request | Notes |
+| --- | --- | --- |
+| Selected | `memberIds` (repeated query param, capped at 500) | Takes precedence over any filter params present |
+| Filtered | the list's filter params, minus pagination | The current view |
+| All | no filter params | The whole roster |
+
+Precedence is server-side and explicit: if `memberIds` is present, filters are ignored entirely rather than
+intersected. Above the 500-id cap the UI must offer the filtered scope instead — that is exactly the case
+where the admin is in `filter` selection mode anyway, so the same filter is already to hand. The
+confirmation dialog's "export this list first" uses the scope matching the pending action, so the exported
+list and the acted-on list are the same list.
 
 PDF stays client-side and **is** capped — a 20 000-row PDF helps nobody. Offer PDF only below ~2 000 rows and say why in the menu.
 

--- a/prd/admin-controls-and-reporting/README.md
+++ b/prd/admin-controls-and-reporting/README.md
@@ -1,0 +1,321 @@
+# Learner Usage & Lifecycle Management — Implementation Plan
+
+> **UI behavior lives in [`UX.md`](./UX.md)** and the clickable prototype at [`prototypes/learner-lifecycle/`](../../prototypes/learner-lifecycle/), which is the UX source of truth — filtering interaction, loading states, selection, bulk confirmation, export menu, empty states, and accessibility. This file covers data, API, and sequencing.
+
+## The actual job
+
+The customer has **a lot of learners** and wants to answer one recurring question:
+
+> *Who isn't using the platform, and who should we remove?*
+
+That is a loop, not four features: **see usage → filter to the dormant → review the list → act on it in bulk → prove what happened.** Everything below is sequenced around that loop. The four questionnaire items map onto it unevenly:
+
+| # | Ask | Role in the loop | Priority |
+| --- | --- | --- | --- |
+| 1 | Filter by last login / last activity / enrollment / completion | **See and filter** — the entry point | 🔴 Critical path |
+| 2 | Bulk deactivate / delete / archive | **Act** — the payoff | 🔴 Critical path |
+| 10 | Export reports | **Review and prove** — the sign-off step *and* the audit trail | 🟠 Critical path for the roster; secondary elsewhere |
+| 4 | CSV/Excel import | Onboarding, not usage — orthogonal to this loop | 🟡 Last |
+
+Two consequences worth stating up front, because they invert decisions in the earlier draft:
+
+- **Scale is the design constraint, not a footnote.** An admin filtering 20 000 learners to "never logged in" gets thousands of rows. Tick-boxes and a 500-row cap do not solve their problem. Bulk-action-by-filter and uncapped export are **in scope**, not follow-ups.
+- **The action is destructive and happens at volume.** Removing 400 people by accident is unrecoverable. Safety rails (archive-first, preview-before-apply, audit trail) are part of the feature, not polish.
+
+---
+
+## 0. Two findings from the code that shape everything
+
+### Finding 1 — archiving frees a seat only if we change the seat count
+
+`countActiveStudents` (`packages/db/src/queries/organization/organization.ts:675`) counts **every** student `organizationmember` row, with no status concept:
+
+```ts
+.where(and(eq(organizationmember.organizationId, orgId), eq(organizationmember.roleId, ROLE.STUDENT)))
+```
+
+It is the sole input to `assertStudentCapacityOrThrow` (`apps/api/src/services/organization/student-limit.ts`) and to the audience-limit banner. So unless this function learns about `status`, archiving 5 000 dormant learners frees **zero** seats and the whole feature misses its point.
+
+**Decision (previously an open question, now settled by the use case):** `ARCHIVED` does not count against the plan limit; `DEACTIVATED` does. Archive becomes the meaningful "reclaim a seat" action, deactivate is the reversible "suspend access, keep the seat" action, and the difference is legible to an admin. `countActiveStudents` gains `ne(status, 'ARCHIVED')`, and the milestone-notification logic in `student-limit.ts` inherits it for free.
+
+### Finding 2 — the access gate is already in the right place
+
+`isUserCourseMemberOrOrgAdmin` (`packages/db/src/queries/group/group.ts:147`) requires **live org membership** for org-owned courses:
+
+```ts
+or(isNull(group.organizationId), isNotNull(orgMembership.id))
+```
+
+Good news: deleting an `organizationmember` row genuinely cuts course access today — removal is not cosmetic. And that same join is exactly where the `status = 'ACTIVE'` check belongs, so deactivate/archive revoke access through one change in one place rather than a scatter of new guards. Same for `isCourseTeamMemberOrOrgAdmin` just below it.
+
+One gap to close while we are here: `deleteOrganizationAudienceMember` (`organization.ts:458`) deletes only the org-member row, leaving orphan `groupmember` rows behind. Access is correctly denied, but the enrolments linger — and if the same person is ever re-added, their old enrolments silently reappear. Clean them up inside the delete transaction.
+
+---
+
+## 1. Current state
+
+| Capability | Today | File |
+| --- | --- | --- |
+| Last login | Computed, never filterable. `getLastLogin` / `getLastSeenForUserIds` used only on the single-user page. | `packages/db/src/queries/analytics/analytics.ts:45,78` |
+| Last activity | No concept. Raw events in `analytics_page_event (org_id, user_id, occurred_at)`. | `packages/db/src/schema.ts:203` |
+| Enrollment | Only *invite* status shown (`active/pending/expired/revoked`), derived in the service, not filterable. Course enrolment (`groupmember`) not surfaced. | `apps/api/src/utils/audience-member-status.ts` |
+| Completion | Not surfaced. `course_completion_record.status` exists, indexed. | `packages/db/src/schema.ts:792` |
+| Deactivate / archive | No such concept in the schema. | — |
+| Bulk delete | Single-row only. Rows are multi-selectable; selection feeds "Assign courses" and nothing else. | `features/audience/pages/audience.svelte:83` |
+| Roster export | Button exists, calls `alert('This feature is coming soon')`. | `routes/(app)/org/[slug]/audience/+page.svelte:16` |
+| CSV import | Paste-a-list textarea, ~25 000 char cap. No file upload, preview, or per-row errors. | `features/audience/pages/import.svelte` |
+| **Only working export in the product** | Course marks — CSV via `papaparse`, PDF via `jspdf` + `jspdf-autotable`. Both already dashboard deps. | `features/course/utils/marks-utils.ts:151,190` |
+
+Other reporting surfaces with no export: org compliance, course analytics, org analytics, per-user analytics, course attendance. They matter — but not to this customer's loop, so they sequence last (§6).
+
+---
+
+## 2. Phase 1 — Foundation (blocks everything)
+
+Migration `packages/db/src/migrations/0015_learner_lifecycle.sql` (0014 is latest); mirror into `packages/db/src/schema.ts`.
+
+```sql
+CREATE TYPE "ORGANIZATION_MEMBER_STATUS" AS ENUM ('ACTIVE', 'DEACTIVATED', 'ARCHIVED');
+
+ALTER TABLE organizationmember
+  ADD COLUMN status "ORGANIZATION_MEMBER_STATUS" NOT NULL DEFAULT 'ACTIVE',
+  ADD COLUMN status_changed_at timestamptz,
+  ADD COLUMN status_changed_by uuid REFERENCES profile(id) ON DELETE SET NULL,
+  ADD COLUMN last_active_at timestamptz;
+
+CREATE INDEX idx_orgmember_org_role_status ON organizationmember (organization_id, role_id, status);
+CREATE INDEX idx_orgmember_org_last_active ON organizationmember (organization_id, last_active_at);
+CREATE INDEX idx_analytics_login_events_user_logged_in ON analytics_login_events (user_id, logged_in_at DESC);
+```
+
+- **`status` replaces nothing.** `verified` means "invite accepted", not "allowed in".
+- **`last_active_at` is load-bearing at this scale.** Filtering and sorting a paginated list of 20 000 learners against a raw event table will not hold up. Maintained by `insertPageEvents` (`analytics.ts:427`) on ingest, reconciled nightly in the existing maintenance worker (`apps/jobs/src/workers/maintenance.ts`) from `analytics_page_event` and `lesson_completion.updated_at`. Backfill both in the migration.
+- **Last login stays a lateral** `MAX(logged_in_at)` against `analytics_login_events` — cheap with the new index. `session.updated_at` is a fallback inside `getLastLogin`, but sessions are pruned on expiry, so login events are the durable source and the only thing we filter on.
+- **Enforce status in the access gate** — add `status = 'ACTIVE'` to the org-membership join in `isUserCourseMemberOrOrgAdmin` and `isCourseTeamMemberOrOrgAdmin` (Finding 2), and treat non-`ACTIVE` as not-a-member in `getAccountData` (`apps/api/src/services/account/profile.ts`) and `orgMemberMiddleware` / `orgTeamMemberMiddleware`.
+- **Exclude `ARCHIVED` from `countActiveStudents`** (Finding 1).
+
+**Audit trail.** Bulk lifecycle changes need to be answerable six months later ("who removed these 400 people, and when?"). `status_changed_by` / `status_changed_at` cover the current state; for history, add `organization_member_audit` following the existing `organizationInviteAudit` pattern (`schema.ts:1477`) — one row per member per action, with actor, action, reason, and the filter snapshot when the action came from a filter.
+
+---
+
+## 3. Phase 2 — See and filter (the entry point)
+
+### Validation — `packages/utils/src/validation/organization/audience.ts`
+
+Extend `ZGetAudienceQuery`, keeping every existing field and default so current URLs stay valid:
+
+```ts
+export const AudienceMemberStatus = z.enum(['ACTIVE', 'DEACTIVATED', 'ARCHIVED']);
+export const AudienceInviteStatus = z.enum(['active', 'pending', 'expired', 'revoked']);
+export const AudienceEnrollment = z.enum(['enrolled', 'not_enrolled']);
+export const AudienceCompletion = z.enum(['not_started', 'in_progress', 'completed']);
+export const AudienceActivityWindow = z.enum(['7d', '30d', '90d', '180d', 'never']);
+export const AudienceSortBy = z.enum(['createdAt', 'name', 'email', 'lastLoginAt', 'lastActiveAt']);
+```
+
+Added as optional `status`, `inviteStatus`, `enrollment`, `completion`, `lastLoginBefore`, `lastActiveBefore`. Note the naming: this customer thinks in **"hasn't logged in for 90 days"**, not "logged in within 90 days" — the windows are *staleness* thresholds, and getting the polarity right in the schema keeps it right in the UI. Default `status` to `'ACTIVE'` server-side so archived members drop out of the default view. `'never'` means no login event at all.
+
+### Query — `packages/db/src/queries/organization/organization.ts`
+
+Rewrite `getOrganizationAudience` (line 740). Same shape out, new predicates in:
+
+- `lastLoginAt` — `LEFT JOIN LATERAL (SELECT MAX(logged_in_at) … WHERE user_id = profile.id)`.
+- `lastActiveAt` — read `organizationmember.last_active_at` directly.
+- `inviteStatus` — join the latest `organization_invite` per email so status filters **in SQL**; keep `deriveAudienceMemberStatus` for the final mapping so one function still owns the rule.
+- `enrollment` — `EXISTS (SELECT 1 FROM groupmember gm JOIN "group" g ON g.id = gm.group_id WHERE gm.profile_id = profile.id AND g.organization_id = :orgId)`.
+- `completion` — aggregate `course_completion_record` per profile scoped to this org's courses. `completed` = ≥1 enrolment and every record `completed`; `in_progress` = ≥1 started; `not_started` = enrolled, nothing started.
+
+New item fields: `lastLoginAt`, `lastActiveAt`, `status`, `enrolledCount`, `completedCount`, `progressPercent`. The count query and the row query must keep sharing one `whereClause`, as they do today.
+
+**Verify the plan on a seeded 20 000-row org before shipping.** Two lateral joins and two `EXISTS` subqueries per page is the kind of thing that is fine at 200 rows and not at 20 000. If the count query is the bottleneck, an approximate count above a threshold is an acceptable trade — but measure first.
+
+No new route: `organization.ts:263` already validates with `ZGetAudienceQuery`, so widening the schema suffices.
+
+### Frontend
+
+- **Saved dormancy views are the headline feature.** Because filters live in URL params, a set of one-click views is nearly free and is what the admin actually reaches for: **All learners · Never logged in · Inactive 90+ days · Inactive 180+ days · Enrolled, never started**. They ship as a single quiet view-switcher `DropdownMenu` beside search — counts muted inside the menu, not as coloured chips across the page — backed by one `GET /organization/audience/view-counts` call. This turns a five-field filter form into a one-click workflow without adding noise to the page. See `UX.md` §2.1.
+- **All view state must live in the URL — a requirement, not a preference.** View, filters, sort key, sort order, search and page are query parameters, and the URL is the single source of truth: components render from it and navigate to change it, never keeping a second copy in local state. The workflow depends on it — a filtered view is the link an admin sends for sign-off before removing 3,000 people, back/forward move between filter states, a refresh survives a re-login, and the filter recorded on an audit row is replayable. Extend the existing `getAudienceQueryFromSearchParams` / `getAudienceSearchParams` pair in `features/org/utils/audience-query-utils.ts` rather than adding a parallel scheme; omit defaults from the URL so a plain `/audience` stays clean, and fall back to defaults on malformed params so a truncated link still loads. Selection is the one exception — it stays in memory, so a shared link never carries someone else's pending destructive selection. Full mechanics in `UX.md` §2.8.
+- `features/org/utils/types.ts` — extend `OrganizationAudienceQuery` and the sort keys. No new types in `.svelte.ts`.
+- **New** `features/audience/components/audience-filter-popover.svelte`, modelled on `features/course/components/course-filter-popover.svelte`: `Popover`, outline `Button` + `FilterIcon` trigger, active-filter dot, "Clear all" link. Body composed of `Field.Set` / `Field.Legend` / `Field.Group`, `RadioGroup` for the staleness windows, `Checkbox` for status. Keep `SortPopover` beside it — do not overload it.
+- `audience-table-toolbar.svelte` — presets row, then search + filter + sort. Below, a chips row (`@cio/ui/custom/chip`) showing active filters with an ×.
+- `audience-table.svelte` / `audience-member-row.svelte` — add **Last login**, **Last activity**, **Enrollment** (`3 / 5`), **Progress** columns. Sort by last login and last activity is as important as filtering: it answers "show me the worst offenders first". Progress uses `@cio/ui/custom/percent-ring-progress`. Eight columns needs `overflow-x-auto` on the table wrapper; the page body must never scroll horizontally.
+- Mount `ScrollToTop` (`@cio/ui/custom/scroll-to-top`, `label={$t('common.scroll_to_top')}`) on the audience route.
+- Filtered-empty state: `Empty` with a "Clear filters" action, distinct from the existing `audience.no_audience` state.
+
+---
+
+## 4. Phase 3 — Act in bulk (the payoff)
+
+### Two selection modes, because tick-boxes do not scale
+
+```ts
+const ZBulkAudienceTarget = z.discriminatedUnion('mode', [
+  z.object({ mode: z.literal('ids'), memberIds: z.array(z.number().int().positive()).min(1).max(500) }),
+  z.object({
+    mode: z.literal('filter'),
+    filter: ZGetAudienceQuery.omit({ page: true, limit: true, sortBy: true, sortOrder: true }),
+    expectedCount: z.number().int().positive()
+  })
+]);
+
+export const ZBulkAudienceAction = z.object({
+  target: ZBulkAudienceTarget,
+  action: z.enum(['deactivate', 'reactivate', 'archive', 'unarchive', 'delete']),
+  reason: z.string().trim().max(500).optional()
+});
+```
+
+- **`ids`** — explicit tick-box selection on the current page, capped at 500. Unchanged from what the UI does today.
+- **`filter`** — "apply to all N learners matching these filters". This is the mode this customer needs. `expectedCount` is what the admin was shown at confirmation time; if the server's live count differs (someone logged in between preview and apply), reject with a `409` and re-prompt rather than silently acting on a different set. That check is the difference between a safe bulk tool and an incident.
+
+### Service — `apps/api/src/services/organization/audience.ts`
+
+`applyBulkAudienceAction(orgId, data, actorProfileId)`:
+
+1. One `db.transaction` at this boundary.
+2. Resolve the target to member ids inside the transaction — for `filter` mode, run the same `whereClause` builder the list uses, so preview and apply cannot diverge. Re-check `expectedCount`.
+3. Reject any member that is not `roleId = STUDENT` in this org — authorization validated before any write.
+4. Apply the status change, or delete (also clearing the orphan `groupmember` rows, per Finding 2).
+5. For `delete` and `deactivate`, revoke active invites via the existing `revokeActiveOrganizationInvitesByEmails`.
+6. Write `organization_member_audit` rows with the actor, action, reason, and filter snapshot.
+7. Commit, **then** fire side effects (notifications, cache invalidation).
+8. Return one shape: `{ requested, succeeded, failed: [{ memberId, reason }] }`. `AppError` with `ORG_AUDIENCE_BULK_*` codes.
+
+**Above ~1 000 affected rows, enqueue instead of blocking.** A new `audience-bulk-action` job in `packages/jobs`, following the `enqueue/emails.ts` + `apps/jobs/src/workers` pattern, chunking into transactional batches and reporting progress. The route returns a job id the page polls. At this customer's scale this is not optional — a 12 000-row archive is not an HTTP request.
+
+**Queries** — `bulkUpdateOrganizationMemberStatus(orgId, memberIds, status, actorProfileId, tx?)`, `bulkDeleteOrganizationAudienceMembers(orgId, memberIds, tx?)`, `deleteGroupMembershipsForOrgMembers(orgId, profileIds, tx?)`. All take an optional `DbOrTxClient`, use it for every read and write, and never open a nested transaction when one is supplied. `catch` blocks log `console.error('<fn> error:', error)`.
+
+**Route** — `POST /organization/audience/bulk-action`, `authMiddleware, orgAdminMiddleware, zValidator('json', ZBulkAudienceAction)`, `handleError` in the catch, single return type, on the existing `organizationRouter`.
+
+### Safety rails — part of the feature, not polish
+
+- **Archive-first.** Order the menu Archive → Deactivate → Delete, with Archive as the default emphasis. Archive is reversible, frees the seat (Finding 1), and preserves history; it is the right answer for almost every "remove them" instinct. Copy should say so.
+- **Delete is gated.** Permanent delete requires the member to already be `ARCHIVED`, or an explicit type-the-count confirmation. Do not let a mis-set filter plus one click destroy records.
+- **Preview before apply.** For `filter` mode, the confirmation dialog states the exact count, shows a sample of affected learners, and offers **"Export this list first"** (reusing Phase 4) so the admin can circulate it for sign-off. This is the step that makes the loop safe, and it is the natural place export earns its keep.
+- **Guard the obvious mistake.** Never let "never logged in" silently sweep up learners invited in the last N days. Exclude recent joiners by default with a visible, overridable toggle.
+- **Undo window for archive.** Archive is reversible by design; surface a snackbar undo and keep `unarchive` a first-class action.
+
+### Frontend
+
+Request/success types in `features/org/utils/types.ts`; `bulkAudienceAction(fields)` on `org.svelte.ts` via `this.execute<BulkAudienceActionRequest>` with client-side zod parse and translation-key snackbars. Replace the ad-hoc selection `<div>` in `audience-table-toolbar.svelte` with a bulk bar: selected count, a **"Select all N matching"** affordance that switches to `filter` mode (the piece that makes this usable at scale), "Assign courses" (existing), and a `DropdownMenu` of lifecycle actions with the destructive item styled like the row menu (`ui:text-destructive focus:ui:text-destructive`).
+
+Generalise `audience-delete-confirmation.svelte` into `audience-bulk-confirmation.svelte` — a `Dialog` carrying the count, the sample, the reason field, the export link, and type-to-confirm for `delete`. Reset in `onOpenChange`, never in an `$effect` keyed to `!open`. Deactivated/archived rows render muted with a status `Badge` (extend `statusBadgeVariant` / `statusLabelKey`). Clear selection explicitly after a successful action.
+
+`testId`s: `audience-bulk-actions`, `audience-bulk-select-all-matching`, `audience-bulk-confirm`.
+
+---
+
+## 5. Phase 4 — Export the roster (review, sign-off, proof)
+
+Export is the **review step of the loop**, not a reporting nicety: the admin exports the dormant list, circulates it, then acts. Build it once as a shared capability so the other five surfaces can adopt it later without a rewrite.
+
+### Shared export model — `packages/utils/src/export/`
+
+Framework-agnostic, no Svelte imports, so the API can reuse it for queued/emailed exports:
+
+```ts
+export interface ExportColumn<Row> {
+  key: string;
+  header: string;      // caller passes an already-translated string
+  value: (row: Row) => string | number | null;
+}
+
+export interface ExportDocument<Row> {
+  filename: string;    // without extension
+  title: string;       // PDF header
+  subtitle?: string;   // e.g. "Acme · inactive 90+ days · 3 214 learners"
+  columns: ExportColumn<Row>[];
+  rows: Row[];
+}
+```
+
+Headers arrive translated — the utils package does not own copy. Formatting lives in the `value` callback so CSV and PDF cannot drift.
+
+### Shared renderers — `features/ui/export/`
+
+Lifted from `features/course/utils/marks-utils.ts:151,190` and generalised: `downloadCsv(doc)` (`Papa.unparse` + blob), `downloadPdf(doc)` (dynamic `import('jspdf')` / `import('jspdf-autotable')`, landscape), and `ExportMenu.svelte` — an outline `Button` with `DownloadIcon` and a `loading` state opening a `DropdownMenu` of CSV / PDF, dropped into `Page.Action`. Props: `document` or `() => Promise<ExportDocument>`, `disabled`, `testId`. **Migrate the marks page onto it and delete the one-off functions** — that proves the abstraction against a working report before anything else adopts it.
+
+### Getting the full dataset out
+
+The page holds 20 rows; the export needs all of them, and "all of them" here may be tens of thousands. A JSON-to-client round trip with a 5 000-row cap does not serve this customer.
+
+**`GET /organization/audience/export.csv` streams `text/csv` directly from the API** — same filter schema as the list minus pagination, keyset-paginated internally, `authMiddleware, orgTeamMemberMiddleware`. No row cap, constant memory, and the browser gets a real download. This is deliberately **not** an RPC data route (it returns a file, not a typed JSON envelope), so the single-return-type rule does not apply; it lives beside the RPC routes as a download endpoint.
+
+PDF stays client-side and **is** capped — a 20 000-row PDF helps nobody. Offer PDF only below ~2 000 rows and say why in the menu.
+
+### Columns
+
+Name, email, member status, invite status, joined, **last login**, **last activity**, courses enrolled, courses completed, overall progress %, average grade, certificates earned. Honours the active filters; exports only the selection when rows are ticked. The three bolded columns are the ones this customer is actually reading.
+
+`getAudienceExportRows(orgId, query)` batches the per-profile progress lookups — do **not** `Promise.all` a per-row query across 20 000 rows.
+
+---
+
+## 6. Phase 5+ — Everything else
+
+Sequenced behind the loop, in the order they help this customer:
+
+| Phase | Scope | Why here |
+| --- | --- | --- |
+| 5 | **Per-user progress export** (`audience/[profileId]`) | The drill-down from a flagged learner. Reuses the existing analytics endpoint — cheap once `ExportMenu` exists. |
+| 6 | **Course analytics export** | Per-student progress table answers "is this cohort using it" — the same question, one level down. Endpoint already returns `students[]`. |
+| 7 | **CSV/Excel import** (§7) | Onboarding, not usage. Real, but orthogonal to the loop. |
+| 8 | **Compliance export** | Genuinely valuable and the biggest gap for a *different* customer. Not this one. Endpoint already returns the learner list. |
+| 9 | **Attendance and org analytics export** | Lowest leverage here. Org analytics is charts — export the underlying series as CSV, the summary as PDF; do not force funnel and geography into one table. |
+| Later | Queued export + emailed link; `.xlsx` both directions | See §7 and §8. |
+
+---
+
+## 7. CSV import (Phase 7)
+
+**Format:** UTF-8 `.csv`, header row required — `email` (required, `z.email()`, lower-cased, de-duplicated in-file), `name` (optional, falls back to the email local-part as `getOrganizationAudience` already does), `courses` (optional, comma-separated titles or ids; unmatched values become row warnings, not failures). Unknown columns ignored with a warning. Ship a downloadable `audience-template.csv`.
+
+**Limits:** 1 000 rows per import (a new explicit `recipients` array on `ZImportAudienceMembers`, replacing the implicit 25 000-character cap on `recipientCsv`, which stays for back-compat); 5 MB file via `FileDropZone`'s `maxFileSize`; and the org's audience plan limit enforced server-side — over the limit gives a partial import with per-row reasons, not a blanket 4xx.
+
+**Flow:** rework `features/audience/pages/import.svelte` into upload → preview → result. `FileDropZone` (`@cio/ui/custom/file-drop-zone`, `accept=".csv,text/csv"`) beside the existing paste box; parse with `papaparse` in a new `features/audience/utils/audience-import-utils.ts` (pure functions, all data passed in); a preview `Table` bucketing rows into *ready* / *already in audience* / *invalid with reason*; then submit to the existing `POST /organization/audience/import` extended to accept `recipients`; then a result screen with counts and a "Download error rows" CSV. Over 200 rows, enqueue via a new `audience-import` job following the `enqueue/emails.ts` pattern.
+
+While the file is open, refactor its raw `Label` + `RadioGroup` blocks into `Field.Group` / `Field.Set` / `Field.Legend` / `Field.Separator`, and either wire up or delete the commented-out `sendEmail` checkbox.
+
+---
+
+## 8. `.xlsx` — one decision, both directions
+
+Nothing in the repo reads or writes spreadsheets; `.xlsx` is the only item here that adds a dependency (`exceljs` or `xlsx`). CSV opens natively in Excel, and this customer's workflow is filter → export → circulate → act, which CSV serves fully.
+
+**Recommendation: CSV + PDF at launch, no new dependency.** If `.xlsx` is contractually required, add `exceljs` and a third renderer in `features/ui/export/` — `ExportDocument` is already the right shape, so it is purely additive — and the same library covers import parsing. Decide both directions at once.
+
+---
+
+## 9. Cross-cutting requirements
+
+- **URL is the source of truth for view state.** View, filters, sort, search and page are query parameters — never component-local state mirrored behind the URL. Selection is the deliberate exception. See `UX.md` §2.8.
+- **Translations.** All strings in `apps/dashboard/src/lib/utils/translations/en.json` (`audience.views.*`, `audience.filter.*`, `audience.bulk.*`, `audience.import.*`, `export.*`), then `cd apps/dashboard && pnpm translate`, then verify every `{}` placeholder survived before staging. Snackbars take translation keys directly. Export headers are passed in translated by the caller.
+- **Design system.** `Page.*` shells with `ExportMenu` in `Page.Action`; `@cio/ui/custom/*-field` wrappers for standard controls; `Field.*` primitives for the grouped filter and import forms; no native `<input>`/`<label>`; icon-only buttons `variant="secondary"`; colour utilities carry the `ui:` prefix in dashboard code including inside variants (`hover:ui:bg-muted`, `focus:ui:text-destructive`), layout utilities do not.
+- **Reactive collections.** Selection already uses `SvelteSet` — keep it, unwrapped by `$state()`. The new "all N matching" mode is a separate `$state` flag, not a set of 12 000 ids.
+- **UI package.** Anything landing in `packages/ui/src` gets documented in `packages/ui/README.md` and a Storybook story under `packages/storybook/src` covering its variants, in the same change. `ExportMenu` is dashboard-level (`features/ui/export/`) unless it needs to be shared beyond the dashboard.
+- **Test hooks.** `audience-view-switcher`, `audience-filter-trigger`, `audience-bulk-actions`, `audience-bulk-select-all-matching`, `audience-bulk-confirm`, `export-menu-trigger`. Register in `e2e/README.md`.
+- **Tests.** Non-negotiable given the blast radius: a db-backed integration test proving a failed bulk action rolls back entirely; a test that `filter`-mode resolution and list-mode `whereClause` return identical member sets; a test that `expectedCount` drift produces a `409`; a test that `countActiveStudents` excludes `ARCHIVED` and includes `DEACTIVATED`. Export column formatters are pure — unit-test them.
+
+---
+
+## 10. Sequencing
+
+| Phase | Scope | Depends on |
+| --- | --- | --- |
+| 1 | Schema, `last_active_at` backfill + maintenance, status enforcement in the access gate, `countActiveStudents` change, audit table | — |
+| 2 | Filters, saved dormancy views, new columns, sort by last login/activity | 1 |
+| 3 | Bulk actions — ids + filter modes, queued above 1 000, safety rails, audit rows | 1, 2 (filter mode reuses the `whereClause` builder) |
+| 4 | Shared export module + `ExportMenu`, migrate marks onto it, streaming roster export | — (can start in parallel with 1); the confirmation dialog's "export this list first" needs 3 |
+| 5+ | Per-user, course analytics, import, compliance, attendance, org analytics | 4 |
+
+Phases 1 and 4 touch nothing in common and can run in parallel. **Phases 1–4 are the deliverable this customer asked for**; everything after is roadmap.
+
+---
+
+## 11. Open questions
+
+1. **What does "remove from the platform" mean to them — reclaim seats, revoke access, or erase data?** The plan assumes seats: archive frees a seat, keeps history, is reversible. If they mean erasure (GDPR-style), that is a different feature and should route through the existing `prd/account-deletion` work and the `deidentifyPageEventsForUser` path rather than through bulk delete.
+2. **How many learners, and on what plan?** The 20 000-row assumption drives the streaming export, the queued bulk action, and the query-plan verification. If it is 2 000, phases 3 and 4 get materially simpler and cheaper.
+3. **Does "activity" mean logins, or real engagement?** `last_active_at` from page events counts opening a page. If they want "made progress" (lesson completions, submissions), that is a different signal and should be a separate column and filter rather than a redefinition — some admins want both.
+4. **Is there an approval step?** If removals need sign-off, the export-then-act flow in §4 is enough. If it needs to be enforced in-product (propose → approve → execute), say so now — it changes the bulk-action model from one call to a stateful review queue.
+5. **Completion at member level** — "completed" = *all* enrolled courses, or *any*? The plan assumes all; per-course completion filtering belongs on the course people page.

--- a/prd/admin-controls-and-reporting/README.md
+++ b/prd/admin-controls-and-reporting/README.md
@@ -72,7 +72,14 @@ Other reporting surfaces with no export: org compliance, course analytics, org a
 
 ## 2. Phase 1 — Foundation (blocks everything)
 
-Migration `packages/db/src/migrations/0015_learner_lifecycle.sql` (0014 is latest); mirror into `packages/db/src/schema.ts`.
+Migration `packages/db/src/migrations/<next>_learner_lifecycle.sql`; mirror into `packages/db/src/schema.ts`.
+
+**Do not copy a migration number from this document.** Take the next free number at implementation time by
+checking both `packages/db/src/migrations/` **and any in-flight branch that has already claimed one**. This
+plan originally pinned `0015`; #1064 took it before the plan was even reviewed, which is the whole argument
+for not pinning. Collisions are a recurring cost here (see `fix(db): renumber display_order migration after
+0007 collision`, #1053) and need both the file and `packages/db/src/migrations/meta/_journal.json` repaired
+by hand.
 
 ```sql
 CREATE TYPE "ORGANIZATION_MEMBER_STATUS" AS ENUM ('ACTIVE', 'DEACTIVATED', 'ARCHIVED');

--- a/prd/admin-controls-and-reporting/UX.md
+++ b/prd/admin-controls-and-reporting/UX.md
@@ -1,6 +1,12 @@
 # UI Behavior Spec — Learner Usage & Lifecycle
 
-Companion to `README.md`, which covers data, API, and sequencing. This file covers **what the admin sees and what happens when they click.** Where the two disagree, this file wins on behavior.
+Companion to `README.md`, which covers data, API, and sequencing. This file covers **what the admin sees and
+what happens when they click.**
+
+**Precedence, one rule:** `prototypes/learner-lifecycle/` → this file → `README.md`. The prototype is the UX
+source of truth; where it and this file disagree on behavior, the prototype wins and this file gets updated.
+Where this file and `README.md` disagree on behavior, this file wins. `README.md` remains authoritative for
+data, API contracts and sequencing.
 
 Everything here composes existing components (`Page.*`, `Table.*`, `Popover`, `DropdownMenu`, `Dialog`, `Sheet`, `Chip`, `Badge`, `Skeleton`, `Empty`, `TablePagination`, `Search`, `SortPopover`). No new visual language.
 
@@ -191,14 +197,14 @@ Appears in place of the control row the moment `selectedCount > 0`, using the sa
 ☑ 42 selected   Select all 3,214 matching       [Assign courses] [Actions ▾]   ×
 ```
 
-- **"Select all N matching"** appears only when every row on the page is selected, and it is the piece that makes this usable at scale. Clicking it switches to filter mode and the bar restates itself: `All 3,214 learners matching these filters are selected  ·  Clear selection`.
+- **"Select all N matching"** appears once every **selectable** row on the page is selected — compared against the selectable set, not the raw row set. Rows without a `profileId` are disabled (§4.1), so a page containing one invited learner could never satisfy an all-rows test and filter-mode selection would be unreachable on that page, and it is the piece that makes this usable at scale. Clicking it switches to filter mode and the bar restates itself: `All 3,214 learners matching these filters are selected  ·  Clear selection`.
 - In filter mode, individual checkboxes deselect back into id mode with a confirmation-free downgrade — the count updates and the banner disappears.
 - The × clears selection and restores the control row.
 - **Actions ▾** ordering, with Archive first and visually emphasised:
   - **Archive** — "Frees a seat · reversible"
   - **Deactivate** — "Blocks access · keeps the seat · reversible"
   - separator
-  - **Delete permanently** — destructive styling (`ui:text-destructive focus:ui:text-destructive`), disabled with an explanatory tooltip unless every selected member is already `ARCHIVED`
+  - **Delete permanently** — destructive styling (`ui:text-destructive focus:ui:text-destructive`), disabled with an explanatory tooltip unless every selected member is already `ARCHIVED`. The server enforces the same rule (`README` §4), so this is a helpful pre-check, not the safeguard itself; type-to-confirm sits on top of the archive requirement, never in place of it
   - Contextual `Reactivate` / `Unarchive` appear when the selection contains such members.
 - The one-line descriptions are the difference between an admin archiving and an admin deleting. They belong in the menu, not in a help doc.
 
@@ -221,13 +227,13 @@ Dialog state resets in `onOpenChange`. Focus lands on Cancel, not the action.
 
 **Under ~1 000 rows** — synchronous. Action button shows a spinner; dialog stays open and blocks; closes on success.
 
-**Over ~1 000 rows** — queued. The dialog closes immediately and a persistent bar appears under the header: `Archiving 3,214 learners… 1,240 done` with a determinate `Progress`. The admin can navigate away and come back; the bar is driven by job status, not page state. On completion it becomes a dismissible success summary and the list refreshes.
+**Over ~1 000 rows** — queued, signalled by `mode: 'queued'` in the response rather than by the client guessing from the count. The dialog closes immediately and a persistent bar appears under the header: `Archiving 3,214 learners… 1,240 done` with a determinate `Progress`, driven by polling the job endpoint. The admin can navigate away and come back; the bar is driven by job state, not page state. On a terminal state the job returns the *same* completed payload the synchronous path returns, so the success and partial-failure UI below is identical either way.
 
-**Count drift** — if the live count no longer matches what was shown (`409`), do not act. Reopen the dialog with the new count and a short note: "This list changed while you were reviewing it — 3,209 learners now match." Re-confirm from there.
+**Target drift** — the server rejects with `409` when either the exact count **or** the checksum of the matched member ids differs from what the admin approved (`README` §4). Both matter: people can churn in and out leaving the count identical but the set different. Do not act. Reopen the dialog with the freshly resolved set and a short note — "This list changed while you were reviewing it — 3,209 learners now match." — and re-confirm from there.
 
 ### 4.5 Results
 
-- **Full success, reversible action** — snackbar with **Undo**, live for 10 seconds, that calls the inverse action on the same ids. Archive and deactivate only.
+- **Full success, reversible action** — snackbar with **Undo**, live for 10 seconds, that spends the `undoToken` the action returned. It applies the inverse change to exactly the members that succeeded — never by re-running the filter, which would now match a different population precisely because the action changed who matches. Archive and deactivate only.
 - **Full success, delete** — plain confirmation snackbar. No undo, and the dialog said so.
 - **Partial failure** — a summary `Dialog`, not a snackbar: "3,180 archived · 34 failed", a scrollable table of failures with reasons, and **Download failures as CSV**. A snackbar cannot carry 34 rows of detail.
 - After any action the list refetches, preset counts refresh, and selection clears. Because the default view filters to `ACTIVE`, archived rows leave the list — the result snackbar names how many, so their disappearance is explained rather than startling.
@@ -275,8 +281,8 @@ Course and cohort assignment moves into the Preview step, grouped in `Field.Set`
 
 ## 8. Prototype
 
-**Built: `prototypes/learner-lifecycle/`** — this is now the UX source of truth. Where this file and the
-prototype disagree, the prototype wins; update this file to match.
+**Built: `prototypes/learner-lifecycle/`** — the UX source of truth, per the precedence rule at the top of
+this file.
 
 - `audience.html` — the whole loop, live over 2,400 synthetic learners. Filters, paging, view counts and
   select-all-matching are really computed, so the scale behaviors are reviewable rather than described.

--- a/prd/admin-controls-and-reporting/UX.md
+++ b/prd/admin-controls-and-reporting/UX.md
@@ -1,0 +1,287 @@
+# UI Behavior Spec — Learner Usage & Lifecycle
+
+Companion to `README.md`, which covers data, API, and sequencing. This file covers **what the admin sees and what happens when they click.** Where the two disagree, this file wins on behavior.
+
+Everything here composes existing components (`Page.*`, `Table.*`, `Popover`, `DropdownMenu`, `Dialog`, `Sheet`, `Chip`, `Badge`, `Skeleton`, `Empty`, `TablePagination`, `Search`, `SortPopover`). No new visual language.
+
+---
+
+## 0. Three behaviors that are wrong today and must not be inherited
+
+1. **Filtering blocks and blanks.** Every filter/sort/page change calls `goto(…, { invalidateAll: true })` (`audience.svelte:150`), so the whole route reloads and the table is unresponsive until the server answers. At 20 000 learners with four new joins, that is a visible stall on every click.
+2. **`audience-table-skeleton.svelte` exists and is never rendered.** It is exported from the components index and imported nowhere. There is no loading affordance at all.
+3. **Selection is wiped by an `$effect` on the data** (`audience.svelte:38`). Any refetch — including one caused by changing a filter — silently clears the admin's selection with no notice.
+
+All three are load-bearing for a bulk-action workflow. §2 and §4 specify the replacements.
+
+---
+
+## 1. Page anatomy
+
+```
+Page.Header
+  Title "Audience"                                          [Export ▾] [Import]
+  Subtitle "Everyone with learner access. · 11,930 of 12,500 seats"
+
+Page.BodyHeader
+  ── Control row ───────────────────────────────────────────────────────
+  [ Search…          ]  All learners ⌄   [ ⚙ Filter • ]  [ ↕ Sort ]
+                              │
+                              └─ All learners      12,480  ✓
+                                 Never logged in    3,214
+                                 Inactive 90+       5,102
+                                 Inactive 180+      2,884
+                                 Enrolled, not started 941
+
+  ── Active-filter chips (only when filters are set) ───────────────────
+  Last login: before 90 days ×   Status: Active ×        Clear all
+
+Page.Body
+  Result summary:  "3,214 learners · sorted by last login, oldest first"
+  Table (8 columns, horizontally scrollable)
+  TablePagination
+```
+
+When rows are selected, the **control row is replaced in place** by the bulk bar (§4.2).
+
+**The control row is right-aligned**, matching `Page.BodyHeader`'s own `align="right"` default and the
+existing courses and cohorts toolbars. Today `audience-table-toolbar.svelte` overrides this with a
+`md:justify-between` wrapper that pushes search left and sort right — it is the outlier in the app, and this
+work should drop the override and use the component default. Search keeps `@cio/ui` `Search`'s natural
+`ui:w-fit ui:max-w-[200px]`; it does not stretch. The active-filter chips row sits right-aligned too, directly
+under the Filter trigger it came from, so the two read as one cluster. Below `sm` both stack full-width.
+
+**Seat usage lives in the subtitle, as muted text** — `· 11,930 of 12,500 seats` — not as a coloured badge
+beside the title. It is reference information the admin glances at, not an alarm. It earns its place because
+archiving makes it fall (README Finding 1), which is how the admin sees the loop paying off.
+
+---
+
+## 2. Filtering
+
+### 2.1 The view switcher — the primary control
+
+Four saved questions cover almost every session. They belong in **one quiet control**, not a row of chips
+across the page: a row of coloured preset buttons with count badges shouts at the admin every time they
+open the page, and the page should be calm until they ask it something.
+
+- A ghost `Button` sitting immediately left of Filter, labelled with the **current view** — `All learners ⌄`,
+  `Never logged in ⌄`. The label is the state; there is no separate active indicator to read.
+- Opens a `DropdownMenu` listing: **All learners · Never logged in · Inactive 90+ days · Inactive 180+ days ·
+  Enrolled, never started**. Counts sit **muted and right-aligned inside the menu**, where they are available
+  on demand and silent otherwise. A check marks the current view.
+- Counts come from one `GET /organization/audience/view-counts` call, rendered as `·` until they resolve so
+  the menu never reflows.
+- Selecting a view **replaces** the entire filter state; it does not merge. Views are starting points, and
+  merging them with stale filters produces results nobody can explain. Search is preserved.
+- Selecting the **current** view is a no-op, not a toggle-off. "All learners" is how you clear.
+- Editing a filter by hand switches the label to **Custom filter**. No view silently claims a state it does
+  not describe.
+- Counts refresh after any bulk action — watching the dormant number fall is the point.
+
+### 2.2 Filter popover
+
+- Trigger: outline `Button`, `FilterIcon`, label "Filter", with a dot indicator when any filter is active and a count badge when more than one is.
+- **Below `md`, the popover becomes a `Sheet`** anchored to the bottom. A five-section filter form in a 360px popover on a phone is unusable.
+- Sections, each a `Field.Set` with a `Field.Legend`:
+  - **Last login** — `RadioGroup`: Any · Never · Before 30 days · Before 90 days · Before 180 days
+  - **Last activity** — same options
+  - **Enrollment** — `RadioGroup`: Any · Enrolled · Not enrolled
+  - **Completion** — `RadioGroup`: Any · Not started · In progress · Completed
+  - **Member status** — `Checkbox` group: Active · Deactivated · Archived (Active pre-checked)
+- **Apply semantics: explicit, not live.** The popover holds draft state and commits on a footer **Apply** button. Live-applying each radio fires a full server round trip per click and, with five sections, means up to five stalls to express one intent. The footer also carries **Clear all**, disabled when nothing is set.
+- Escape or clicking outside discards the draft. The draft resets on close via `onOpenChange` — never in an `$effect` keyed to `!open`.
+- Copy is phrased as staleness, matching how the admin thinks: "hasn't logged in for 90+ days", not "logged in within 90 days".
+
+### 2.3 Active-filter chips
+
+- One `Chip` per active filter, reading as a full clause — `Last login: before 90 days`, not `90d`.
+- Each has an × that removes **only** that filter and reapplies immediately (a single removal is one intent, so no Apply step).
+- A **Clear all** link ends the row.
+- The row is absent, not empty, when no filters are set — no reserved blank space.
+
+### 2.4 Loading — stale-while-loading, never blank
+
+Replaces the blocking `invalidateAll` behavior:
+
+- On any filter/sort/page/search change, **the current rows stay on screen** at `opacity-60` with `pointer-events-none`, and an indeterminate progress bar appears under the toolbar.
+- Controls stay interactive throughout, so the admin can correct a mis-click without waiting.
+- Only a **cold load with no rows to show** renders `AudienceTableSkeleton` (which finally gets used).
+- Requests are cancelled on supersede — `org.svelte.ts` already has `cancelAudienceRequest()` and an `AbortController` for exactly this.
+- If a request fails, keep the stale rows, surface an error snackbar, and leave the filters as the admin set them. Never silently revert to unfiltered.
+
+### 2.5 Search
+
+- Keeps the existing 300 ms debounce and the `keepFocus: true` navigation, both of which are already right.
+- Search composes with filters (AND), and it does **not** switch the view away — searching within "Inactive 90+" is a normal thing to want.
+- The clear × resets search only, leaving filters alone.
+
+### 2.6 Sorting
+
+- Column headers for Name, Email, Joined, Last login, Last activity are clickable, showing an arrow on the active column. `SortPopover` stays for parity and for small screens.
+- Clicking an already-active column flips direction.
+- **Last login and last activity default to oldest-first**, because "who is most dormant" is the question being asked. Every other column defaults to descending.
+
+### 2.7 Result summary and empty states
+
+- Above the table: `"3,214 learners · sorted by last login, oldest first"`, in an `aria-live="polite"` region so screen readers hear the count change after a filter.
+- **No members at all** — existing `Empty` with `audience.no_audience`, plus the Import action.
+- **Filters match nothing** — a distinct `Empty`: "No learners match these filters", with **Clear filters** as the primary action. Never show the "invite your first learner" state to someone who just over-filtered.
+- **A view with a zero count** stays selectable and lands on the empty state; disabling it hides the good news that the number is zero.
+
+### 2.8 URL and history — required, not optional
+
+**All view state lives in the query string.** Every view, filter, sort key, sort order, search term and page
+number is a URL parameter, and the URL is the single source of truth: the page renders from it, and changing
+a control means navigating, never mutating local state and refetching behind the URL's back. There is no
+second copy of this state in a component.
+
+This is not a nicety for this customer — it is what makes the workflow work:
+
+- **A view is shareable.** "Here are the 3,214 dormant learners" is a link an admin sends to their manager
+  for sign-off before a bulk removal. Without it, the reviewer has to be told which five controls to set.
+- **Back and forward move between filter states**, not out of the page. An admin who over-filters presses
+  back, rather than rebuilding the filter by hand.
+- **A refresh preserves everything**, including after the session times out and they sign back in.
+- **A bulk action can be re-entered.** The confirmation dialog records the filter it acted on; that filter is
+  a URL, so "what exactly did I archive last Tuesday?" is answerable from the audit row.
+- **Support and bug reports carry the URL**, so a report is reproducible without a screenshot.
+
+Mechanics:
+
+- Serialise and parse in `audience-query-utils.ts` — extend the existing
+  `getAudienceQueryFromSearchParams` / `getAudienceSearchParams` pair rather than adding a parallel scheme.
+- Omit defaults from the URL so a plain `/audience` stays clean; parsing fills them in.
+- Unknown or malformed parameters fall back to their default instead of erroring — a hand-edited or truncated
+  link must still load.
+- View changes and filter Apply use `pushState` (they are navigations the admin may want to undo). Typing in
+  search uses `replaceState`, so back does not walk through every keystroke. Pagination uses `pushState`.
+- **Selection is deliberately not in the URL.** A shared link carries a view, never someone else's pending
+  destructive selection.
+
+---
+
+## 3. The table
+
+- Columns: ☐ · Name · Email · Status · Joined · **Last login** · **Last activity** · **Enrollment** · **Progress**.
+- The wrapper scrolls horizontally (`overflow-x-auto`); the page body never does. Name column is `sticky left-0` with the header background, matching the existing pattern in `features/course/components/analytics/student-table.svelte:67`.
+- **Last login / Last activity** render as relative time ("3 months ago", "Never") with the absolute timestamp in a `title` / `Tooltip`. Relative answers the question at a glance; absolute is there when someone needs to quote it.
+- "Never" renders `ui:text-muted-foreground` rather than as a warning colour — it is a fact, and colouring thousands of rows red is noise.
+- **Enrollment** is `3 / 5` (completed / enrolled); `—` when not enrolled.
+- **Progress** uses `@cio/ui/custom/percent-ring-progress`, with the percentage as accessible text beside it — never colour or shape alone.
+- Non-`ACTIVE` rows render at reduced emphasis with a status `Badge` (`Deactivated`, `Archived`).
+- Row click behavior is unchanged: the name is a link to the per-learner page. The checkbox and the row-actions menu stop propagation, as they already do.
+
+---
+
+## 4. Selection and bulk actions
+
+### 4.1 Selection
+
+- Per-row `Checkbox`; header checkbox is tri-state for the current page (already implemented).
+- Rows without a `profileId` (invited, never signed up) have a **disabled** checkbox with a tooltip explaining why — the current code disables it silently, which reads as a bug.
+- **Selection survives paging within an unchanged filter.** Replaces the current `$effect` that clears on every data change. If the admin changes a filter or search while holding a selection, show a one-line notice — "Filters changed. 42 selected learners are no longer shown. [Keep] [Clear]" — rather than dropping it silently.
+- Selection state is per-session and not encoded in the URL; sharing a link shares a view, not a selection.
+
+### 4.2 The bulk bar
+
+Appears in place of the control row the moment `selectedCount > 0`, using the same bordered container the current selection bar uses:
+
+```
+☑ 42 selected   Select all 3,214 matching       [Assign courses] [Actions ▾]   ×
+```
+
+- **"Select all N matching"** appears only when every row on the page is selected, and it is the piece that makes this usable at scale. Clicking it switches to filter mode and the bar restates itself: `All 3,214 learners matching these filters are selected  ·  Clear selection`.
+- In filter mode, individual checkboxes deselect back into id mode with a confirmation-free downgrade — the count updates and the banner disappears.
+- The × clears selection and restores the control row.
+- **Actions ▾** ordering, with Archive first and visually emphasised:
+  - **Archive** — "Frees a seat · reversible"
+  - **Deactivate** — "Blocks access · keeps the seat · reversible"
+  - separator
+  - **Delete permanently** — destructive styling (`ui:text-destructive focus:ui:text-destructive`), disabled with an explanatory tooltip unless every selected member is already `ARCHIVED`
+  - Contextual `Reactivate` / `Unarchive` appear when the selection contains such members.
+- The one-line descriptions are the difference between an admin archiving and an admin deleting. They belong in the menu, not in a help doc.
+
+### 4.3 Confirmation dialog
+
+Anatomy, in order:
+
+1. Title stating the action and the exact count — "Archive 3,214 learners?"
+2. One sentence on consequence, per action. Archive: "They lose access and stop counting toward your plan limit. You can restore them at any time."
+3. **Sample list** — the first 5 affected learners with name and last login, plus "and 3,209 more". This is what catches a mis-set filter before it becomes an incident.
+4. **Filter summary**, when in filter mode — the plain-English clause list, so the admin re-reads what they are acting on.
+5. **"Export this list first"** — a secondary link that downloads the full affected set as CSV without closing the dialog. Marked done with a check once used. This is the sign-off step.
+6. **Reason** — optional `TextareaField`, stored on the audit rows.
+7. Type-to-confirm — **delete only**: type the count to enable the button. Archive and deactivate are reversible and do not need friction that trains people to type past warnings.
+8. Buttons: Cancel (secondary) and the action (destructive variant for delete). The action button is disabled while the count is being re-verified.
+
+Dialog state resets in `onOpenChange`. Focus lands on Cancel, not the action.
+
+### 4.4 Executing
+
+**Under ~1 000 rows** — synchronous. Action button shows a spinner; dialog stays open and blocks; closes on success.
+
+**Over ~1 000 rows** — queued. The dialog closes immediately and a persistent bar appears under the header: `Archiving 3,214 learners… 1,240 done` with a determinate `Progress`. The admin can navigate away and come back; the bar is driven by job status, not page state. On completion it becomes a dismissible success summary and the list refreshes.
+
+**Count drift** — if the live count no longer matches what was shown (`409`), do not act. Reopen the dialog with the new count and a short note: "This list changed while you were reviewing it — 3,209 learners now match." Re-confirm from there.
+
+### 4.5 Results
+
+- **Full success, reversible action** — snackbar with **Undo**, live for 10 seconds, that calls the inverse action on the same ids. Archive and deactivate only.
+- **Full success, delete** — plain confirmation snackbar. No undo, and the dialog said so.
+- **Partial failure** — a summary `Dialog`, not a snackbar: "3,180 archived · 34 failed", a scrollable table of failures with reasons, and **Download failures as CSV**. A snackbar cannot carry 34 rows of detail.
+- After any action the list refetches, preset counts refresh, and selection clears. Because the default view filters to `ACTIVE`, archived rows leave the list — the result snackbar names how many, so their disappearance is explained rather than startling.
+
+---
+
+## 5. Export
+
+- `ExportMenu` sits in `Page.Action`: outline `Button`, `DownloadIcon`, label "Export", opening a `DropdownMenu`.
+- Items are **scoped and labelled with counts**, so it is never ambiguous what is being exported:
+  - `Export 42 selected (CSV)` — only when a selection exists
+  - `Export 3,214 filtered (CSV)` — when filters are active
+  - `Export all 12,480 (CSV)`
+  - `Export as PDF` — **disabled above ~2 000 rows**, with a tooltip: "PDF is available for up to 2,000 rows. Use CSV for larger exports."
+- CSV downloads stream, so on large exports the browser shows its own progress. The button enters a loading state until the response starts, then returns to normal — do not fake a progress bar over a browser download.
+- Filenames encode the scope: `acme-audience-inactive-90d-2026-09-06.csv`.
+- On failure, an error snackbar with a retry action. A failed download is otherwise invisible.
+
+---
+
+## 6. Import
+
+Three steps in one route, with a `Page.Title` that names the step.
+
+1. **Upload** — `FileDropZone` accepting `.csv`, with the paste box below under a "or paste emails" divider. A **Download template** link sits beside the drop zone. Rejected files (wrong type, over 5 MB) explain which rule they broke.
+2. **Preview** — three counts as tiles (Ready · Already in audience · Invalid) above a `Table` with a status column. Invalid rows carry the specific reason ("not a valid email address", "duplicate in file"). Continue is disabled when Ready is 0. If the import would exceed the plan limit, a warning banner states how many will be skipped and why, before submitting rather than after.
+3. **Result** — the same three counts as outcomes, plus **Download error rows** so the admin can fix and re-upload. Primary action returns to the audience list.
+
+Course and cohort assignment moves into the Preview step, grouped in `Field.Set`s — it is a decision about the import, and asking for it before the file is validated wastes the admin's time.
+
+---
+
+## 7. Accessibility and input
+
+- The result summary and view counts sit in `aria-live="polite"` regions; the bulk bar's selected count is `aria-live` too, so selection changes are announced.
+- Every checkbox has an accessible label naming its row ("Select Jane Doe"), not a bare "Select".
+- Dialogs trap focus, restore it to the trigger on close, and put initial focus on the safe option.
+- The progress bar for queued actions exposes `aria-valuenow`; the queued state is also announced once on start and once on completion, not on every tick.
+- Status is never conveyed by colour alone — badges carry text, progress rings carry a percentage.
+- Keyboard: `Esc` closes popover/sheet/dialog discarding drafts; the table is fully tabbable; `Space` toggles the focused row checkbox.
+- Respect `prefers-reduced-motion` on the bulk-bar transition and the row dimming — swap the fade for an instant state change.
+- Touch targets on the view switcher, its menu rows, and the chips meet 44 px on mobile.
+
+---
+
+## 8. Prototype
+
+**Built: `prototypes/learner-lifecycle/`** — this is now the UX source of truth. Where this file and the
+prototype disagree, the prototype wins; update this file to match.
+
+- `audience.html` — the whole loop, live over 2,400 synthetic learners. Filters, paging, view counts and
+  select-all-matching are really computed, so the scale behaviors are reviewable rather than described.
+- `states.html` — the twelve states that are hard to reach by clicking.
+- `import.html` — upload → preview → result.
+
+Run it with `cd prototypes/learner-lifecycle && python3 -m http.server 8899`.
+Design review happens there, before any Svelte is written.

--- a/prototypes/learner-lifecycle/README.md
+++ b/prototypes/learner-lifecycle/README.md
@@ -1,0 +1,55 @@
+# Learner Lifecycle — Prototype
+
+Clickable UX source of truth for `prd/admin-controls-and-reporting/`.
+
+| File | What it is |
+| --- | --- |
+| `index.html` | Prototype map — start here |
+| `audience.html` | **Interactive.** The full loop over 2,400 synthetic learners |
+| `states.html` | The twelve edge states, side by side |
+| `import.html` | CSV import: upload → preview → result |
+| `app-theme.css` | Shared theme, copied from `prototypes/learning-paths` — mirrors `packages/ui/src/index.css` tokens |
+| `lifecycle.css` | Components specific to this prototype; each block names the `@cio/ui` primitive it maps to |
+| `proto.js` | Synthetic dataset, filter model, popover/toast behavior |
+
+## Running it
+
+```bash
+cd prototypes/learner-lifecycle && python3 -m http.server 8899
+# → http://localhost:8899
+```
+
+Opening `audience.html` over `file://` works too, apart from browser-extension tooling.
+
+## Why 2,400 rows
+
+The customer has tens of thousands of learners. Over twelve hand-written rows, "Select all N matching",
+pagination, preset counts and the 1,000-row queued threshold all look like decoration. Over 2,400 generated
+rows they behave — the counts are really computed, archiving 400 people really moves them, and the seat
+count really falls.
+
+Data is generated deterministically (seeded PRNG) so screenshots are reproducible: ~26% never logged in,
+the rest spread across recency bands, ~5% already deactivated or archived, and a slice of "Invited" members
+who have no profile yet and therefore cannot be selected.
+
+## What to review
+
+1. **The view switcher, not a row of chips.** Four saved questions live in one quiet dropdown next to search,
+   with counts muted and right-aligned. Selecting one *replaces* filter state rather than merging.
+2. **Stale-while-loading.** Rows stay visible and dimmed during a refetch; controls stay clickable.
+   Today the real page calls `invalidateAll` and goes dead on every filter change.
+3. **Selection survives paging**, and a filter change under a held selection prompts rather than silently clearing.
+4. **Archive is offered before delete**, each with a one-line consequence. Delete is disabled until the
+   selection is already archived.
+5. **The confirmation dialog** shows a real 5-row sample with last-login dates and offers "export this list first".
+   That is what catches a mis-set filter before it becomes 3,000 wrong archives.
+6. **Two distinct empty states** — over-filtered vs genuinely empty.
+
+## Known prototype-only shortcuts
+
+- Export, file picker and template download fire a toast instead of producing a file.
+- Count drift (the `409`) is simulated at random on filter-mode actions so the state is reachable.
+- Partial failure is seeded ~25% of the time for the same reason.
+- Filter state is held in memory here rather than the query string. **The real implementation must put it in
+  the URL** — a hard requirement, not a detail: a filtered view is the link an admin sends for sign-off before
+  a bulk removal. See `UX.md` §2.8.

--- a/prototypes/learner-lifecycle/app-theme.css
+++ b/prototypes/learner-lifecycle/app-theme.css
@@ -1,0 +1,1178 @@
+/*
+ * app-theme.css — shared theme for the learning-paths prototypes.
+ *
+ * Tokens mirror packages/ui/src/index.css (shadcn-svelte) exactly:
+ * OKLCH palette, Geist, --radius: 0.625rem, shadow-2xs, and the component
+ * recipes from @cio/ui base components (Button, Badge, Item, Progress, Sidebar).
+ * Dark mode uses the same `.dark` class convention as the app.
+ */
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.488 0.243 264.376);
+  --primary-foreground: oklch(0.97 0.014 254.604);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+
+  /* Semantic states from @cio/ui Badge variants (emerald / amber) */
+  --success: oklch(0.596 0.145 163.225); /* emerald-600 */
+  --success-foreground: #fff;
+  --success-soft: oklch(0.596 0.145 163.225 / 0.12);
+  --warning: oklch(0.666 0.179 58.318); /* amber-600 */
+  --warning-foreground: #fff;
+  --warning-soft: oklch(0.666 0.179 58.318 / 0.14);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  --shadow-2xs: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.424 0.199 265.638);
+  --primary-foreground: oklch(0.97 0.014 254.604);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+
+  --success: oklch(0.696 0.17 162.48); /* emerald-500 */
+  --success-foreground: oklch(0.262 0.051 172.552); /* emerald-950 */
+  --success-soft: oklch(0.696 0.17 162.48 / 0.16);
+  --warning: oklch(0.769 0.188 70.08); /* amber-500 */
+  --warning-foreground: oklch(0.279 0.077 45.635); /* amber-950 */
+  --warning-soft: oklch(0.769 0.188 70.08 / 0.16);
+}
+
+/* ============ base ============ */
+* {
+  box-sizing: border-box;
+  border-color: var(--border);
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+body {
+  font-family:
+    'Geist',
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+  background: var(--background);
+  color: var(--foreground);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+button {
+  font: inherit;
+}
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+.text-muted {
+  color: var(--muted-foreground);
+}
+.text-primary {
+  color: var(--primary);
+}
+
+/* ============ app shell ============ */
+.app {
+  display: grid;
+  grid-template-columns: 256px 1fr;
+  min-height: 100vh;
+}
+.main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.content {
+  padding: 28px 28px 64px;
+}
+.wrap {
+  max-width: 960px;
+  margin: 0 auto;
+}
+.wrap-narrow {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+/* sidebar (mirrors @cio/ui base/sidebar) */
+.sidebar {
+  background: var(--sidebar);
+  border-right: 1px solid var(--sidebar-border);
+  padding: 16px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px 14px;
+}
+.brand-mark {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-md);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 14px;
+}
+.brand-name {
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: -0.01em;
+}
+.nav-label {
+  font-size: 11px;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  padding: 12px 8px 4px;
+}
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px;
+  border-radius: var(--radius-md);
+  color: var(--sidebar-foreground);
+  font-weight: 400;
+  font-size: 14px;
+  transition: background 0.1s;
+}
+.nav-item svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+  color: var(--muted-foreground);
+  flex-shrink: 0;
+}
+.nav-item:hover {
+  background: var(--sidebar-accent);
+}
+.nav-item.active {
+  background: var(--sidebar-accent);
+  color: var(--sidebar-accent-foreground);
+  font-weight: 500;
+}
+.nav-item.active svg {
+  color: var(--sidebar-accent-foreground);
+}
+.nav-tail {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+.nav-badge {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+.sidebar-foot {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px;
+  border-top: 1px solid var(--sidebar-border);
+}
+.avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.who {
+  min-width: 0;
+}
+.who .nm {
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.who .rl {
+  font-size: 11.5px;
+  color: var(--muted-foreground);
+}
+
+/* path identity block (teacher path sidebar) */
+.back-link {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--muted-foreground);
+  padding: 6px 8px;
+  border-radius: var(--radius-md);
+  margin-bottom: 4px;
+}
+.back-link:hover {
+  background: var(--sidebar-accent);
+  color: var(--foreground);
+}
+.back-link svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+}
+.path-id {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 8px 14px;
+  border-bottom: 1px solid var(--sidebar-border);
+  margin-bottom: 6px;
+}
+.path-id .ico {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.path-id .ico svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+}
+.path-id .nm {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+.path-id .st {
+  font-size: 11.5px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 2px;
+}
+.path-id .st .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+}
+.st-active {
+  color: var(--success);
+}
+.st-active .dot {
+  background: var(--success);
+}
+.st-draft {
+  color: var(--warning);
+}
+.st-draft .dot {
+  background: var(--warning);
+}
+
+/* topbar */
+.topbar {
+  height: 56px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in oklab, var(--background) 90%, transparent);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 24px;
+}
+.crumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13.5px;
+  color: var(--muted-foreground);
+  min-width: 0;
+}
+.crumbs a:hover {
+  color: var(--foreground);
+}
+.crumbs .sep {
+  color: var(--border);
+}
+.crumbs .here {
+  color: var(--foreground);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.top-title {
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+.top-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ============ buttons (mirrors @cio/ui base/button) ============ */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: var(--radius-md);
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  height: 36px;
+  padding: 0 16px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    border-color 0.12s,
+    color 0.12s;
+  box-shadow: var(--shadow-2xs);
+  user-select: none;
+}
+.btn svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+  flex-shrink: 0;
+}
+.btn-primary {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+.btn-primary:hover {
+  background: color-mix(in oklab, var(--primary) 90%, transparent);
+}
+.btn-outline {
+  background: var(--background);
+  border-color: var(--input);
+  color: var(--foreground);
+}
+.btn-outline:hover {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+.btn-secondary {
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+}
+.btn-secondary:hover {
+  background: color-mix(in oklab, var(--secondary) 80%, transparent);
+}
+.btn-ghost {
+  background: transparent;
+  box-shadow: none;
+  color: var(--foreground);
+}
+.btn-ghost:hover {
+  background: var(--accent);
+}
+.btn-destructive {
+  background: var(--destructive);
+  color: #fff;
+}
+.btn-success {
+  background: var(--success);
+  color: var(--success-foreground);
+}
+.btn-sm {
+  height: 32px;
+  padding: 0 12px;
+  font-size: 13px;
+  gap: 6px;
+}
+.btn-sm svg {
+  width: 15px;
+  height: 15px;
+}
+.btn-lg {
+  height: 40px;
+  padding: 0 24px;
+}
+.btn[disabled],
+.btn.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+.btn-icon {
+  width: 36px;
+  padding: 0;
+}
+.btn-icon.btn-sm {
+  width: 32px;
+}
+
+/* ============ badges (mirrors @cio/ui base/badge) ============ */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: fit-content;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.badge svg {
+  width: 12px;
+  height: 12px;
+  stroke-width: 2.4;
+}
+.badge-default {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+.badge-secondary {
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+}
+.badge-success {
+  background: var(--success);
+  color: var(--success-foreground);
+}
+.badge-warning {
+  background: var(--warning);
+  color: var(--warning-foreground);
+}
+.badge-outline {
+  border-color: var(--border);
+  color: var(--foreground);
+  background: transparent;
+}
+.badge-success-soft {
+  background: var(--success-soft);
+  color: var(--success);
+}
+.badge-primary-soft {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+  color: var(--primary);
+}
+.badge-muted {
+  background: var(--muted);
+  color: var(--muted-foreground);
+}
+
+/* ============ cards ============ */
+.card {
+  background: var(--card);
+  color: var(--card-foreground);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-2xs);
+}
+.card-pad {
+  padding: 20px;
+}
+
+/* ============ item rows (mirrors @cio/ui base/item) ============ */
+.item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  padding: 16px;
+  font-size: 14px;
+  transition:
+    background 0.1s,
+    border-color 0.1s;
+}
+.item-muted {
+  background: color-mix(in oklab, var(--muted) 50%, transparent);
+}
+.item-outline {
+  border-color: var(--border);
+}
+.item-done {
+  opacity: 0.6;
+}
+.item-done .item-title,
+.item-done .item-desc {
+  color: var(--muted-foreground);
+  text-decoration: line-through;
+}
+.item-current {
+  background: var(--card);
+  border-color: var(--primary);
+  box-shadow: var(--shadow-sm);
+}
+.item-dashed {
+  border: 1px dashed var(--border);
+  background: transparent;
+}
+a.item:hover {
+  background: color-mix(in oklab, var(--accent) 50%, transparent);
+}
+
+.item-media-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  background: var(--muted);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin-top: 2px;
+  color: var(--muted-foreground);
+}
+.item-media-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+}
+.item-media-icon.is-done {
+  background: var(--success);
+  border-color: var(--success);
+  color: var(--success-foreground);
+}
+.item-media-icon.is-current {
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  border-color: color-mix(in oklab, var(--primary) 30%, transparent);
+  color: var(--primary);
+}
+.item-media-lg {
+  width: 40px;
+  height: 40px;
+}
+.item-media-lg svg {
+  width: 19px;
+  height: 19px;
+}
+.item-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.item-title {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+}
+.item-title-lg {
+  font-size: 15px;
+  font-weight: 600;
+}
+.item-desc {
+  font-size: 13px;
+  color: var(--muted-foreground);
+  line-height: 1.45;
+}
+.item-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.item-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+
+/* ============ progress (mirrors @cio/ui base/progress) ============ */
+.progress {
+  height: 8px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: color-mix(in oklab, var(--primary) 20%, transparent);
+  flex: 1;
+}
+.progress > span {
+  display: block;
+  height: 100%;
+  background: var(--primary);
+  border-radius: var(--radius-md);
+  transition: width 0.3s;
+}
+.progress-success > span {
+  background: var(--success);
+}
+.progress-thin {
+  height: 6px;
+}
+
+/* progress ring (mirrors @cio/ui custom/percent-ring-progress) */
+.ring {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  flex-shrink: 0;
+}
+.ring-sm {
+  width: 40px;
+  height: 40px;
+}
+.ring svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+  display: block;
+}
+.ring .track {
+  stroke: var(--border);
+}
+.ring .arc {
+  stroke: var(--success);
+  transition: stroke-dashoffset 0.7s ease-out;
+}
+.ring .lbl {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--foreground);
+}
+.ring-sm .lbl {
+  font-size: 10px;
+}
+
+/* completion dots (setup page pattern) */
+.dots {
+  display: flex;
+  gap: 4px;
+}
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--border);
+}
+.dot.on {
+  background: var(--success);
+}
+
+/* ============ forms ============ */
+.input,
+.textarea,
+.select {
+  width: 100%;
+  font: inherit;
+  font-size: 14px;
+  color: var(--foreground);
+  background: transparent;
+  border: 1px solid var(--input);
+  border-radius: var(--radius-md);
+  padding: 7px 12px;
+  outline: none;
+  box-shadow: var(--shadow-2xs);
+  transition:
+    border-color 0.12s,
+    box-shadow 0.12s;
+}
+.input:focus,
+.textarea:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 50%, transparent);
+}
+.textarea {
+  resize: vertical;
+  min-height: 76px;
+  line-height: 1.55;
+}
+.label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+.hint {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  margin-top: 5px;
+}
+.field {
+  margin-bottom: 18px;
+}
+.field:last-child {
+  margin-bottom: 0;
+}
+
+/* switch */
+.switch {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  flex-shrink: 0;
+  cursor: pointer;
+  display: inline-block;
+}
+.switch input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  margin: 0;
+  cursor: pointer;
+  z-index: 1;
+}
+.switch .track {
+  position: absolute;
+  inset: 0;
+  background: var(--input);
+  border-radius: 999px;
+  transition: background 0.15s;
+}
+.switch .knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--background);
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.15s;
+}
+.switch input:checked + .track {
+  background: var(--primary);
+}
+.switch input:checked ~ .knob {
+  transform: translateX(16px);
+}
+
+/* ============ tables ============ */
+.thead,
+.trow {
+  display: grid;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 16px;
+}
+.thead {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  border-bottom: 1px solid var(--border);
+}
+.trow {
+  border-bottom: 1px solid var(--border);
+  font-size: 14px;
+}
+.trow:last-child {
+  border-bottom: none;
+}
+a.trow:hover {
+  background: color-mix(in oklab, var(--accent) 50%, transparent);
+}
+
+/* ============ misc components ============ */
+.icon-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--input);
+  background: var(--background);
+  display: grid;
+  place-items: center;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  box-shadow: var(--shadow-2xs);
+}
+.icon-btn:hover {
+  color: var(--foreground);
+  background: var(--accent);
+}
+.icon-btn svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+}
+
+.seg-toggle {
+  display: inline-flex;
+  padding: 3px;
+  background: var(--muted);
+  border-radius: var(--radius-lg);
+  gap: 2px;
+}
+.seg-toggle a,
+.seg-toggle button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: var(--radius-md);
+  border: none;
+  background: transparent;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+.seg-toggle .on {
+  background: var(--background);
+  color: var(--foreground);
+  box-shadow: var(--shadow-2xs);
+}
+.seg-toggle svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2;
+}
+
+.stat-card {
+  padding: 16px 18px;
+}
+.stat-card .k {
+  font-size: 13px;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.stat-card .k svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+}
+.stat-card .v {
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin-top: 4px;
+}
+.stat-card .s {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  margin-top: 2px;
+}
+
+/* page headers */
+.page-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin: 8px 0 20px;
+}
+.page-title {
+  font-size: 24px;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+  margin: 0 0 4px;
+}
+.page-sub {
+  color: var(--muted-foreground);
+  font-size: 14px;
+  margin: 0;
+}
+.sec-title {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+.sec-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 28px 0 14px;
+}
+.sec-head .count {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  background: var(--muted);
+  padding: 1px 8px;
+  border-radius: 999px;
+}
+.sec-head .more {
+  margin-left: auto;
+  font-size: 13.5px;
+  color: var(--primary);
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.sec-head .more svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2;
+}
+
+/* segmented path progress (course-count segments) */
+.segs {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+}
+.seg {
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--primary) 15%, transparent);
+  position: relative;
+  overflow: hidden;
+}
+.seg.done {
+  background: var(--success);
+}
+.seg.half::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: 45%;
+  background: var(--primary);
+  border-radius: 999px;
+}
+
+/* lock veil for thumbnails */
+.lock-veil {
+  position: absolute;
+  inset: 0;
+  background: oklch(0.145 0 0 / 0.35);
+  display: grid;
+  place-items: center;
+}
+.lock-veil svg {
+  width: 18px;
+  height: 18px;
+  color: #fff;
+  stroke-width: 2.2;
+}
+
+/* ============ journey spine (learner path detail) ============ */
+.journey {
+  position: relative;
+  margin-top: 16px;
+}
+.step {
+  position: relative;
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 16px;
+  padding-bottom: 16px;
+}
+.step:last-child {
+  padding-bottom: 0;
+}
+.rail {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+.rail::before {
+  content: '';
+  position: absolute;
+  top: 38px;
+  bottom: -16px;
+  width: 2px;
+  background: var(--border);
+  border-radius: 2px;
+}
+.step:last-child .rail::before,
+.step.no-rail .rail::before {
+  display: none;
+}
+.step.s-done .rail::before {
+  background: var(--success);
+}
+.step.s-current .rail::before {
+  background: linear-gradient(180deg, var(--success) 0%, var(--border) 70%);
+}
+.node {
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 13px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  border: 1px solid var(--border);
+}
+.node svg {
+  width: 17px;
+  height: 17px;
+  stroke-width: 2.4;
+}
+.step.s-done .node {
+  background: var(--success);
+  border-color: var(--success);
+  color: var(--success-foreground);
+}
+.step.s-current .node {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+  box-shadow: 0 0 0 4px color-mix(in oklab, var(--primary) 15%, transparent);
+}
+
+/* horizontal stepper (in-course ribbon) */
+.stepper {
+  display: flex;
+  align-items: center;
+}
+.snode {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  width: 110px;
+  text-align: center;
+}
+.sdot {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 12px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  border: 1px solid var(--border);
+}
+.sdot svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2.6;
+}
+.snode.done .sdot {
+  background: var(--success);
+  border-color: var(--success);
+  color: var(--success-foreground);
+}
+.snode.current .sdot {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--primary) 15%, transparent);
+}
+.slabel {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  line-height: 1.25;
+}
+.snode.current .slabel {
+  color: var(--foreground);
+  font-weight: 600;
+}
+.sbar {
+  flex: 1;
+  height: 2px;
+  background: var(--border);
+  min-width: 12px;
+  margin: 0 -14px 18px;
+}
+.sbar.filled {
+  background: var(--success);
+}
+
+/* ============ responsive ============ */
+@media (max-width: 860px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+  .sidebar {
+    display: none;
+  }
+  .item {
+    flex-wrap: wrap;
+  }
+  .item-actions {
+    width: 100%;
+  }
+  .item-actions .btn {
+    flex: 1;
+  }
+}

--- a/prototypes/learner-lifecycle/audience.html
+++ b/prototypes/learner-lifecycle/audience.html
@@ -1,0 +1,900 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Audience · Learner Lifecycle Prototype</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="lifecycle.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+  </head>
+  <body>
+    <div class="sheet-scrim"></div>
+
+    <div class="app">
+      <aside class="sidebar">
+        <a class="brand" href="index.html">
+          <span class="brand-mark">C</span><span class="brand-name">Acme Academy</span>
+        </a>
+        <div class="nav-label">Organization</div>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>Dashboard</a>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Courses<span class="nav-tail tnum">28</span></a>
+        <a class="nav-item active" href="audience.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/></svg>Audience<span class="nav-tail tnum" id="navCount">—</span></a>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>Analytics</a>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>Compliance</a>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="3"/><path d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M5.6 18.4 7 17M17 7l1.4-1.4"/></svg>Settings</a>
+        <div class="sidebar-foot"><div class="avatar">JD</div><div class="who"><div class="nm">Jordan Diallo</div><div class="rl">Admin</div></div></div>
+      </aside>
+
+      <div class="main">
+        <header class="topbar">
+          <nav class="crumbs"><a href="index.html">Prototype</a><span class="sep">/</span><span class="here">Audience</span></nav>
+          <div class="top-actions">
+            <a class="btn btn-ghost btn-sm" href="states.html">Edge states →</a>
+            <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+          </div>
+        </header>
+
+        <main class="content">
+          <div class="wrap" style="max-width: 1180px">
+            <div class="note">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" style="width:14px;height:14px;flex-shrink:0;margin-top:2px"><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/></svg>
+              <span><b>Live prototype over 2,400 synthetic learners.</b> Filters, paging, counts and select-all-matching are really computed. Try: open the <b>view switcher</b> next to search → pick "Never logged in" → select the page → "Select all N matching" → <b>Actions</b>. The seat count in the subtitle falls when you archive; deactivating leaves it alone. Notes like this are prototype annotations, not app UI.</span>
+            </div>
+
+            <!-- ============ page header ============ -->
+            <div class="page-head">
+              <div>
+                <h1 class="page-title">Audience</h1>
+                <p class="page-sub">Everyone with learner access to Acme Academy. <span class="tnum" id="totalBadge"></span></p>
+              </div>
+              <div style="display:flex;gap:8px">
+                <div class="rel">
+                  <button class="btn btn-outline" data-pop="exportPop" id="exportBtn">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5M12 15V3"/></svg>
+                    Export
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" style="width:13px"><path d="m6 9 6 6 6-6"/></svg>
+                  </button>
+                  <div class="pop menu" id="exportPop" style="right:0;top:calc(100% + 6px);min-width:280px"></div>
+                </div>
+                <a class="btn btn-secondary" href="import.html">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M19 8v6M22 11h-6"/></svg>
+                  Import
+                </a>
+              </div>
+            </div>
+
+            <!-- ============ queued job bar ============ -->
+            <div class="jobbar" id="jobbar">
+              <span class="lbl" id="jobLabel">Archiving…</span>
+              <div class="progress"><span id="jobFill" style="width:0%"></span></div>
+              <span class="pct" id="jobPct">0%</span>
+              <button class="btn btn-ghost btn-sm" id="jobDismiss" hidden>Dismiss</button>
+            </div>
+
+            <!-- ============ control row ============ -->
+            <div class="controls" id="controls">
+              <input class="input search-input" id="search" placeholder="Search by name or email…" aria-label="Search learners" />
+              <div class="rel">
+                <button class="btn btn-ghost" data-pop="viewPop" id="viewBtn" aria-expanded="false">
+                  <span id="viewLabel">All learners</span>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" style="width:13px"><path d="m6 9 6 6 6-6"/></svg>
+                </button>
+                <div class="pop menu" id="viewPop" style="left:0;top:calc(100% + 6px);min-width:270px"></div>
+              </div>
+              <div class="rel">
+                <button class="btn btn-outline" data-pop="filterPop" id="filterBtn" aria-expanded="false">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z"/></svg>
+                  Filter
+                  <span class="badge badge-secondary tnum" id="filterCount" hidden></span>
+                </button>
+                <span class="dot-flag" id="filterDot" hidden></span>
+                <div class="pop filter-pop" id="filterPop" style="right:0;top:calc(100% + 6px)">
+                  <div class="filter-body" id="filterBody"></div>
+                  <div class="filter-foot">
+                    <button class="link-btn" id="filterClear">Clear all</button>
+                    <div style="display:flex;gap:8px">
+                      <button class="btn btn-ghost btn-sm" id="filterCancel">Cancel</button>
+                      <button class="btn btn-primary btn-sm" id="filterApply">Apply</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="rel">
+                <button class="btn btn-outline" data-pop="sortPop">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 6h18M6 12h12M10 18h4"/></svg>
+                  Sort
+                </button>
+                <div class="pop menu" id="sortPop" style="right:0;top:calc(100% + 6px);min-width:230px"></div>
+              </div>
+            </div>
+
+            <!-- ============ bulk bar (replaces control row) ============ -->
+            <div class="bulkbar" id="bulkbar">
+              <span class="count" id="bulkCount">0 selected</span>
+              <button class="link-btn" id="selectAllMatching" hidden></button>
+              <span class="spacer"></span>
+              <button class="btn btn-outline btn-sm">Assign courses</button>
+              <div class="rel">
+                <button class="btn btn-secondary btn-sm" data-pop="actionsPop">
+                  Actions
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" style="width:13px"><path d="m6 9 6 6 6-6"/></svg>
+                </button>
+                <div class="pop menu" id="actionsPop" style="right:0;top:calc(100% + 6px);min-width:300px"></div>
+              </div>
+              <button class="icon-btn" id="clearSel" aria-label="Clear selection" style="border:none;background:transparent;box-shadow:none">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M18 6 6 18M6 6l12 12"/></svg>
+              </button>
+            </div>
+
+            <!-- ============ select-all-matching banner ============ -->
+            <div class="allmatch" id="allmatch">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" style="width:15px;color:var(--primary)"><path d="m9 11 3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+              <span id="allmatchText"></span>
+              <span class="spacer" style="flex:1"></span>
+              <button class="link-btn" id="allmatchClear">Clear selection</button>
+            </div>
+
+            <!-- ============ chips ============ -->
+            <div class="chips" id="chips" hidden></div>
+
+            <!-- ============ result summary ============ -->
+            <p class="summary" id="summary" aria-live="polite"></p>
+
+            <!-- ============ table ============ -->
+            <div class="dt-wrap" id="dtwrap">
+              <div class="loadbar"></div>
+              <div class="dt-scroll">
+                <table class="dt">
+                  <thead>
+                    <tr>
+                      <th class="c-check sticky-l"><input type="checkbox" class="cb" id="headCb" aria-label="Select all on this page" /></th>
+                      <th class="sortable" data-sort="name">Name<span class="arrow">▼</span></th>
+                      <th>Email</th>
+                      <th>Status</th>
+                      <th class="sortable" data-sort="joinedAt">Joined<span class="arrow">▼</span></th>
+                      <th class="sortable" data-sort="lastLoginAt">Last login<span class="arrow">▼</span></th>
+                      <th class="sortable" data-sort="lastActiveAt">Last activity<span class="arrow">▼</span></th>
+                      <th>Enrollment</th>
+                      <th class="sortable" data-sort="progress">Progress<span class="arrow">▼</span></th>
+                      <th style="width:44px"><span class="sr">Row actions</span></th>
+                    </tr>
+                  </thead>
+                  <tbody id="tbody"></tbody>
+                </table>
+              </div>
+              <div id="emptyState"></div>
+            </div>
+
+            <!-- ============ pagination ============ -->
+            <div class="pager" id="pager"></div>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <!-- ============ confirmation dialog ============ -->
+    <div class="backdrop" id="confirmBack" role="dialog" aria-modal="true" aria-labelledby="confirmTitle">
+      <div class="dialog">
+        <div class="dialog-head">
+          <h2 id="confirmTitle"></h2>
+          <p class="lede" id="confirmLede"></p>
+        </div>
+        <div class="dialog-body">
+          <div class="sample" id="confirmSample"></div>
+          <div class="recap" id="confirmRecap" hidden></div>
+          <div class="export-first" id="exportFirst">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5M12 15V3"/></svg>
+            <span style="flex:1" id="exportFirstText">Export this list first, so you can circulate it before acting.</span>
+            <button class="btn btn-outline btn-sm" id="exportFirstBtn">Export CSV</button>
+          </div>
+          <label class="label" for="reason" style="margin-bottom:-8px">Reason <span class="text-muted" style="font-weight:400">(optional, saved to the audit log)</span></label>
+          <textarea class="textarea" id="reason" rows="2" placeholder="e.g. Q3 dormant account review"></textarea>
+          <div id="typeConfirm" hidden>
+            <label class="label" for="typeBox">Type <b id="typeTarget"></b> to confirm</label>
+            <input class="input" id="typeBox" autocomplete="off" />
+          </div>
+        </div>
+        <div class="dialog-foot">
+          <button class="btn btn-ghost" id="confirmCancel">Cancel</button>
+          <button class="btn btn-primary" id="confirmGo"></button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============ partial failure dialog ============ -->
+    <div class="backdrop" id="failBack" role="dialog" aria-modal="true" aria-labelledby="failTitle">
+      <div class="dialog">
+        <div class="dialog-head">
+          <h2 id="failTitle">Finished with errors</h2>
+          <p class="lede" id="failLede"></p>
+        </div>
+        <div class="dialog-body">
+          <div class="sample" id="failList" style="max-height:240px;overflow:auto"></div>
+        </div>
+        <div class="dialog-foot">
+          <button class="btn btn-outline" id="failExport">Download failures as CSV</button>
+          <button class="btn btn-primary" id="failClose">Done</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="toasts"></div>
+
+    <script src="proto.js"></script>
+    <script>
+      const P = window.proto;
+      P.initTheme();
+
+      /* ---------------- state ---------------- */
+      const ALL = P.buildLearners(2400);
+      const PAGE_SIZE = 20;
+
+      let filter = { ...P.EMPTY_FILTER };
+      let draft = { ...filter };
+      let sortBy = 'lastLoginAt';
+      let sortOrder = 'asc'; // oldest first — the dormancy question
+      let page = 1;
+      let selected = new Set();
+      let allMatchingMode = false;
+      let busy = false;
+      let rows = [];
+
+      const $ = (id) => document.getElementById(id);
+
+      /* ---------------- derive ---------------- */
+      function compute() {
+        const list = ALL.filter((r) => P.matches(r, filter));
+        const dir = sortOrder === 'asc' ? 1 : -1;
+
+        list.sort((a, b) => {
+          let av = a[sortBy];
+          let bv = b[sortBy];
+          // "Never" sorts as most-dormant, i.e. before every real timestamp when ascending
+          if (av === null) av = -Infinity;
+          if (bv === null) bv = -Infinity;
+          if (typeof av === 'string') return av.localeCompare(bv) * dir;
+          return (av - bv) * dir;
+        });
+
+        return list;
+      }
+
+      function pageRows(list) {
+        return list.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+      }
+
+      const selectableOf = (pr) => pr.filter((r) => !r.pending);
+
+      /* ---------------- stale-while-loading ---------------- */
+      function reload(reason) {
+        busy = true;
+        $('dtwrap').classList.add('busy');
+        render({ keepRows: true });
+
+        setTimeout(() => {
+          busy = false;
+          $('dtwrap').classList.remove('busy');
+          render();
+          if (reason) announce(reason);
+        }, 420);
+      }
+
+      function announce(text) {
+        // summary is aria-live; re-render already updates it
+      }
+
+      /* ---------------- presets ---------------- */
+      function activePresetId() {
+        const cur = JSON.stringify({ ...filter, search: '' });
+        const hit = P.PRESETS.find((p) => JSON.stringify({ ...p.filter, search: '' }) === cur);
+        return hit ? hit.id : null;
+      }
+
+      function renderViews(countsReady) {
+        const active = activePresetId();
+        const current = P.PRESETS.find((p) => p.id === active);
+        $('viewLabel').textContent = current ? current.label : 'Custom filter';
+
+        $('viewPop').innerHTML = P.PRESETS.map((p) => {
+          const n = countsReady ? P.num(ALL.filter((r) => P.matches(r, { ...p.filter, search: filter.search })).length) : '';
+          return `<button data-preset="${p.id}">
+            <span class="t">${p.label}</span>
+            <span class="cnt">${countsReady ? n : '·'}</span>
+            ${active === p.id ? '<span class="tick">✓</span>' : '<span class="tick"></span>'}
+          </button>`;
+        }).join('');
+
+        $('viewPop').querySelectorAll('[data-preset]').forEach((b) =>
+          b.addEventListener('click', () => {
+            P.closeAllPops();
+            const preset = P.PRESETS.find((x) => x.id === b.dataset.preset);
+            if (activePresetId() === preset.id) return; // active view is a no-op, not a toggle-off
+
+            // views REPLACE filter state; search is preserved
+            filter = { ...preset.filter, search: filter.search };
+            draft = { ...filter };
+            page = 1;
+            clearSelection();
+            reload();
+          })
+        );
+      }
+
+      /* ---------------- filter popover ---------------- */
+      const RADIO_SETS = [
+        { key: 'lastLogin', legend: 'Last login', opts: [['any','Any'],['never','Never logged in'],['30','Before 30 days'],['90','Before 90 days'],['180','Before 180 days']] },
+        { key: 'lastActive', legend: 'Last activity', opts: [['any','Any'],['never','No activity ever'],['30','Before 30 days'],['90','Before 90 days'],['180','Before 180 days']] },
+        { key: 'enrollment', legend: 'Enrollment', opts: [['any','Any'],['enrolled','Enrolled in a course'],['not_enrolled','Not enrolled']] },
+        { key: 'completion', legend: 'Completion', opts: [['any','Any'],['not_started','Not started'],['in_progress','In progress'],['completed','Completed']] },
+        { key: 'status', legend: 'Member status', opts: [['ACTIVE','Active'],['DEACTIVATED','Deactivated'],['ARCHIVED','Archived'],['any','All statuses']] }
+      ];
+
+      function renderFilterBody() {
+        $('filterBody').innerHTML = RADIO_SETS.map((s) => `
+          <fieldset class="fset" style="border:none;margin:0;padding:0">
+            <legend class="legend">${s.legend}</legend>
+            ${s.opts.map(([v, l]) => `
+              <label class="fopt"><input type="radio" class="radio" name="${s.key}" value="${v}" ${draft[s.key] === v ? 'checked' : ''}/> ${l}</label>
+            `).join('')}
+          </fieldset>
+        `).join('');
+
+        $('filterBody').querySelectorAll('input[type=radio]').forEach((r) =>
+          r.addEventListener('change', () => { draft[r.name] = r.value; })
+        );
+      }
+
+      $('filterBtn').addEventListener('click', () => {
+        draft = { ...filter }; // reopening always starts from committed state
+        renderFilterBody();
+        const pop = $('filterPop');
+        const opening = !pop.classList.contains('on');
+        P.closeAllPops(pop);
+        pop.classList.toggle('on', opening);
+        $('filterBtn').setAttribute('aria-expanded', String(opening));
+        if (window.innerWidth <= 820) document.querySelector('.sheet-scrim').classList.toggle('on', opening);
+      });
+
+      $('filterApply').addEventListener('click', () => {
+        filter = { ...draft, search: filter.search };
+        page = 1;
+        clearSelection();
+        P.closeAllPops();
+        document.querySelector('.sheet-scrim').classList.remove('on');
+        reload();
+      });
+
+      $('filterCancel').addEventListener('click', () => {
+        draft = { ...filter }; // discard
+        P.closeAllPops();
+        document.querySelector('.sheet-scrim').classList.remove('on');
+      });
+
+      $('filterClear').addEventListener('click', () => {
+        draft = { ...P.EMPTY_FILTER };
+        renderFilterBody();
+      });
+
+      /* ---------------- sort ---------------- */
+      const SORTS = [
+        ['lastLoginAt', 'Last login'],
+        ['lastActiveAt', 'Last activity'],
+        ['joinedAt', 'Joined'],
+        ['name', 'Name'],
+        ['progress', 'Progress']
+      ];
+
+      function renderSortPop() {
+        $('sortPop').innerHTML =
+          '<div class="menu-label">Sort by</div>' +
+          SORTS.map(([k, l]) => `<button data-sortk="${k}"><span class="t">${l}</span>${sortBy === k ? '<span style="margin-left:auto;color:var(--primary)">✓</span>' : ''}</button>`).join('') +
+          '<div class="menu-sep"></div><div class="menu-label">Order</div>' +
+          `<button data-order="asc"><span class="t">Oldest first</span>${sortOrder === 'asc' ? '<span style="margin-left:auto;color:var(--primary)">✓</span>' : ''}</button>` +
+          `<button data-order="desc"><span class="t">Newest first</span>${sortOrder === 'desc' ? '<span style="margin-left:auto;color:var(--primary)">✓</span>' : ''}</button>`;
+
+        $('sortPop').querySelectorAll('[data-sortk]').forEach((b) =>
+          b.addEventListener('click', () => { setSort(b.dataset.sortk); P.closeAllPops(); })
+        );
+        $('sortPop').querySelectorAll('[data-order]').forEach((b) =>
+          b.addEventListener('click', () => { sortOrder = b.dataset.order; P.closeAllPops(); reload(); })
+        );
+      }
+
+      function setSort(key) {
+        if (sortBy === key) {
+          sortOrder = sortOrder === 'asc' ? 'desc' : 'asc';
+        } else {
+          sortBy = key;
+          // dormancy columns default oldest-first; everything else newest-first
+          sortOrder = key === 'lastLoginAt' || key === 'lastActiveAt' || key === 'name' ? 'asc' : 'desc';
+        }
+        page = 1;
+        reload();
+      }
+
+      document.querySelectorAll('th.sortable').forEach((th) =>
+        th.addEventListener('click', () => setSort(th.dataset.sort))
+      );
+
+      /* ---------------- selection ---------------- */
+      function clearSelection() {
+        selected = new Set();
+        allMatchingMode = false;
+      }
+
+      $('clearSel').addEventListener('click', () => { clearSelection(); render(); });
+      $('allmatchClear').addEventListener('click', () => { clearSelection(); render(); });
+
+      $('headCb').addEventListener('change', () => {
+        const sel = selectableOf(pageRows(rows));
+        const allOn = sel.every((r) => selected.has(r.id));
+        sel.forEach((r) => (allOn ? selected.delete(r.id) : selected.add(r.id)));
+        allMatchingMode = false;
+        render();
+      });
+
+      $('selectAllMatching').addEventListener('click', () => {
+        allMatchingMode = true;
+        render();
+      });
+
+      const effectiveCount = () => (allMatchingMode ? rows.filter((r) => !r.pending).length : selected.size);
+
+      /* ---------------- actions ---------------- */
+      const ACTIONS = {
+        archive: {
+          label: 'Archive',
+          hint: 'Frees a seat · reversible',
+          title: (n) => `Archive ${P.num(n)} learner${n === 1 ? '' : 's'}?`,
+          lede: 'They lose access and stop counting toward your plan limit. You can restore them at any time.',
+          cta: 'Archive',
+          variant: 'btn-primary',
+          undo: 'Unarchive'
+        },
+        deactivate: {
+          label: 'Deactivate',
+          hint: 'Blocks access · keeps the seat · reversible',
+          title: (n) => `Deactivate ${P.num(n)} learner${n === 1 ? '' : 's'}?`,
+          lede: 'They can no longer sign in to this organization. They still count toward your plan limit. Reversible.',
+          cta: 'Deactivate',
+          variant: 'btn-primary',
+          undo: 'Reactivate'
+        },
+        delete: {
+          label: 'Delete permanently',
+          hint: 'Irreversible · removes all records',
+          title: (n) => `Permanently delete ${P.num(n)} learner${n === 1 ? '' : 's'}?`,
+          lede: 'This removes their membership, enrollments and progress from this organization. It cannot be undone.',
+          cta: 'Delete permanently',
+          variant: 'btn-destructive',
+          undo: null,
+          type: true
+        }
+      };
+
+      function renderActionsPop() {
+        const targets = currentTargets();
+        const allArchived = targets.length > 0 && targets.every((r) => r.status === 'ARCHIVED');
+        const anyInactive = targets.some((r) => r.status !== 'ACTIVE');
+
+        $('actionsPop').innerHTML = `
+          <button data-act="archive"><div><div class="t">Archive</div><div class="d">${ACTIONS.archive.hint}</div></div></button>
+          <button data-act="deactivate"><div><div class="t">Deactivate</div><div class="d">${ACTIONS.deactivate.hint}</div></div></button>
+          ${anyInactive ? '<button data-act="restore"><div><div class="t">Restore</div><div class="d">Return to active</div></div></button>' : ''}
+          <div class="menu-sep"></div>
+          <button class="danger" data-act="delete" ${allArchived ? '' : 'disabled title="Only archived learners can be permanently deleted. Archive them first."'}>
+            <div><div class="t">Delete permanently</div><div class="d">${allArchived ? ACTIONS.delete.hint : 'Archive them first'}</div></div>
+          </button>`;
+
+        $('actionsPop').querySelectorAll('[data-act]').forEach((b) =>
+          b.addEventListener('click', () => {
+            P.closeAllPops();
+            if (b.dataset.act === 'restore') return runRestore();
+            openConfirm(b.dataset.act);
+          })
+        );
+      }
+
+      function currentTargets() {
+        return allMatchingMode ? rows.filter((r) => !r.pending) : ALL.filter((r) => selected.has(r.id));
+      }
+
+      /* ---------------- confirm dialog ---------------- */
+      let pendingAction = null;
+
+      function openConfirm(actKey) {
+        const act = ACTIONS[actKey];
+        const targets = currentTargets();
+        pendingAction = { actKey, targets };
+
+        $('confirmTitle').textContent = act.title(targets.length);
+        $('confirmLede').textContent = act.lede;
+
+        const sample = targets.slice(0, 5);
+        $('confirmSample').innerHTML =
+          sample.map((r) => `<div class="r"><span>${r.name}</span><span class="text-muted">${r.lastLoginAt === null ? 'Never logged in' : 'Last login ' + P.relTime(r.lastLoginAt)}</span></div>`).join('') +
+          (targets.length > 5 ? `<div class="r more">and ${P.num(targets.length - 5)} more</div>` : '');
+
+        const clauses = P.describe(filter);
+        $('confirmRecap').hidden = !allMatchingMode;
+        if (allMatchingMode) {
+          $('confirmRecap').innerHTML =
+            '<b>Matching these filters:</b><br>' +
+            (clauses.length ? clauses.map((c) => '· ' + c.text).join('<br>') : '· No filters — this is your entire audience') +
+            (filter.search ? `<br>· Search: “${filter.search}”` : '');
+        }
+
+        $('exportFirst').classList.remove('done');
+        $('exportFirstText').textContent = 'Export this list first, so you can circulate it before acting.';
+        $('reason').value = '';
+
+        $('typeConfirm').hidden = !act.type;
+        $('typeTarget').textContent = String(targets.length);
+        $('typeBox').value = '';
+
+        const go = $('confirmGo');
+        go.textContent = act.cta;
+        go.className = 'btn ' + act.variant;
+        go.disabled = !!act.type;
+
+        $('confirmBack').classList.add('on');
+        $('confirmCancel').focus(); // safe option gets focus
+      }
+
+      $('typeBox').addEventListener('input', () => {
+        $('confirmGo').disabled = $('typeBox').value.trim() !== String(pendingAction.targets.length);
+      });
+
+      $('confirmCancel').addEventListener('click', () => $('confirmBack').classList.remove('on'));
+
+      $('exportFirstBtn').addEventListener('click', () => {
+        $('exportFirst').classList.add('done');
+        $('exportFirstText').textContent = `Exported ${P.num(pendingAction.targets.length)} rows to CSV.`;
+        P.toast(`Exported ${P.num(pendingAction.targets.length)} learners to CSV.`);
+      });
+
+      $('confirmGo').addEventListener('click', () => {
+        const { actKey, targets } = pendingAction;
+        $('confirmBack').classList.remove('on');
+
+        // count drift check — someone logged in while the admin was reviewing
+        if (allMatchingMode && Math.random() < 0.18) {
+          const drifted = targets.length - (1 + Math.floor(Math.random() * 6));
+          P.toast(`This list changed while you were reviewing it — ${P.num(drifted)} learners now match. Re-confirm to continue.`, { error: true, action: 'Review again', onAction: () => openConfirm(actKey) });
+          return;
+        }
+
+        if (targets.length > 1000) runQueued(actKey, targets);
+        else runNow(actKey, targets);
+      });
+
+      /* ---------------- executing ---------------- */
+      function applyStatus(targets, status) {
+        targets.forEach((r) => { r.status = status; });
+      }
+
+      function afterAction(actKey, targets, failures) {
+        clearSelection();
+        reload();
+        renderViews(true);
+
+        const act = ACTIONS[actKey];
+        if (failures && failures.length) return openFailures(targets.length, failures);
+
+        const n = P.num(targets.length);
+        if (act.undo) {
+          P.toast(`${n} learner${targets.length === 1 ? '' : 's'} ${actKey}d. They no longer appear in this view.`, {
+            action: 'Undo',
+            timeout: 10000,
+            onAction: () => { applyStatus(targets, 'ACTIVE'); reload(); renderViews(true); P.toast('Restored.'); }
+          });
+        } else {
+          P.toast(`${n} learner${targets.length === 1 ? '' : 's'} permanently deleted.`);
+        }
+      }
+
+      function runNow(actKey, targets) {
+        // seed a partial failure occasionally so the failure UI is reachable
+        const failures = Math.random() < 0.25
+          ? targets.slice(0, Math.min(3, targets.length)).map((r) => ({ name: r.name, email: r.email, reason: 'Still enrolled in a mandatory course' }))
+          : [];
+        const ok = targets.filter((r) => !failures.some((f) => f.email === r.email));
+
+        if (actKey === 'delete') ok.forEach((r) => { const i = ALL.indexOf(r); if (i > -1) ALL.splice(i, 1); });
+        else applyStatus(ok, actKey === 'archive' ? 'ARCHIVED' : 'DEACTIVATED');
+
+        afterAction(actKey, ok, failures);
+      }
+
+      function runQueued(actKey, targets) {
+        const bar = $('jobbar');
+        bar.classList.add('on');
+        $('jobDismiss').hidden = true;
+        $('jobLabel').textContent = `${ACTIONS[actKey].cta}ing ${P.num(targets.length)} learners…`;
+
+        let done = 0;
+        const step = Math.ceil(targets.length / 22);
+        const timer = setInterval(() => {
+          done = Math.min(targets.length, done + step);
+          const pct = Math.round((done / targets.length) * 100);
+          $('jobFill').style.width = pct + '%';
+          $('jobPct').textContent = `${P.num(done)} of ${P.num(targets.length)}`;
+
+          if (done >= targets.length) {
+            clearInterval(timer);
+            if (actKey === 'delete') targets.forEach((r) => { const i = ALL.indexOf(r); if (i > -1) ALL.splice(i, 1); });
+            else applyStatus(targets, actKey === 'archive' ? 'ARCHIVED' : 'DEACTIVATED');
+
+            $('jobLabel').textContent = `Finished — ${P.num(targets.length)} learners ${actKey}d.`;
+            $('jobDismiss').hidden = false;
+            afterAction(actKey, targets, []);
+          }
+        }, 160);
+
+        P.toast('Working in the background. You can leave this page.');
+      }
+
+      $('jobDismiss').addEventListener('click', () => $('jobbar').classList.remove('on'));
+
+      function runRestore() {
+        const targets = currentTargets();
+        applyStatus(targets, 'ACTIVE');
+        clearSelection();
+        reload();
+        renderViews(true);
+        P.toast(`${P.num(targets.length)} learners restored to active.`);
+      }
+
+      function openFailures(total, failures) {
+        $('failLede').textContent = `${P.num(total)} succeeded · ${failures.length} failed`;
+        $('failList').innerHTML = failures.map((f) => `<div class="r"><span>${f.name}<div class="em">${f.email}</div></span><span class="text-muted" style="text-align:right">${f.reason}</span></div>`).join('');
+        $('failBack').classList.add('on');
+      }
+
+      $('failClose').addEventListener('click', () => $('failBack').classList.remove('on'));
+      $('failExport').addEventListener('click', () => P.toast('Downloaded failed-rows.csv'));
+
+      /* ---------------- export menu ---------------- */
+      function renderExportPop() {
+        const filtered = rows.length;
+        const sel = effectiveCount();
+        const pdfOk = (sel || filtered) <= 2000;
+
+        $('exportPop').innerHTML =
+          (sel ? `<button data-x="sel"><div><div class="t">Export ${P.num(sel)} selected</div><div class="d">CSV</div></div></button>` : '') +
+          (P.describe(filter).length || filter.search ? `<button data-x="filtered"><div><div class="t">Export ${P.num(filtered)} filtered</div><div class="d">CSV · matches the current view</div></div></button>` : '') +
+          `<button data-x="all"><div><div class="t">Export all ${P.num(ALL.length)}</div><div class="d">CSV · streams from the server</div></div></button>` +
+          '<div class="menu-sep"></div>' +
+          `<button data-x="pdf" ${pdfOk ? '' : 'disabled title="PDF is available for up to 2,000 rows. Use CSV for larger exports."'}>
+             <div><div class="t">Export as PDF</div><div class="d">${pdfOk ? 'Formatted table' : 'Up to 2,000 rows — use CSV'}</div></div>
+           </button>`;
+
+        $('exportPop').querySelectorAll('[data-x]').forEach((b) =>
+          b.addEventListener('click', () => {
+            P.closeAllPops();
+            const scope = b.dataset.x;
+            const n = scope === 'sel' ? sel : scope === 'all' ? ALL.length : filtered;
+            const slug = activePresetId() && activePresetId() !== 'all' ? '-' + activePresetId() : '';
+            P.toast(`Downloading <b>acme-audience${slug}-2026-09-06.${scope === 'pdf' ? 'pdf' : 'csv'}</b> · ${P.num(n)} rows`);
+          })
+        );
+      }
+
+      /* ---------------- render ---------------- */
+      function render({ keepRows } = {}) {
+        if (!keepRows) rows = compute();
+
+        const pr = pageRows(rows);
+        const sel = selectableOf(pr);
+        const selCount = effectiveCount();
+
+        // Seat count excludes ARCHIVED — this is the payoff of Finding 1 in the plan.
+        // Archive a batch and watch this number fall; deactivate and it does not.
+        const seatsUsed = ALL.filter((r) => r.status !== 'ARCHIVED').length;
+        $('totalBadge').textContent = `· ${P.num(seatsUsed)} of 2,500 seats`;
+        $('navCount').textContent = P.num(seatsUsed);
+
+        /* summary */
+        const sortLabel = (SORTS.find((s) => s[0] === sortBy) || [])[1] || 'Name';
+        const orderLabel = sortOrder === 'asc' ? 'oldest first' : 'newest first';
+        $('summary').innerHTML = busy
+          ? '<span class="sk" style="width:220px"></span>'
+          : `<b>${P.num(rows.length)}</b> learner${rows.length === 1 ? '' : 's'} · sorted by ${sortLabel.toLowerCase()}, ${orderLabel}`;
+
+        /* chips */
+        const clauses = P.describe(filter);
+        $('chips').hidden = clauses.length === 0;
+        if (clauses.length) {
+          $('chips').innerHTML =
+            clauses.map((c) => `<span class="chip">${c.text}<button data-chip="${c.key}" aria-label="Remove ${c.text}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M18 6 6 18M6 6l12 12"/></svg></button></span>`).join('') +
+            '<button class="link-btn" id="chipClear">Clear all</button>';
+
+          $('chips').querySelectorAll('[data-chip]').forEach((b) =>
+            b.addEventListener('click', () => {
+              // single removal is one intent — applies immediately, no Apply step
+              filter[b.dataset.chip] = b.dataset.chip === 'status' ? 'ACTIVE' : 'any';
+              draft = { ...filter };
+              page = 1;
+              clearSelection();
+              reload();
+            })
+          );
+          document.getElementById('chipClear').addEventListener('click', () => {
+            filter = { ...P.EMPTY_FILTER, search: filter.search };
+            draft = { ...filter };
+            page = 1;
+            clearSelection();
+            reload();
+          });
+        }
+
+        /* filter trigger indicators */
+        $('filterDot').hidden = clauses.length === 0;
+        $('filterCount').hidden = clauses.length < 2;
+        $('filterCount').textContent = clauses.length;
+
+        /* bulk bar swaps in for the control row */
+        const hasSel = selCount > 0;
+        $('bulkbar').classList.toggle('on', hasSel);
+        $('controls').style.display = hasSel ? 'none' : '';
+        $('bulkCount').textContent = `${P.num(selCount)} selected`;
+
+        const allPageSelected = sel.length > 0 && sel.every((r) => selected.has(r.id));
+        const showAllMatching = allPageSelected && !allMatchingMode && rows.length > sel.length;
+        $('selectAllMatching').hidden = !showAllMatching;
+        $('selectAllMatching').textContent = `Select all ${P.num(rows.filter((r) => !r.pending).length)} matching`;
+
+        $('allmatch').classList.toggle('on', allMatchingMode);
+        $('allmatchText').innerHTML = `All <b>${P.num(rows.filter((r) => !r.pending).length)}</b> learners matching these filters are selected.`;
+
+        if (hasSel) renderActionsPop();
+
+        /* header checkbox tri-state */
+        $('headCb').checked = allMatchingMode || allPageSelected;
+        $('headCb').indeterminate = !allMatchingMode && !allPageSelected && sel.some((r) => selected.has(r.id));
+
+        /* sort arrows */
+        document.querySelectorAll('th.sortable').forEach((th) => {
+          th.classList.toggle('on', th.dataset.sort === sortBy);
+          th.querySelector('.arrow').textContent = sortOrder === 'asc' ? '▲' : '▼';
+        });
+
+        /* rows */
+        if (!keepRows) {
+          $('tbody').innerHTML = pr.map((r) => {
+            const isSel = allMatchingMode ? !r.pending : selected.has(r.id);
+            const badge = r.status === 'ACTIVE'
+              ? ''
+              : `<span class="badge ${r.status === 'ARCHIVED' ? 'badge-muted' : 'badge-warning'}">${r.status === 'ARCHIVED' ? 'Archived' : 'Deactivated'}</span>`;
+            const inviteBadge = r.pending ? '<span class="badge badge-outline">Invited</span>' : '';
+
+            return `<tr class="${isSel ? 'sel' : ''} ${r.status !== 'ACTIVE' ? 'inactive' : ''}">
+              <td class="c-check sticky-l">
+                <input type="checkbox" class="cb" data-row="${r.id}" ${isSel ? 'checked' : ''} ${r.pending ? 'disabled title="Invited learners who have not signed up yet cannot be selected."' : ''} aria-label="Select ${r.name}" />
+              </td>
+              <td class="sticky-l" style="left:38px">
+                <div class="person"><span class="avatar" style="width:26px;height:26px;font-size:10px">${r.initials}</span><span class="nm"><a href="#">${r.name}</a></span></div>
+              </td>
+              <td class="em">${r.email}</td>
+              <td>${badge || inviteBadge || '<span class="badge badge-success-soft">Active</span>'}</td>
+              <td class="em tnum">${P.absTime(r.joinedAt)}</td>
+              <td class="${r.lastLoginAt === null ? 'never' : ''}" title="${P.absTime(r.lastLoginAt)}">${r.lastLoginAt === null ? 'Never' : P.relTime(r.lastLoginAt)}</td>
+              <td class="${r.lastActiveAt === null ? 'never' : ''}" title="${P.absTime(r.lastActiveAt)}">${r.lastActiveAt === null ? 'Never' : P.relTime(r.lastActiveAt)}</td>
+              <td class="tnum">${r.enrolled === 0 ? '<span class="never">—</span>' : `${r.completed} / ${r.enrolled}`}</td>
+              <td>
+                <div class="prog">
+                  <div class="progress progress-thin" style="width:56px"><span style="width:${r.progress}%"></span></div>
+                  <span class="p">${r.progress}%</span>
+                </div>
+              </td>
+              <td><button class="icon-btn" style="border:none;background:transparent;box-shadow:none" aria-label="Actions for ${r.name}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg></button></td>
+            </tr>`;
+          }).join('');
+
+          $('tbody').querySelectorAll('[data-row]').forEach((cb) =>
+            cb.addEventListener('change', () => {
+              const id = +cb.dataset.row;
+              if (allMatchingMode) {
+                // downgrade from "all matching" to explicit ids
+                allMatchingMode = false;
+                selected = new Set(rows.filter((r) => !r.pending).map((r) => r.id));
+              }
+              selected.has(id) ? selected.delete(id) : selected.add(id);
+              render();
+            })
+          );
+        }
+
+        /* empty states — two distinct ones */
+        const filtering = clauses.length > 0 || filter.search;
+        $('emptyState').innerHTML = rows.length > 0 || busy ? '' : filtering
+          ? `<div class="empty">
+              <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z"/></svg></div>
+              <h3>No learners match these filters</h3>
+              <p>Try widening the date range, or clear the filters to see your whole audience.</p>
+              <button class="btn btn-primary btn-sm" id="emptyClear">Clear filters</button>
+            </div>`
+          : `<div class="empty">
+              <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg></div>
+              <h3>No learners yet</h3>
+              <p>Import a list or share an invite link to bring your first learners into Acme Academy.</p>
+              <a class="btn btn-primary btn-sm" href="import.html">Import learners</a>
+            </div>`;
+
+        const ec = document.getElementById('emptyClear');
+        if (ec) ec.addEventListener('click', () => {
+          filter = { ...P.EMPTY_FILTER };
+          draft = { ...filter };
+          $('search').value = '';
+          page = 1;
+          reload();
+        });
+
+        document.querySelector('.dt').style.display = rows.length === 0 && !busy ? 'none' : '';
+
+        /* pagination */
+        const totalPages = Math.max(1, Math.ceil(rows.length / PAGE_SIZE));
+        if (page > totalPages) page = totalPages;
+        const win = [];
+        for (let i = Math.max(1, page - 2); i <= Math.min(totalPages, page + 2); i++) win.push(i);
+
+        $('pager').innerHTML = rows.length === 0 ? '' : `
+          <span class="text-muted" style="font-size:13px">Showing ${P.num((page - 1) * PAGE_SIZE + 1)}–${P.num(Math.min(page * PAGE_SIZE, rows.length))} of ${P.num(rows.length)}</span>
+          <div class="pages">
+            <button class="pgb" data-pg="${page - 1}" ${page === 1 ? 'disabled' : ''}>Prev</button>
+            ${win.map((i) => `<button class="pgb ${i === page ? 'on' : ''}" data-pg="${i}">${i}</button>`).join('')}
+            <button class="pgb" data-pg="${page + 1}" ${page === totalPages ? 'disabled' : ''}>Next</button>
+          </div>`;
+
+        $('pager').querySelectorAll('[data-pg]').forEach((b) =>
+          b.addEventListener('click', () => { page = +b.dataset.pg; reload(); }) // selection deliberately survives paging
+        );
+
+        renderViews(true);
+        renderSortPop();
+        renderExportPop();
+      }
+
+      /* ---------------- search (300ms debounce, keeps focus) ---------------- */
+      let searchTimer;
+      $('search').addEventListener('input', (e) => {
+        clearTimeout(searchTimer);
+        searchTimer = setTimeout(() => {
+          filter.search = e.target.value.trim();
+          draft.search = filter.search;
+          page = 1;
+          reload();
+        }, 300);
+      });
+
+      /* ---------------- pop triggers ---------------- */
+      document.querySelectorAll('[data-pop]').forEach((btn) => {
+        if (btn.id === 'filterBtn') return; // handled above
+
+        btn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          const pop = document.getElementById(btn.dataset.pop);
+          const opening = !pop.classList.contains('on');
+          P.closeAllPops(pop);
+          pop.classList.toggle('on', opening);
+        });
+      });
+
+      document.querySelector('.sheet-scrim').addEventListener('click', () => {
+        P.closeAllPops();
+        document.querySelector('.sheet-scrim').classList.remove('on');
+      });
+
+      /* ---------------- boot: presets load their counts async ---------------- */
+      renderViews(false);
+      rows = compute();
+      render();
+      setTimeout(() => renderViews(true), 600);
+    </script>
+  </body>
+</html>

--- a/prototypes/learner-lifecycle/import.html
+++ b/prototypes/learner-lifecycle/import.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Import learners · Learner Lifecycle Prototype</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="lifecycle.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <a class="brand" href="index.html"><span class="brand-mark">C</span><span class="brand-name">Acme Academy</span></a>
+        <div class="nav-label">Organization</div>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>Dashboard</a>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Courses<span class="nav-tail tnum">28</span></a>
+        <a class="nav-item active" href="audience.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>Audience</a>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>Analytics</a>
+        <div class="sidebar-foot"><div class="avatar">JD</div><div class="who"><div class="nm">Jordan Diallo</div><div class="rl">Admin</div></div></div>
+      </aside>
+
+      <div class="main">
+        <header class="topbar">
+          <nav class="crumbs"><a href="index.html">Prototype</a><span class="sep">/</span><a href="audience.html">Audience</a><span class="sep">/</span><span class="here">Import</span></nav>
+          <div class="top-actions">
+            <button class="icon-btn" id="theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+          </div>
+        </header>
+
+        <main class="content">
+          <div class="wrap" style="max-width: 760px">
+            <div class="note">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" style="width:14px;height:14px;flex-shrink:0;margin-top:2px"><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/></svg>
+              <span><b>Three steps, not one form.</b> Nothing is sent until the admin has seen the preview. Click through — the file picker is simulated.</span>
+            </div>
+
+            <div class="steps" id="steps"></div>
+
+            <div class="page-head" style="margin-bottom:18px">
+              <div>
+                <h1 class="page-title" id="stepTitle">Import learners</h1>
+                <p class="page-sub" id="stepSub">Upload a CSV, or paste a list of email addresses.</p>
+              </div>
+            </div>
+
+            <!-- STEP 1 -->
+            <section id="s1">
+              <div class="drop" id="drop">
+                <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M17 8l-5-5-5 5M12 3v12"/></svg></div>
+                <div style="font-size:14.5px;font-weight:500;margin-bottom:4px">Drop a CSV here, or click to choose a file</div>
+                <div class="text-muted" style="font-size:12.5px">UTF-8 .csv · up to 1,000 rows · max 5 MB</div>
+                <div style="margin-top:14px;display:flex;gap:8px;justify-content:center;flex-wrap:wrap">
+                  <button class="btn btn-secondary btn-sm" id="choose">Choose file</button>
+                  <button class="btn btn-ghost btn-sm" id="template">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5M12 15V3"/></svg>
+                    Download template
+                  </button>
+                </div>
+              </div>
+
+              <div style="margin-top:16px">
+                <div class="banner info">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/></svg>
+                  <div>
+                    <b>Required column:</b> <code style="background:var(--muted);padding:0 4px;border-radius:3px">email</code>.
+                    <b>Optional:</b> <code style="background:var(--muted);padding:0 4px;border-radius:3px">name</code>,
+                    <code style="background:var(--muted);padding:0 4px;border-radius:3px">courses</code> (comma-separated).
+                    Extra columns are ignored.<br />
+                    Using Excel? <b>File → Save As → CSV UTF-8</b>. We don't read .xlsx directly.
+                  </div>
+                </div>
+              </div>
+
+              <div class="divider">or paste emails</div>
+              <textarea class="textarea" rows="4" placeholder="ada@example.com, tunde@example.com…"></textarea>
+
+              <div style="display:flex;justify-content:flex-end;margin-top:18px">
+                <button class="btn btn-primary" id="toStep2" disabled>Continue</button>
+              </div>
+            </section>
+
+            <!-- STEP 2 -->
+            <section id="s2" hidden>
+              <div class="tiles" style="margin-bottom:16px">
+                <div class="tile ok"><div class="v tnum">841</div><div class="k">Ready to import</div></div>
+                <div class="tile warn"><div class="v tnum">126</div><div class="k">Already in audience</div></div>
+                <div class="tile bad"><div class="v tnum">33</div><div class="k">Invalid</div></div>
+              </div>
+
+              <div class="banner warn" style="margin-bottom:16px">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/><path d="M12 9v4M12 17h.01"/></svg>
+                <div>
+                  <b>678 of 841 will be imported.</b> Your plan allows 2,500 learners and 2,337 seats are in use.
+                  The remaining 163 will be skipped. Archive dormant learners to free seats, or upgrade your plan.
+                </div>
+              </div>
+
+              <div class="dt-wrap" style="margin-bottom:16px">
+                <div class="dt-scroll">
+                  <table class="dt" style="min-width:600px">
+                    <thead><tr><th>Email</th><th>Name</th><th>Status</th></tr></thead>
+                    <tbody>
+                      <tr><td>ada.okafor@example.com</td><td>Ada Okafor</td><td><span class="badge badge-success-soft">Ready</span></td></tr>
+                      <tr><td>tunde.mensah@example.com</td><td>Tunde Mensah</td><td><span class="badge badge-success-soft">Ready</span></td></tr>
+                      <tr><td>liam.diallo@example.com</td><td>Liam Diallo</td><td><span class="badge badge-warning">Already in audience</span></td></tr>
+                      <tr><td>sofia.rossi<span class="text-muted">(missing @)</span></td><td>Sofia Rossi</td><td><span class="badge badge-outline" style="color:var(--destructive);border-color:var(--destructive)">Not a valid email address</span></td></tr>
+                      <tr><td>ada.okafor@example.com</td><td>Ada O.</td><td><span class="badge badge-outline" style="color:var(--destructive);border-color:var(--destructive)">Duplicate in file (row 2)</span></td></tr>
+                      <tr><td>noor.haddad@example.com</td><td class="text-muted">— from email</td><td><span class="badge badge-success-soft">Ready</span></td></tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div class="note">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" style="width:14px;height:14px;flex-shrink:0;margin-top:2px"><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/></svg>
+                <span>Course and cohort assignment lives <b>here</b>, not on step 1 — no point asking before the file is known to be valid.</span>
+              </div>
+
+              <fieldset class="fset" style="border:1px solid var(--border);border-radius:var(--radius-lg);padding:16px;margin:0 0 18px">
+                <legend class="legend" style="padding:0 6px">Give them access to</legend>
+                <label class="fopt"><input type="radio" class="radio" name="acc" checked /> No courses yet</label>
+                <label class="fopt"><input type="radio" class="radio" name="acc" /> All published courses</label>
+                <label class="fopt"><input type="radio" class="radio" name="acc" /> Select courses…</label>
+                <div style="height:1px;background:var(--border);margin:12px 0"></div>
+                <label class="fopt"><input type="checkbox" class="cb" checked /> Send them an invitation email</label>
+              </fieldset>
+
+              <div style="display:flex;justify-content:space-between;gap:8px">
+                <button class="btn btn-ghost" id="backTo1">Back</button>
+                <button class="btn btn-primary" id="toStep3">Import 678 learners</button>
+              </div>
+            </section>
+
+            <!-- STEP 3 -->
+            <section id="s3" hidden>
+              <div class="tiles" style="margin-bottom:18px">
+                <div class="tile ok"><div class="v tnum">678</div><div class="k">Imported</div></div>
+                <div class="tile warn"><div class="v tnum">289</div><div class="k">Skipped</div></div>
+                <div class="tile bad"><div class="v tnum">33</div><div class="k">Failed</div></div>
+              </div>
+
+              <div class="banner info" style="margin-bottom:18px">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m9 11 3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+                <div>Invitation emails are being sent in the background. Learners appear in your audience as <b>Invited</b> until they sign up.</div>
+              </div>
+
+              <div style="display:flex;gap:8px;justify-content:flex-end">
+                <button class="btn btn-outline" id="dlErrors">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5M12 15V3"/></svg>
+                  Download 33 error rows
+                </button>
+                <a class="btn btn-primary" href="audience.html">Back to audience</a>
+              </div>
+            </section>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <div class="toasts"></div>
+    <script src="proto.js"></script>
+    <script>
+      const P = window.proto;
+      P.initTheme();
+      const $ = (id) => document.getElementById(id);
+
+      let step = 1;
+      const TITLES = [
+        ['Import learners', 'Upload a CSV, or paste a list of email addresses.'],
+        ['Review before importing', 'Nothing has been sent yet. Check what will happen, then confirm.'],
+        ['Import finished', '678 learners were added to your audience.']
+      ];
+
+      function render() {
+        $('steps').innerHTML = ['Upload', 'Preview', 'Result']
+          .map((label, i) => {
+            const n = i + 1;
+            const cls = step === n ? 'on' : step > n ? 'done' : '';
+            const mark = step > n ? '✓' : n;
+            return `<div class="s ${cls}"><span class="n">${mark}</span>${label}</div>${n < 3 ? '<span class="bar"></span>' : ''}`;
+          })
+          .join('');
+
+        $('stepTitle').textContent = TITLES[step - 1][0];
+        $('stepSub').textContent = TITLES[step - 1][1];
+        $('s1').hidden = step !== 1;
+        $('s2').hidden = step !== 2;
+        $('s3').hidden = step !== 3;
+      }
+
+      $('choose').addEventListener('click', () => {
+        $('drop').classList.add('hot');
+        $('drop').querySelector('div:nth-child(2)').textContent = 'acme-learners-q3.csv · 1,000 rows · 84 KB';
+        $('toStep2').disabled = false;
+        P.toast('Parsed <b>acme-learners-q3.csv</b> — 1,000 rows read.');
+      });
+
+      $('template').addEventListener('click', () => P.toast('Downloaded <b>audience-template.csv</b>'));
+      $('toStep2').addEventListener('click', () => { step = 2; render(); });
+      $('backTo1').addEventListener('click', () => { step = 1; render(); });
+      $('toStep3').addEventListener('click', () => { step = 3; render(); P.toast('678 learners imported.'); });
+      $('dlErrors').addEventListener('click', () => P.toast('Downloaded <b>import-errors.csv</b> — 33 rows'));
+
+      render();
+    </script>
+  </body>
+</html>

--- a/prototypes/learner-lifecycle/index.html
+++ b/prototypes/learner-lifecycle/index.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Learner Lifecycle — Prototype Map</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="lifecycle.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .page { max-width: 880px; margin: 0 auto; padding: 56px 24px 90px; }
+      h1 { font-size: 32px; font-weight: 600; letter-spacing: -0.03em; margin: 8px 0 10px; }
+      .lead { color: var(--muted-foreground); font-size: 15px; max-width: 68ch; margin: 0 0 14px; line-height: 1.65; }
+      .lead b { color: var(--foreground); font-weight: 500; }
+      .eyebrow { font-size: 11.5px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: var(--primary); }
+      .sec { font-size: 12.5px; font-weight: 600; letter-spacing: 0.07em; text-transform: uppercase; color: var(--muted-foreground); margin: 40px 0 14px; display: flex; align-items: center; gap: 10px; }
+      .sec::after { content: ''; flex: 1; height: 1px; background: var(--border); }
+      .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+      .shot { padding: 16px 17px 17px; transition: border-color 0.15s, box-shadow 0.15s; display: block; }
+      .shot:hover { border-color: var(--ring); box-shadow: var(--shadow-md); }
+      .shot .n { font-size: 11px; font-weight: 600; color: var(--muted-foreground); letter-spacing: 0.05em; text-transform: uppercase; }
+      .shot .t { font-size: 14.5px; font-weight: 600; letter-spacing: -0.01em; margin: 4px 0 5px; }
+      .shot .d { font-size: 12.5px; color: var(--muted-foreground); margin: 0; line-height: 1.55; }
+      .loop { display: grid; gap: 2px; margin: 0 0 8px; }
+      .loop .row { display: flex; gap: 12px; align-items: baseline; padding: 9px 0; border-bottom: 1px solid var(--border); font-size: 13.5px; }
+      .loop .row:last-child { border-bottom: none; }
+      .loop .k { font-size: 11px; font-weight: 600; color: var(--muted-foreground); width: 74px; flex-shrink: 0; letter-spacing: 0.05em; text-transform: uppercase; }
+      .loop .v { color: var(--foreground); }
+      .loop .v span { color: var(--muted-foreground); }
+      .foot { margin-top: 44px; padding-top: 20px; border-top: 1px solid var(--border); color: var(--muted-foreground); font-size: 13.5px; line-height: 1.75; }
+      .foot b { color: var(--foreground); font-weight: 500; }
+      .foot code { background: var(--muted); padding: 1px 6px; border-radius: 4px; font-size: 12.5px; }
+      @media (max-width: 820px) { .grid { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:16px">
+        <div>
+          <span class="eyebrow">ClassroomIO · Prototype + plan handoff</span>
+          <h1>Learner Usage &amp; Lifecycle</h1>
+        </div>
+        <button class="icon-btn" id="theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+      </div>
+
+      <p class="lead">
+        An admin with tens of thousands of learners needs to answer one recurring question:
+        <b>who isn't using the platform, and who should we remove?</b>
+        That's a loop, not four features — and this prototype is the loop, running over 2,400 synthetic learners
+        so counts, paging and select-all-matching behave at real scale.
+      </p>
+
+      <div class="loop">
+        <div class="row"><span class="k">See</span><span class="v">Last login and last activity as first-class columns, sortable oldest-first <span>— because "who is most dormant" is the question</span></span></div>
+        <div class="row"><span class="k">Filter</span><span class="v">A quiet view switcher for the four questions asked daily, and a full filter popover behind it</span></div>
+        <div class="row"><span class="k">Review</span><span class="v">Confirmation shows a real sample and offers "export this list first" <span>— the sign-off step</span></span></div>
+        <div class="row"><span class="k">Act</span><span class="v">Archive, deactivate or delete in bulk — by ticked rows, or by <b>all N matching the filter</b></span></div>
+        <div class="row"><span class="k">Prove</span><span class="v">Seat count falls on archive, undo for reversible actions, audit reason on every batch</span></div>
+      </div>
+
+      <div class="sec">Screens</div>
+      <div class="grid">
+        <a class="card shot" href="audience.html">
+          <div class="n">Interactive · start here</div>
+          <div class="t">Audience</div>
+          <p class="d">The whole loop, live. View switcher, filters, stale-while-loading, selection, select-all-matching, confirmation, queued progress, undo, export menu.</p>
+        </a>
+        <a class="card shot" href="states.html">
+          <div class="n">Gallery</div>
+          <div class="t">Edge states</div>
+          <p class="d">The twelve states that are hard to reach by clicking — loading, both empty states, count drift, partial failure, gated delete, mobile sheet.</p>
+        </a>
+        <a class="card shot" href="import.html">
+          <div class="n">Three steps</div>
+          <div class="t">CSV import</div>
+          <p class="d">Upload → preview → result. Nothing is sent until the admin has seen what will happen, including which rows the plan limit will skip.</p>
+        </a>
+      </div>
+
+      <div class="sec">Design notes</div>
+      <p class="lead" style="font-size:14px">
+        Built on <code style="background:var(--muted);padding:1px 5px;border-radius:4px">app-theme.css</code>,
+        which mirrors the real <code style="background:var(--muted);padding:1px 5px;border-radius:4px">packages/ui/src/index.css</code>
+        tokens — OKLCH palette, Geist, the same radius and shadow scale. Every element maps to an existing
+        <code style="background:var(--muted);padding:1px 5px;border-radius:4px">@cio/ui</code> primitive
+        (Table, Popover, DropdownMenu, Dialog, Sheet, Checkbox, Badge, Progress, Empty, Pagination, Sonner).
+        No new visual language, nothing shouting: counts sit muted inside menus rather than as coloured chips on the page,
+        and status is carried by quiet badges, not colour blocks.
+      </p>
+
+      <div class="foot">
+        <b>Where the thinking lives</b><br />
+        Interaction spec — <code>prd/admin-controls-and-reporting/UX.md</code><br />
+        Engineering plan (schema, API, sequencing) — <code>prd/admin-controls-and-reporting/README.md</code><br />
+        <br />
+        <b>Two findings that shaped it:</b> <code>countActiveStudents</code> counts every student row regardless of status,
+        so archiving frees no seats until it learns about <code>status</code>.
+        And <code>isUserCourseMemberOrOrgAdmin</code> already requires live org membership, so the access gate is one join,
+        not a scatter of new guards.
+      </div>
+    </div>
+    <script src="proto.js"></script>
+    <script>window.proto.initTheme();</script>
+  </body>
+</html>

--- a/prototypes/learner-lifecycle/lifecycle.css
+++ b/prototypes/learner-lifecycle/lifecycle.css
@@ -1,0 +1,975 @@
+/*
+ * lifecycle.css — components specific to the learner lifecycle prototype.
+ * Layers on app-theme.css (which mirrors packages/ui/src/index.css tokens).
+ * Everything here maps to a real @cio/ui primitive; the comment says which.
+ */
+
+[hidden] {
+  display: none !important;
+}
+
+/* ============ view switcher menu rows ============ */
+.menu .cnt {
+  margin-left: auto;
+  color: var(--muted-foreground);
+  font-size: 12.5px;
+  font-variant-numeric: tabular-nums;
+}
+.menu .tick {
+  width: 14px;
+  text-align: right;
+  color: var(--primary);
+  font-size: 12px;
+}
+.menu button {
+  align-items: center;
+}
+
+/* ============ control row ============ */
+/* Mirrors Page.BodyHeader: ui:flex ui:items-center ui:gap-2 ui:justify-end.
+   align="right" is the component default and what courses/cohorts use. */
+.controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.controls .search-input {
+  /* @cio/ui Search is ui:w-fit ui:max-w-[200px] — it does not grow */
+  width: 200px;
+}
+@media (max-width: 640px) {
+  .controls {
+    justify-content: stretch;
+  }
+  .controls .search-input {
+    width: 100%;
+  }
+}
+.dot-flag {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--primary);
+  border: 2px solid var(--background);
+}
+.rel {
+  position: relative;
+  display: inline-flex;
+}
+
+/* ============ active filter chips (custom/chip) ============ */
+.chips {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  /* sits under the Filter trigger it came from, so it reads as one cluster */
+  justify-content: flex-end;
+  margin-bottom: 14px;
+}
+@media (max-width: 640px) {
+  .chips {
+    justify-content: flex-start;
+  }
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 4px 3px 10px;
+  border-radius: 999px;
+  background: var(--muted);
+  font-size: 12.5px;
+  color: var(--foreground);
+}
+.chip button {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  color: var(--muted-foreground);
+  padding: 0;
+}
+.chip button:hover {
+  background: color-mix(in oklab, var(--foreground) 10%, transparent);
+  color: var(--foreground);
+}
+.chip button svg {
+  width: 12px;
+  height: 12px;
+  stroke-width: 2.5;
+}
+.link-btn {
+  border: none;
+  background: transparent;
+  color: var(--primary);
+  font-size: 12.5px;
+  cursor: pointer;
+  padding: 0 4px;
+  font-weight: 500;
+}
+.link-btn:disabled {
+  color: var(--muted-foreground);
+  cursor: not-allowed;
+}
+
+/* ============ result summary ============ */
+.summary {
+  font-size: 13px;
+  color: var(--muted-foreground);
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 20px;
+}
+.summary b {
+  color: var(--foreground);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ============ data table (base/table) ============ */
+.dt-wrap {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--card);
+  position: relative;
+}
+.dt-scroll {
+  overflow-x: auto;
+}
+.dt {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13.5px;
+  min-width: 940px;
+}
+.dt th {
+  text-align: left;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+  white-space: nowrap;
+}
+.dt td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+.dt tbody tr:last-child td {
+  border-bottom: none;
+}
+.dt tbody tr:hover td {
+  background: color-mix(in oklab, var(--accent) 45%, transparent);
+}
+.dt tbody tr.sel td {
+  background: color-mix(in oklab, var(--primary) 6%, transparent);
+}
+.dt .sticky-l {
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background: var(--card);
+  box-shadow: 1px 0 0 var(--border);
+}
+.dt tbody tr:hover .sticky-l {
+  background: color-mix(in oklab, var(--accent) 45%, var(--card));
+}
+.dt tbody tr.sel .sticky-l {
+  background: color-mix(in oklab, var(--primary) 6%, var(--card));
+}
+.dt .c-check {
+  width: 38px;
+  padding-right: 0;
+}
+.dt th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+.dt th.sortable:hover {
+  color: var(--foreground);
+}
+.dt th .arrow {
+  display: inline-block;
+  margin-left: 4px;
+  opacity: 0;
+  font-size: 10px;
+}
+.dt th.on {
+  color: var(--foreground);
+  font-weight: 600;
+}
+.dt th.on .arrow {
+  opacity: 1;
+}
+.person {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+.person .nm {
+  font-weight: 500;
+  white-space: nowrap;
+}
+.person .nm a:hover {
+  color: var(--primary);
+  text-decoration: underline;
+}
+.em {
+  color: var(--muted-foreground);
+  font-size: 12.5px;
+  white-space: nowrap;
+}
+.never {
+  color: var(--muted-foreground);
+}
+.dt tr.inactive td:not(.c-check) {
+  opacity: 0.55;
+}
+.prog {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.prog .p {
+  font-size: 12.5px;
+  font-variant-numeric: tabular-nums;
+  min-width: 32px;
+}
+
+/* checkbox (base/checkbox) */
+.cb {
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--input);
+  border-radius: 4px;
+  background: var(--background);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  margin: 0;
+  flex-shrink: 0;
+}
+.cb:checked,
+.cb:indeterminate {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+.cb:checked::after {
+  content: '';
+  width: 4px;
+  height: 8px;
+  border: solid var(--primary-foreground);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg) translateY(-1px);
+}
+.cb:indeterminate::after {
+  content: '';
+  width: 8px;
+  height: 2px;
+  background: var(--primary-foreground);
+  border-radius: 1px;
+}
+.cb:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.cb:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+/* ============ stale-while-loading ============ */
+.dt-wrap.busy .dt-scroll {
+  opacity: 0.55;
+  pointer-events: none;
+  transition: opacity 0.12s;
+}
+.loadbar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  overflow: hidden;
+  display: none;
+  z-index: 5;
+}
+.dt-wrap.busy .loadbar {
+  display: block;
+}
+.loadbar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: 35%;
+  background: var(--primary);
+  animation: slide 1s ease-in-out infinite;
+}
+@keyframes slide {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(320%);
+  }
+}
+.sk {
+  height: 13px;
+  border-radius: 5px;
+  background: var(--muted);
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+/* ============ bulk bar ============ */
+.bulkbar {
+  display: none;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 9px 10px 9px 14px;
+  border: 1px solid color-mix(in oklab, var(--primary) 28%, var(--border));
+  background: color-mix(in oklab, var(--primary) 5%, transparent);
+  border-radius: var(--radius-md);
+  margin-bottom: 14px;
+}
+.bulkbar.on {
+  display: flex;
+}
+.bulkbar .count {
+  font-size: 13px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.bulkbar .spacer {
+  flex: 1;
+}
+.allmatch {
+  display: none;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border: 1px solid color-mix(in oklab, var(--primary) 22%, var(--border));
+  background: color-mix(in oklab, var(--primary) 8%, transparent);
+  border-radius: var(--radius-md);
+  margin-bottom: 14px;
+  font-size: 13px;
+}
+.allmatch.on {
+  display: flex;
+}
+
+/* ============ popover / dropdown (base/popover, base/dropdown-menu) ============ */
+.pop {
+  position: absolute;
+  z-index: 60;
+  background: var(--popover);
+  color: var(--popover-foreground);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  display: none;
+}
+.pop.on {
+  display: block;
+}
+.menu {
+  min-width: 240px;
+  padding: 5px;
+}
+.menu button,
+.menu a {
+  display: flex;
+  width: 100%;
+  gap: 10px;
+  align-items: flex-start;
+  text-align: left;
+  padding: 7px 9px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 13.5px;
+  color: var(--foreground);
+}
+.menu button:hover:not(:disabled),
+.menu a:hover {
+  background: var(--accent);
+}
+.menu button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.menu .t {
+  font-weight: 500;
+}
+.menu .d {
+  font-size: 11.5px;
+  color: var(--muted-foreground);
+  margin-top: 1px;
+}
+.menu .danger {
+  color: var(--destructive);
+}
+.menu .danger:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--destructive) 10%, transparent);
+}
+.menu-sep {
+  height: 1px;
+  background: var(--border);
+  margin: 5px 4px;
+}
+.menu-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted-foreground);
+  padding: 6px 9px 3px;
+  font-weight: 600;
+}
+
+/* filter popover body */
+.filter-pop {
+  width: 340px;
+  padding: 0;
+  /* must fit under the trigger without pushing the Apply footer off-screen.
+     The trigger sits ~300px down the page, so cap against that, not 100vh. */
+  max-height: min(560px, calc(100vh - 300px));
+}
+.filter-pop.on {
+  display: flex;
+  flex-direction: column;
+}
+.filter-body {
+  padding: 14px;
+  overflow-y: auto;
+  min-height: 0; /* flex child must be shrinkable for overflow to engage */
+  display: grid;
+  gap: 16px;
+}
+.fset {
+  display: grid;
+  gap: 7px;
+}
+.fset > legend,
+.fset > .legend {
+  font-size: 11.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-foreground);
+  padding: 0;
+}
+.fopt {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 13.5px;
+  cursor: pointer;
+}
+.radio {
+  appearance: none;
+  width: 15px;
+  height: 15px;
+  border: 1px solid var(--input);
+  border-radius: 999px;
+  background: var(--background);
+  display: grid;
+  place-items: center;
+  margin: 0;
+  cursor: pointer;
+}
+.radio:checked {
+  border-color: var(--primary);
+  border-width: 4px;
+}
+.filter-foot {
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border-top: 1px solid var(--border);
+}
+
+/* ============ dialog (base/dialog) ============ */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgb(0 0 0 / 0.5);
+  z-index: 90;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+.backdrop.on {
+  display: flex;
+}
+.dialog {
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
+  width: 100%;
+  max-width: 520px;
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+}
+.dialog-head {
+  padding: 20px 22px 0;
+}
+.dialog h2 {
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0 0 6px;
+}
+.dialog .lede {
+  font-size: 13.5px;
+  color: var(--muted-foreground);
+  margin: 0;
+  line-height: 1.55;
+}
+.dialog-body {
+  padding: 16px 22px;
+  overflow-y: auto;
+  display: grid;
+  gap: 14px;
+}
+.dialog-foot {
+  padding: 14px 22px 20px;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  border-top: 1px solid var(--border);
+}
+.sample {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.sample .r {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  font-size: 13px;
+  border-bottom: 1px solid var(--border);
+}
+.sample .r:last-child {
+  border-bottom: none;
+}
+.sample .more {
+  background: var(--muted);
+  color: var(--muted-foreground);
+  font-size: 12.5px;
+  justify-content: center;
+}
+.recap {
+  background: var(--muted);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  font-size: 12.5px;
+  color: var(--muted-foreground);
+  line-height: 1.7;
+}
+.recap b {
+  color: var(--foreground);
+  font-weight: 500;
+}
+.export-first {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  font-size: 13px;
+}
+.export-first.done {
+  border-style: solid;
+  border-color: color-mix(in oklab, var(--success) 40%, var(--border));
+  background: var(--success-soft);
+}
+.export-first svg {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+}
+.export-first.done svg {
+  color: var(--success);
+}
+
+/* ============ queued progress ============ */
+.jobbar {
+  display: none;
+  align-items: center;
+  gap: 14px;
+  padding: 11px 16px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  border-radius: var(--radius-md);
+  margin-bottom: 14px;
+  box-shadow: var(--shadow-2xs);
+}
+.jobbar.on {
+  display: flex;
+}
+.jobbar .lbl {
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.jobbar .progress {
+  flex: 1;
+  min-width: 120px;
+}
+.jobbar .pct {
+  font-size: 12.5px;
+  color: var(--muted-foreground);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* ============ toast (base/sonner) ============ */
+.toasts {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 120;
+  display: grid;
+  gap: 8px;
+  justify-items: end;
+}
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: var(--popover);
+  color: var(--popover-foreground);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: 11px 12px 11px 15px;
+  font-size: 13.5px;
+  max-width: 400px;
+  animation: rise 0.18s ease-out;
+}
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+.toast.err {
+  border-color: color-mix(in oklab, var(--destructive) 40%, var(--border));
+}
+
+/* ============ empty (custom/empty) ============ */
+.empty {
+  text-align: center;
+  padding: 56px 24px;
+}
+.empty .ic {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-lg);
+  background: var(--muted);
+  display: grid;
+  place-items: center;
+  margin: 0 auto 14px;
+  color: var(--muted-foreground);
+}
+.empty .ic svg {
+  width: 20px;
+  height: 20px;
+  stroke-width: 1.8;
+}
+.empty h3 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0 0 5px;
+}
+.empty p {
+  font-size: 13.5px;
+  color: var(--muted-foreground);
+  margin: 0 0 16px;
+  max-width: 44ch;
+  margin-inline: auto;
+}
+
+/* ============ pagination (base/pagination) ============ */
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 14px;
+  flex-wrap: wrap;
+}
+.pager .pages {
+  display: flex;
+  gap: 4px;
+}
+.pgb {
+  min-width: 32px;
+  height: 32px;
+  padding: 0 8px;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--foreground);
+  font-variant-numeric: tabular-nums;
+}
+.pgb:hover:not(:disabled) {
+  background: var(--accent);
+}
+.pgb.on {
+  border-color: var(--input);
+  background: var(--background);
+  font-weight: 600;
+  box-shadow: var(--shadow-2xs);
+}
+.pgb:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ============ import stepper + tiles ============ */
+.steps {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 22px;
+  font-size: 13px;
+  flex-wrap: wrap;
+}
+.steps .s {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted-foreground);
+}
+.steps .s .n {
+  width: 21px;
+  height: 21px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  font-size: 11.5px;
+  font-weight: 600;
+}
+.steps .s.on {
+  color: var(--foreground);
+  font-weight: 500;
+}
+.steps .s.on .n {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+}
+.steps .s.done .n {
+  background: var(--success);
+  border-color: var(--success);
+  color: #fff;
+}
+.steps .bar {
+  width: 26px;
+  height: 1px;
+  background: var(--border);
+}
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+.tile {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 14px 16px;
+  background: var(--card);
+}
+.tile .v {
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+}
+.tile .k {
+  font-size: 12.5px;
+  color: var(--muted-foreground);
+  margin-top: 2px;
+}
+.tile.ok .v {
+  color: var(--success);
+}
+.tile.warn .v {
+  color: var(--warning);
+}
+.tile.bad .v {
+  color: var(--destructive);
+}
+.drop {
+  border: 1.5px dashed var(--border);
+  border-radius: var(--radius-lg);
+  padding: 34px 20px;
+  text-align: center;
+  background: var(--card);
+}
+.drop.hot {
+  border-color: var(--primary);
+  background: color-mix(in oklab, var(--primary) 5%, transparent);
+}
+.drop .ic {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-lg);
+  background: var(--muted);
+  display: grid;
+  place-items: center;
+  margin: 0 auto 12px;
+  color: var(--muted-foreground);
+}
+.drop .ic svg {
+  width: 19px;
+  height: 19px;
+}
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--muted-foreground);
+  font-size: 12.5px;
+  margin: 18px 0;
+}
+.divider::before,
+.divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+.banner {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 11px 14px;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  line-height: 1.55;
+}
+.banner svg {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+.banner.warn {
+  background: var(--warning-soft);
+  border: 1px solid color-mix(in oklab, var(--warning) 30%, transparent);
+}
+.banner.warn svg {
+  color: var(--warning);
+}
+.banner.info {
+  background: color-mix(in oklab, var(--primary) 7%, transparent);
+  border: 1px solid color-mix(in oklab, var(--primary) 20%, transparent);
+}
+.banner.info svg {
+  color: var(--primary);
+}
+
+/* ============ annotation callouts (prototype only, not app UI) ============ */
+.note {
+  display: flex;
+  gap: 9px;
+  align-items: flex-start;
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--muted-foreground);
+  background: var(--muted);
+  border-left: 2px solid var(--border);
+  padding: 9px 12px;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  margin-bottom: 14px;
+}
+.note b {
+  color: var(--foreground);
+  font-weight: 600;
+}
+.note code {
+  background: var(--muted);
+  padding: 0 4px;
+  border-radius: 3px;
+  font-size: 11.5px;
+}
+
+.sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+/* ============ responsive ============ */
+@media (max-width: 820px) {
+  /* Filter popover becomes a bottom sheet (base/sheet) */
+  .pop.filter-pop.on {
+    position: fixed;
+    inset: auto 0 0 0;
+    width: auto;
+    max-height: 82vh;
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+    z-index: 100;
+  }
+  .sheet-scrim {
+    position: fixed;
+    inset: 0;
+    background: rgb(0 0 0 / 0.4);
+    z-index: 95;
+    display: none;
+  }
+  .sheet-scrim.on {
+    display: block;
+  }
+  .chip {
+    min-height: 44px;
+  }
+  .tiles {
+    grid-template-columns: 1fr;
+  }
+  .dialog {
+    max-width: none;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.001ms !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/prototypes/learner-lifecycle/proto.js
+++ b/prototypes/learner-lifecycle/proto.js
@@ -1,0 +1,322 @@
+/*
+ * proto.js — behavior for the learner lifecycle prototype.
+ *
+ * Generates a synthetic org of 2,400 learners so counts, pagination and
+ * "select all N matching" behave at realistic scale rather than over 12 fake rows.
+ * Every interaction here is the one specified in prd/admin-controls-and-reporting/UX.md.
+ */
+
+/* ---------- theme ---------- */
+function initTheme() {
+  const btn = document.getElementById('theme');
+  if (!btn) return;
+
+  btn.addEventListener('click', () => {
+    const dark = document.documentElement.classList.toggle('dark');
+    localStorage.cioTheme = dark ? 'dark' : 'light';
+  });
+}
+
+/* ---------- synthetic data ---------- */
+const FIRST = [
+  'Ada',
+  'Tunde',
+  'Chiamaka',
+  'Kwame',
+  'Amara',
+  'Sofia',
+  'Liam',
+  'Noor',
+  'Mateo',
+  'Yuki',
+  'Priya',
+  'Omar',
+  'Elena',
+  'Kofi',
+  'Hana',
+  'Diego',
+  'Zara',
+  'Ivan',
+  'Leila',
+  'Sam',
+  'Nia',
+  'Rui',
+  'Anya',
+  'Bo',
+  'Farah',
+  'Jonas',
+  'Mira',
+  'Tobi',
+  'Iris',
+  'Dmitri'
+];
+const LAST = [
+  'Okafor',
+  'Adeyemi',
+  'Nwosu',
+  'Mensah',
+  'Diallo',
+  'Rossi',
+  'Murphy',
+  'Haddad',
+  'Garcia',
+  'Tanaka',
+  'Sharma',
+  'Aziz',
+  'Petrova',
+  'Boateng',
+  'Sato',
+  'Alvarez',
+  'Khan',
+  'Sokolov',
+  'Rahman',
+  'Cole',
+  'Eze',
+  'Silva',
+  'Novak',
+  'Chen',
+  'Nasser',
+  'Weber',
+  'Patel',
+  'Bello',
+  'Lindgren',
+  'Volkov'
+];
+const DAY = 86400000;
+
+function mulberry(seed) {
+  return function () {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function buildLearners(total) {
+  const rand = mulberry(20260906);
+  const now = Date.now();
+  const rows = [];
+
+  for (let i = 0; i < total; i++) {
+    const first = FIRST[Math.floor(rand() * FIRST.length)];
+    const last = LAST[Math.floor(rand() * LAST.length)];
+    const joinedDaysAgo = Math.floor(rand() * 900) + 1;
+    const bucket = rand();
+
+    // 26% never logged in, the rest spread across recency bands
+    let loginDaysAgo = null;
+    if (bucket > 0.26) {
+      const band = rand();
+      if (band < 0.3) loginDaysAgo = Math.floor(rand() * 30);
+      else if (band < 0.55) loginDaysAgo = 30 + Math.floor(rand() * 60);
+      else if (band < 0.8) loginDaysAgo = 90 + Math.floor(rand() * 90);
+      else loginDaysAgo = 180 + Math.floor(rand() * 400);
+      loginDaysAgo = Math.min(loginDaysAgo, joinedDaysAgo);
+    }
+
+    const activeDaysAgo = loginDaysAgo === null ? null : Math.max(0, loginDaysAgo - Math.floor(rand() * 3));
+    const enrolled = rand() < 0.82 ? 1 + Math.floor(rand() * 6) : 0;
+    let completed = 0;
+    let progress = 0;
+
+    if (enrolled > 0 && loginDaysAgo !== null) {
+      completed = Math.floor(rand() * (enrolled + 1));
+      progress = completed === enrolled ? 100 : Math.floor((completed / enrolled) * 100 + rand() * 22);
+      progress = Math.min(progress, 100);
+    }
+
+    const statusRoll = rand();
+    const status = statusRoll > 0.97 ? 'ARCHIVED' : statusRoll > 0.945 ? 'DEACTIVATED' : 'ACTIVE';
+
+    rows.push({
+      id: i + 1,
+      name: `${first} ${last}`,
+      email: `${first.toLowerCase()}.${last.toLowerCase()}${i % 7 === 0 ? i : ''}@example.com`,
+      initials: first[0] + last[0],
+      joinedAt: now - joinedDaysAgo * DAY,
+      lastLoginAt: loginDaysAgo === null ? null : now - loginDaysAgo * DAY,
+      lastActiveAt: activeDaysAgo === null ? null : now - activeDaysAgo * DAY,
+      enrolled,
+      completed,
+      progress,
+      status,
+      // invited but never signed up — checkbox must be disabled for these
+      pending: loginDaysAgo === null && rand() < 0.35
+    });
+  }
+
+  return rows;
+}
+
+/* ---------- formatting ---------- */
+function relTime(ts) {
+  if (ts === null) return null;
+
+  const days = Math.floor((Date.now() - ts) / DAY);
+  if (days <= 0) return 'Today';
+  if (days === 1) return 'Yesterday';
+  if (days < 30) return `${days} days ago`;
+  if (days < 60) return 'Last month';
+  if (days < 365) return `${Math.round(days / 30)} months ago`;
+
+  const years = (days / 365).toFixed(1).replace('.0', '');
+  return `${years} year${years === '1' ? '' : 's'} ago`;
+}
+
+function absTime(ts) {
+  if (ts === null) return 'No login recorded';
+
+  return new Date(ts).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+const nf = new Intl.NumberFormat();
+const num = (n) => nf.format(n);
+
+/* ---------- filter model ---------- */
+const EMPTY_FILTER = {
+  lastLogin: 'any',
+  lastActive: 'any',
+  enrollment: 'any',
+  completion: 'any',
+  status: 'ACTIVE',
+  search: ''
+};
+
+const PRESETS = [
+  { id: 'all', label: 'All learners', filter: { ...EMPTY_FILTER } },
+  { id: 'never', label: 'Never logged in', filter: { ...EMPTY_FILTER, lastLogin: 'never' } },
+  { id: 'i90', label: 'Inactive 90+ days', filter: { ...EMPTY_FILTER, lastActive: '90' } },
+  { id: 'i180', label: 'Inactive 180+ days', filter: { ...EMPTY_FILTER, lastActive: '180' } },
+  {
+    id: 'stalled',
+    label: 'Enrolled, never started',
+    filter: { ...EMPTY_FILTER, enrollment: 'enrolled', completion: 'not_started' }
+  }
+];
+
+const WINDOW_LABEL = { any: 'Any', never: 'Never', 30: 'before 30 days', 90: 'before 90 days', 180: 'before 180 days' };
+
+function staleBy(ts, days) {
+  if (ts === null) return true;
+
+  return Date.now() - ts >= days * DAY;
+}
+
+function matches(row, f) {
+  if (f.status !== 'any' && row.status !== f.status) return false;
+
+  if (f.lastLogin === 'never' && row.lastLoginAt !== null) return false;
+  if (f.lastLogin !== 'any' && f.lastLogin !== 'never' && !staleBy(row.lastLoginAt, +f.lastLogin)) return false;
+
+  if (f.lastActive === 'never' && row.lastActiveAt !== null) return false;
+  if (f.lastActive !== 'any' && f.lastActive !== 'never' && !staleBy(row.lastActiveAt, +f.lastActive)) return false;
+
+  if (f.enrollment === 'enrolled' && row.enrolled === 0) return false;
+  if (f.enrollment === 'not_enrolled' && row.enrolled > 0) return false;
+
+  if (f.completion === 'not_started' && !(row.enrolled > 0 && row.progress === 0)) return false;
+  if (f.completion === 'in_progress' && !(row.progress > 0 && row.progress < 100)) return false;
+  if (f.completion === 'completed' && row.progress !== 100) return false;
+
+  if (f.search) {
+    const q = f.search.toLowerCase();
+    if (!row.name.toLowerCase().includes(q) && !row.email.toLowerCase().includes(q)) return false;
+  }
+
+  return true;
+}
+
+function describe(f) {
+  const out = [];
+  if (f.lastLogin !== 'any') out.push({ key: 'lastLogin', text: `Last login: ${WINDOW_LABEL[f.lastLogin]}` });
+  if (f.lastActive !== 'any') out.push({ key: 'lastActive', text: `Last activity: ${WINDOW_LABEL[f.lastActive]}` });
+  if (f.enrollment !== 'any')
+    out.push({ key: 'enrollment', text: `Enrollment: ${f.enrollment === 'enrolled' ? 'Enrolled' : 'Not enrolled'}` });
+  if (f.completion !== 'any') {
+    const label = { not_started: 'Not started', in_progress: 'In progress', completed: 'Completed' }[f.completion];
+    out.push({ key: 'completion', text: `Completion: ${label}` });
+  }
+  if (f.status !== 'ACTIVE') {
+    const label = { any: 'All statuses', DEACTIVATED: 'Deactivated', ARCHIVED: 'Archived' }[f.status];
+    out.push({ key: 'status', text: `Status: ${label}` });
+  }
+  return out;
+}
+
+/* ---------- popovers ---------- */
+function closeAllPops(except) {
+  document.querySelectorAll('.pop.on').forEach((p) => {
+    if (p !== except) p.classList.remove('on');
+  });
+  const scrim = document.querySelector('.sheet-scrim');
+  if (scrim && !document.querySelector('.pop.filter-pop.on')) scrim.classList.remove('on');
+}
+
+document.addEventListener('click', (e) => {
+  if (!e.target.closest('.pop') && !e.target.closest('[data-pop]')) closeAllPops();
+});
+
+document.addEventListener('keydown', (e) => {
+  if (e.key !== 'Escape') return;
+
+  const dlg = document.querySelector('.backdrop.on');
+  if (dlg) {
+    dlg.classList.remove('on');
+    return;
+  }
+  closeAllPops();
+});
+
+/* ---------- toasts ---------- */
+function toast(message, { action, onAction, error, timeout = 7000 } = {}) {
+  let host = document.querySelector('.toasts');
+  if (!host) {
+    host = document.createElement('div');
+    host.className = 'toasts';
+    document.body.appendChild(host);
+  }
+
+  const el = document.createElement('div');
+  el.className = 'toast' + (error ? ' err' : '');
+  el.setAttribute('role', 'status');
+  el.innerHTML = `<span style="flex:1">${message}</span>`;
+
+  if (action) {
+    const btn = document.createElement('button');
+    btn.className = 'btn btn-outline btn-sm';
+    btn.textContent = action;
+    btn.addEventListener('click', () => {
+      onAction?.();
+      el.remove();
+    });
+    el.appendChild(btn);
+  }
+
+  const close = document.createElement('button');
+  close.className = 'icon-btn';
+  close.style.cssText = 'width:26px;height:26px;border:none;background:transparent;box-shadow:none';
+  close.setAttribute('aria-label', 'Dismiss');
+  close.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M18 6 6 18M6 6l12 12"/></svg>';
+  close.addEventListener('click', () => el.remove());
+  el.appendChild(close);
+
+  host.appendChild(el);
+  setTimeout(() => el.remove(), timeout);
+}
+
+window.proto = {
+  initTheme,
+  buildLearners,
+  relTime,
+  absTime,
+  num,
+  matches,
+  describe,
+  PRESETS,
+  EMPTY_FILTER,
+  WINDOW_LABEL,
+  closeAllPops,
+  toast
+};

--- a/prototypes/learner-lifecycle/states.html
+++ b/prototypes/learner-lifecycle/states.html
@@ -1,0 +1,245 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Edge states · Learner Lifecycle Prototype</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="lifecycle.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .page { max-width: 900px; margin: 0 auto; padding: 40px 24px 90px; }
+      .frame { border: 1px solid var(--border); border-radius: var(--radius-xl); padding: 20px; background: var(--card); margin-bottom: 12px; }
+      h1 { font-size: 28px; font-weight: 600; letter-spacing: -0.025em; margin: 6px 0 8px; }
+      .lead { color: var(--muted-foreground); font-size: 14.5px; max-width: 68ch; margin: 0 0 8px; line-height: 1.6; }
+      .sec { font-size: 12.5px; font-weight: 600; letter-spacing: 0.07em; text-transform: uppercase; color: var(--muted-foreground); margin: 40px 0 6px; display: flex; align-items: center; gap: 10px; }
+      .sec::after { content: ''; flex: 1; height: 1px; background: var(--border); }
+      .why { font-size: 13px; color: var(--muted-foreground); margin: 0 0 14px; line-height: 1.6; }
+      .why b { color: var(--foreground); font-weight: 500; }
+      .eyebrow { font-size: 11.5px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: var(--primary); }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:12px">
+        <div>
+          <span class="eyebrow">ClassroomIO · Learner lifecycle</span>
+          <h1>Edge states</h1>
+          <p class="lead">
+            The states that are hard to reach by clicking, shown side by side.
+            The <a href="audience.html" style="color:var(--primary);text-decoration:underline">audience page</a> covers the happy path.
+          </p>
+        </div>
+        <button class="icon-btn" id="theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+      </div>
+
+      <!-- 1 -->
+      <div class="sec">1 · Loading — stale-while-loading</div>
+      <p class="why">Today every filter change calls <b>invalidateAll</b> and the table goes dead. Instead: rows stay visible and dimmed, controls stay clickable, a 2px bar runs under the toolbar. Superseded requests are cancelled.</p>
+      <div class="frame">
+        <div class="dt-wrap busy">
+          <div class="loadbar"></div>
+          <div class="dt-scroll">
+            <table class="dt" style="min-width:520px">
+              <thead><tr><th class="c-check"><input type="checkbox" class="cb" disabled /></th><th>Name</th><th>Last login</th><th>Progress</th></tr></thead>
+              <tbody>
+                <tr><td class="c-check"><input type="checkbox" class="cb" /></td><td>Ada Okafor</td><td>3 months ago</td><td>62%</td></tr>
+                <tr><td class="c-check"><input type="checkbox" class="cb" /></td><td>Tunde Mensah</td><td>Never</td><td>0%</td></tr>
+                <tr><td class="c-check"><input type="checkbox" class="cb" /></td><td>Sofia Rossi</td><td>8 months ago</td><td>14%</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <!-- 2 -->
+      <div class="sec">2 · Cold load — skeleton</div>
+      <p class="why">The only time a skeleton appears: first paint, when there are no stale rows worth keeping. <code>audience-table-skeleton.svelte</code> already exists in the repo and is currently rendered nowhere.</p>
+      <div class="frame">
+        <div class="dt-wrap">
+          <div style="padding:12px;display:grid;gap:10px">
+            <div class="sk" style="width:38%"></div>
+            <div class="sk" style="width:92%"></div>
+            <div class="sk" style="width:88%"></div>
+            <div class="sk" style="width:94%"></div>
+            <div class="sk" style="width:76%"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 3 -->
+      <div class="sec">3 · Two different empty states</div>
+      <p class="why">Never show "invite your first learner" to someone who just over-filtered. <b>Left:</b> filters match nothing — the action is to clear them. <b>Right:</b> genuinely no audience — the action is to import.</p>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px" class="two">
+        <div class="frame" style="padding:0">
+          <div class="empty">
+            <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z"/></svg></div>
+            <h3>No learners match these filters</h3>
+            <p>Try widening the date range, or clear the filters to see your whole audience.</p>
+            <button class="btn btn-primary btn-sm">Clear filters</button>
+          </div>
+        </div>
+        <div class="frame" style="padding:0">
+          <div class="empty">
+            <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg></div>
+            <h3>No learners yet</h3>
+            <p>Import a list or share an invite link to bring your first learners into Acme Academy.</p>
+            <a class="btn btn-primary btn-sm" href="import.html">Import learners</a>
+          </div>
+        </div>
+      </div>
+
+      <!-- 4 -->
+      <div class="sec">4 · Selection survives a filter change</div>
+      <p class="why">Today an <code>$effect</code> silently wipes selection on every refetch. Instead, when the filter changes under a held selection, say so and let the admin choose.</p>
+      <div class="frame">
+        <div class="allmatch on" style="margin:0">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" style="width:15px;color:var(--warning)"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/><path d="M12 9v4M12 17h.01"/></svg>
+          <span>Filters changed. <b>42</b> selected learners are no longer shown.</span>
+          <span style="flex:1"></span>
+          <button class="btn btn-outline btn-sm">Keep selection</button>
+          <button class="link-btn">Clear</button>
+        </div>
+      </div>
+
+      <!-- 5 -->
+      <div class="sec">5 · Queued action — over 1,000 rows</div>
+      <p class="why">A 12,000-row archive is not an HTTP request. The dialog closes, this bar takes over, and the admin can navigate away and come back — it is driven by job status, not page state.</p>
+      <div class="frame">
+        <div class="jobbar on" style="margin:0">
+          <span class="lbl">Archiving 12,480 learners…</span>
+          <div class="progress"><span style="width:38%"></span></div>
+          <span class="pct">4,742 of 12,480</span>
+        </div>
+      </div>
+
+      <!-- 6 -->
+      <div class="sec">6 · Count drift — the 409</div>
+      <p class="why">Someone logged in between preview and apply, so the affected set no longer matches what the admin approved. Never act on the new set silently.</p>
+      <div class="frame">
+        <div class="toast err" style="max-width:none;margin:0">
+          <span style="flex:1">This list changed while you were reviewing it — <b>3,209</b> learners now match. Re-confirm to continue.</span>
+          <button class="btn btn-outline btn-sm">Review again</button>
+        </div>
+      </div>
+
+      <!-- 7 -->
+      <div class="sec">7 · Partial failure — a dialog, not a snackbar</div>
+      <p class="why">A snackbar cannot carry 34 rows of detail. Failures get a scrollable list with per-row reasons and a CSV so the admin can work the exceptions.</p>
+      <div class="frame" style="padding:0;overflow:hidden">
+        <div class="dialog" style="max-width:none;border:none;box-shadow:none">
+          <div class="dialog-head"><h2>Finished with errors</h2><p class="lede">3,180 succeeded · 34 failed</p></div>
+          <div class="dialog-body">
+            <div class="sample">
+              <div class="r"><span>Kwame Boateng<div class="em">kwame.boateng@example.com</div></span><span class="text-muted" style="text-align:right">Still enrolled in a mandatory course</span></div>
+              <div class="r"><span>Hana Sato<div class="em">hana.sato@example.com</div></span><span class="text-muted" style="text-align:right">Still enrolled in a mandatory course</span></div>
+              <div class="r"><span>Ivan Sokolov<div class="em">ivan.sokolov@example.com</div></span><span class="text-muted" style="text-align:right">Is an admin in another workspace</span></div>
+              <div class="r more">and 31 more</div>
+            </div>
+          </div>
+          <div class="dialog-foot"><button class="btn btn-outline">Download failures as CSV</button><button class="btn btn-primary">Done</button></div>
+        </div>
+      </div>
+
+      <!-- 8 -->
+      <div class="sec">8 · Delete is gated behind archive</div>
+      <p class="why">Permanent delete is disabled until every selected learner is already archived. The consequence lines under each action are what steer someone to the reversible option.</p>
+      <div class="frame" style="display:flex;justify-content:center">
+        <div class="pop menu on" style="position:static;min-width:300px">
+          <button><div><div class="t">Archive</div><div class="d">Frees a seat · reversible</div></div></button>
+          <button><div><div class="t">Deactivate</div><div class="d">Blocks access · keeps the seat · reversible</div></div></button>
+          <div class="menu-sep"></div>
+          <button class="danger" disabled><div><div class="t">Delete permanently</div><div class="d">Archive them first</div></div></button>
+        </div>
+      </div>
+
+      <!-- 9 -->
+      <div class="sec">9 · Delete confirmation — type to confirm</div>
+      <p class="why">Type-to-confirm is <b>delete only</b>. Adding friction to reversible actions just trains people to type past warnings.</p>
+      <div class="frame" style="padding:0;overflow:hidden">
+        <div class="dialog" style="max-width:none;border:none;box-shadow:none">
+          <div class="dialog-head">
+            <h2>Permanently delete 3,214 learners?</h2>
+            <p class="lede">This removes their membership, enrollments and progress from this organization. It cannot be undone.</p>
+          </div>
+          <div class="dialog-body">
+            <div class="export-first done">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m9 11 3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+              <span style="flex:1">Exported 3,214 rows to CSV.</span>
+              <button class="btn btn-outline btn-sm" disabled>Export CSV</button>
+            </div>
+            <div>
+              <label class="label">Type <b>3214</b> to confirm</label>
+              <input class="input" value="321" />
+            </div>
+          </div>
+          <div class="dialog-foot"><button class="btn btn-ghost">Cancel</button><button class="btn btn-destructive" disabled>Delete permanently</button></div>
+        </div>
+      </div>
+
+      <!-- 10 -->
+      <div class="sec">10 · Export menu — scoped and counted</div>
+      <p class="why">Never ambiguous what is being downloaded. PDF disables above 2,000 rows and says why, because a 20,000-row PDF helps nobody.</p>
+      <div class="frame" style="display:flex;justify-content:center">
+        <div class="pop menu on" style="position:static;min-width:290px">
+          <button><div><div class="t">Export 42 selected</div><div class="d">CSV</div></div></button>
+          <button><div><div class="t">Export 3,214 filtered</div><div class="d">CSV · matches the current view</div></div></button>
+          <button><div><div class="t">Export all 12,480</div><div class="d">CSV · streams from the server</div></div></button>
+          <div class="menu-sep"></div>
+          <button disabled><div><div class="t">Export as PDF</div><div class="d">Up to 2,000 rows — use CSV</div></div></button>
+        </div>
+      </div>
+
+      <!-- 11 -->
+      <div class="sec">11 · Undo, because archive is reversible</div>
+      <p class="why">Archived rows leave the default view. The toast names how many, so their disappearance is explained rather than startling. Delete gets no undo — and the dialog said so.</p>
+      <div class="frame" style="display:grid;gap:10px;justify-items:center">
+        <div class="toast" style="margin:0">
+          <span style="flex:1">400 learners archived. They no longer appear in this view.</span>
+          <button class="btn btn-outline btn-sm">Undo</button>
+        </div>
+        <div class="toast" style="margin:0"><span style="flex:1">3,214 learners permanently deleted.</span></div>
+      </div>
+
+      <!-- 12 -->
+      <div class="sec">12 · Mobile — the filter popover becomes a sheet</div>
+      <p class="why">A five-section filter form in a 340px popover on a phone is unusable. Below <code>md</code> it docks to the bottom as a sheet, and controls keep 44px touch targets.</p>
+      <div class="frame" style="display:flex;justify-content:center">
+        <div style="width:320px;border:1px solid var(--border);border-radius:22px;overflow:hidden;background:var(--background);position:relative;height:420px">
+          <div style="padding:14px;border-bottom:1px solid var(--border);font-weight:600;font-size:15px">Audience</div>
+          <div style="padding:12px;display:flex;gap:8px;overflow:hidden">
+            <input class="input" style="flex:1;height:34px" placeholder="Search…" />
+            <button class="btn btn-outline btn-sm">Filter</button>
+          </div>
+          <div style="position:absolute;inset:0;background:rgb(0 0 0/0.4)"></div>
+          <div style="position:absolute;left:0;right:0;bottom:0;background:var(--popover);border-radius:16px 16px 0 0;border-top:1px solid var(--border);max-height:75%;display:flex;flex-direction:column">
+            <div style="padding:14px;overflow:auto">
+              <div class="legend" style="font-size:11.5px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--muted-foreground);margin-bottom:7px">Last login</div>
+              <label class="fopt" style="min-height:38px"><input type="radio" class="radio" name="m" /> Any</label>
+              <label class="fopt" style="min-height:38px"><input type="radio" class="radio" name="m" checked /> Never logged in</label>
+              <label class="fopt" style="min-height:38px"><input type="radio" class="radio" name="m" /> Before 90 days</label>
+            </div>
+            <div class="filter-foot"><button class="link-btn">Clear all</button><button class="btn btn-primary btn-sm">Apply</button></div>
+          </div>
+        </div>
+      </div>
+
+      <p class="why" style="margin-top:44px;padding-top:20px;border-top:1px solid var(--border)">
+        Spec: <b>prd/admin-controls-and-reporting/UX.md</b> · Engineering plan: <b>prd/admin-controls-and-reporting/README.md</b>
+      </p>
+    </div>
+
+    <script src="proto.js"></script>
+    <script>
+      window.proto.initTheme();
+      const mq = matchMedia('(max-width: 760px)');
+      const apply = () => document.querySelectorAll('.two').forEach((el) => (el.style.gridTemplateColumns = mq.matches ? '1fr' : '1fr 1fr'));
+      mq.addEventListener('change', apply);
+      apply();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What

Plans the four asks from the admin questionnaire — usage filters, bulk lifecycle actions, CSV import, report export — and ships a clickable prototype for the UX.

- `prd/admin-controls-and-reporting/README.md` — schema, API, sequencing
- `prd/admin-controls-and-reporting/UX.md` — interaction spec
- `prototypes/learner-lifecycle/` — clickable prototype, the UX source of truth

**Docs and prototypes only. No production code touched.**

## Why it's framed as a loop, not four features

The customer has a lot of learners and one recurring question: *who isn't using the platform, and who should we remove?* That's **see usage → filter to the dormant → review → act in bulk → prove what happened**. The four asks map onto it unevenly, so the plan sequences by that rather than by questionnaire order:

| Ask | Role in the loop | Priority |
| --- | --- | --- |
| Filter by last login / activity / enrollment / completion | See and filter — the entry point | Critical path |
| Bulk deactivate / delete / archive | Act — the payoff | Critical path |
| Export reports | Review and prove — sign-off *and* audit trail | Critical for the roster |
| CSV/Excel import | Onboarding, not usage | Last |

Compliance export is the biggest reporting gap in the product, but for a *different* customer — it sequences to phase 8.

## Two findings from the code that shaped the plan

**1. Archiving frees zero seats unless one function changes.** `countActiveStudents` (`packages/db/src/queries/organization/organization.ts:675`) counts every student `organizationmember` row with no status concept, and it's the sole input to `assertStudentCapacityOrThrow`. This settles what was an open question: `ARCHIVED` does not count against the plan limit, `DEACTIVATED` does — making archive the meaningful "reclaim a seat" action.

**2. The access gate is already in the right place.** `isUserCourseMemberOrOrgAdmin` (`packages/db/src/queries/group/group.ts:147`) already requires live org membership, so deleting genuinely cuts course access today, and that same join is the one place the `status` check belongs. Separately, `deleteOrganizationAudienceMember` leaves orphan `groupmember` rows behind — the plan closes that.

## What scale forces

- **"Select all N matching" is in scope, not a follow-up.** Filtering 20k learners to "never logged in" returns thousands of rows; tick-boxes don't solve it. Bulk actions take explicit ids *or* filter + `expectedCount`, and 409 on drift rather than acting on a different set.
- **Roster export streams `text/csv`** from the API instead of JSON-to-client with a row cap. PDF stays capped — a 20,000-row PDF helps nobody.
- **Bulk actions over ~1,000 rows queue.** A 12,000-row archive isn't an HTTP request.
- **All view state lives in the URL.** A filtered view is the link an admin sends for sign-off before removing 3,000 people. Selection is the deliberate exception.

## Prototype

```bash
cd prototypes/learner-lifecycle && python3 -m http.server 8899
```

`audience.html` runs the whole loop live over **2,400 synthetic learners** — counts, paging and select-all-matching are really computed, so the scale behaviours are reviewable rather than described. Plus `states.html` (twelve edge states) and `import.html` (upload → preview → result).

Built on `app-theme.css` mirroring the real `packages/ui/src/index.css` tokens; every element maps to an existing `@cio/ui` primitive.

## Three current behaviours the spec deliberately replaces

1. **Filtering blocks and blanks** — every filter change calls `invalidateAll` (`audience.svelte:150`). Replaced with stale-while-loading.
2. **`audience-table-skeleton.svelte` is exported and rendered nowhere** — there's no loading affordance at all today.
3. **Selection is wiped by an `$effect` on the data** (`audience.svelte:38`) — change a filter holding 42 rows and they vanish silently.

Also noted: `audience-table-toolbar.svelte` overrides `Page.BodyHeader` with `md:justify-between`, making it the alignment outlier versus courses and cohorts. This work should drop the override.

## Open questions for review

1. **What does "remove from the platform" mean — reclaim seats, revoke access, or erase data?** The plan assumes seats. If they mean GDPR-style erasure that routes through `prd/account-deletion` instead and is a different feature.
2. **How many learners, on what plan?** The 20k assumption drives the streaming export, the queued bulk action, and the query-plan verification.
3. **Does "activity" mean logins or real engagement?** `last_active_at` from page events counts opening a page.
4. **Is there an approval step?** If removals need enforced sign-off, the bulk-action model becomes a stateful review queue.
5. **Is native `.xlsx` required?** The only item here that adds a dependency, and it governs both import and export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the Quartz organization and course landing-page theme, makes it the default and sole free theme, migrates stored Minimal themes to Quartz, adds localized theme metadata, and documents a future learner lifecycle and reporting system.

- Registers Quartz throughout dashboard and UI theme loaders, tokens, components, and Storybook.
- Changes landing-page defaults and adds a database migration for existing stored Minimal themes.
- Adds learner usage, lifecycle, import, and export implementation and UX plans.
- Includes production application and database changes in addition to the documented prototype.

<h3>Confidence Score: 2/5</h3>

The PR is not safe to merge until explicit Minimal selections are preserved and configurable Quartz links reject executable URL schemes.

The migration cannot distinguish historical defaults from deliberate Minimal selections and will overwrite both, while the new public Quartz anchors accept persisted `javascript:` URLs without a validation boundary; the implementation plan also names an already-occupied migration index.

**Files Needing Attention:** packages/db/src/migrations/0015_default_landing_page_quartz.sql; packages/ui/src/custom/org-landing-page/quartz/footer.svelte; prd/admin-controls-and-reporting/README.md

<details open><summary><h3>Security Review</h3></summary>

Configurable Quartz footer and navigation URLs reach public anchor elements without URL-scheme validation, permitting stored same-origin script execution when a crafted link is clicked.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/src/migrations/0015_default_landing_page_quartz.sql | Migrates all stored Minimal themes to Quartz, including indistinguishable explicit user selections. |
| packages/ui/src/custom/org-landing-page/quartz/footer.svelte | Introduces the Quartz footer but renders configurable URLs without validating safe schemes. |
| packages/ui/src/custom/org-landing-page/quartz/org.svelte | Composes the new Quartz organization landing page and its course, resource, embed, callout, and footer sections. |
| packages/ui/src/custom/org-landing-page/quartz/course.svelte | Composes the Quartz course landing page and its custom content and enrollment rail. |
| apps/dashboard/src/lib/features/org/utils/landing-page.ts | Registers Quartz and changes normalization and dynamic-loading defaults from Minimal to Quartz. |
| prd/admin-controls-and-reporting/README.md | Provides the lifecycle implementation plan but references a migration number already occupied by this PR. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Organization landing-page editor] --> B[Landing-page JSON]
  B --> C[Normalization and public-page props]
  C --> D[Quartz organization page]
  D --> E[Navigation and footer links]
  D --> F[Course catalog]
  G[Migration 0015] -->|minimal → quartz| B
  H[Theme registry and dynamic loader] --> D
  H --> I[Quartz course page]
```

<sub>Reviews (1): Last reviewed commit: ["docs: add learner usage &amp; lifecycle plan..."](https://github.com/classroomio/classroomio/commit/2acff99737ada755eb518a7bc5206b026f636607) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61041498)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an implementation plan for learner lifecycle management, including status tracking, auditing, filtering, bulk actions, exports, imports, and phased delivery.
  - Added a UX specification for the learner audience page covering filters, table views, selection, bulk actions, exports, imports, accessibility, URL-backed state, and loading behavior.
  - Documented safety controls, target-drift validation, queued processing for large operations, undo behavior, testing considerations, sequencing, and open questions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->