### PR TITLE
docs(prd): landing page learner account menu

### DIFF
--- a/prd/landing-learner-menu/README.md
+++ b/prd/landing-learner-menu/README.md
@@ -1,0 +1,291 @@
+# Landing Page Learner Menu PRD
+
+## Status
+
+- Draft
+
+## Prototypes — the UX source of truth
+
+UX for this feature comes from the prototype folder, not from prose. Where this document and a prototype disagree on a UI detail, **the prototype wins** and this document must be corrected.
+
+```
+prototypes/landing-learner-menu/index.html
+```
+
+| Surface | Prototype file |
+| --- | --- |
+| Start page / screen map | `prototypes/landing-learner-menu/index.html` |
+| Quartz landing page — enrolled learner (menu open) | `prototypes/landing-learner-menu/learner-member.html` |
+| Quartz landing page — logged in, not a member | `prototypes/landing-learner-menu/learner-non-member.html` |
+| Quartz landing page — logged out (unchanged baseline) | `prototypes/landing-learner-menu/learner-logged-out.html` |
+| All menu states side by side (member / non-member / loading / no-avatar / mobile) | `prototypes/landing-learner-menu/menu-states.html` |
+| The menu rendered in 4 other landing themes (bold, terminal, editorial, vibrant) | `prototypes/landing-learner-menu/themes.html` |
+
+## Purpose
+
+A customer-education academy is a marketing site and a product entrance at the same time. Today the org landing page treats every visitor as anonymous: the nav shows one button, and a learner who is already signed in gets no acknowledgement that they are signed in, no way to see which account they are using, and no way to sign out without first entering the LMS. This PRD adds a **learner account menu** — an avatar in the far right of the landing nav that opens a popover with identity, learner destinations, theme preference, and log out — alongside the existing primary CTA.
+
+The reference experience is the account popover on developer-tool marketing sites (Vercel, Linear, Resend): avatar on the far right, name + email at the top, a short list of destinations, a theme row, log out, and a filled CTA pinned to the bottom of the card. The screenshot supplied by the user is the visual reference; the CTA there reads "Upgrade to Pro", and for a customer-education academy the equivalent bottom CTA is **Continue Learning**.
+
+## Problem Statement
+
+- A signed-in learner on `acme.classroomio.com` sees no evidence they are signed in. The nav looks identical to a cold visitor's, so the page reads as "log in again".
+- There is no way to tell **which** account is signed in. On shared or corporate machines, learners routinely complete training under the wrong account, and the only way to check today is to enter the LMS and open the sidebar.
+- There is no log out on the public site at all. Signing out requires navigating into `/lms`, opening the sidebar footer menu, and choosing Log Out.
+- Certificates — the artifact a compliance or customer-education learner actually comes back for — are three clicks deep and invisible from the academy's front door.
+- Theme preference can only be changed inside the app shell, so a learner who prefers dark mode enters the LMS in the wrong theme and has to fix it after arrival.
+- `getOrgLandingAuthAction()` (`apps/dashboard/src/lib/features/org/utils/org-landing-auth-action.ts`) compresses every possible signed-in state into a single button label. It cannot express "signed in as X, and here is what you can do".
+
+## Confirmed Decisions
+
+1. **Nav shape: CTA button + avatar.** When a learner is signed in and a member of the academy being viewed, the nav renders the existing primary CTA (`Continue Learning`) **and** an avatar trigger to its right. The avatar does not replace the button. One-click LMS access is preserved; the popover is for identity and secondary destinations.
+2. **The popover repeats the CTA.** `Continue Learning` appears as a filled, full-width button pinned to the bottom of the popover card, mirroring the reference screenshot's "Upgrade to Pro" slot.
+3. **CTA target is `/lms`.** No deep-link-to-last-lesson in v1, and no progress data is fetched on the public site. (This reverses an earlier answer in the same clarification session — resume-last-lesson was chosen first, then explicitly cut to keep v1 small. Recorded as a deliberate scope cut, see Non-Goals.)
+4. **Menu items for members:** identity block (name + email), `My Courses` → `/lms`, `My Certificates` → `/lms/certificates`, `Account Settings` → `/lms/settings`, a `Theme` row, `Log Out`, then the `Continue Learning` CTA.
+5. **Logged in but not a member of this academy:** the avatar still renders — hiding it when the person is demonstrably signed in is the confusing case. The CTA becomes `Join Academy` (in the nav and in the popover), and the learner-scoped items (`My Courses`, `My Certificates`) are dropped. `Account Settings`, `Theme` and `Log Out` remain. When the academy is invite-only, has `disableSignup`, or the learner has a pending invite, **no CTA renders at all** — the avatar and popover still do, minus the CTA button. This preserves the existing `getOrgLandingAuthAction()` gating exactly.
+6. **Staff see exactly what learners see.** An admin or tutor of the academy viewing its public landing page gets `Continue Learning` → `/lms`, the same as a learner. No "Dashboard" CTA and no "Edit landing page" shortcut in v1. The one exception already in the code — self-hosted admins/tutors getting `Dashboard` → `/org/<siteName>` — is preserved unchanged.
+7. **The theme toggle sets the app/LMS theme, not the landing page.** Landing themes are fixed single palettes (`packages/ui/src/custom/org-landing-page/*/vars.ts` — there is no dark variant and no `prefers-color-scheme` handling anywhere in that folder). The existing `ThemeToggle` (light / dark / system via `mode-watcher`) is reused as-is; it sets the preference the LMS and dashboard will render with. The landing page's own appearance does not change when it is used. See Risks for the disclosure requirement.
+8. **One shared component across all 11 themes.** A single `learner-menu.svelte` lives in `packages/ui/src/custom/org-landing-page/`, styled entirely from `--landing-*` variables, and is dropped into every theme's `nav.svelte` (bold, classic, corporate, editorial, minimal, quartz, saas, studio, tech, terminal, vibrant). No per-theme forks in v1.
+
+## Current-State Audit
+
+| Capability | Current state | Notes |
+| --- | --- | --- |
+| Landing nav auth affordance | Single `LandingButton` driven by `authAction` | `packages/ui/src/custom/org-landing-page/*/nav.svelte`; prop shape at `types.ts:359` |
+| Auth action logic | `getOrgLandingAuthAction()` | Returns `{label, href, loading?}` or `undefined`; handles logged-out, loading, member, self-hosted staff, invite-only, `disableSignup`, pending invite |
+| Signed-in identity on landing | None | No avatar, no name, no email anywhere on the public site |
+| Log out from landing | None | Only via `/lms` sidebar footer → `menu.svelte` |
+| Profile data availability | Available | Root `+layout.svelte` runs `appInitApi.setupApp()` for org-site routes too; `$profile` (`fullname`, `email`, `avatarUrl`) and `appInitApi.data.organizations` are populated |
+| Avatar primitive | `UserAvatar` | `packages/ui/src/custom/user-avatar/` — wraps `base/avatar`, falls back to `/images/avatar.svg` |
+| Popover primitive | `base/popover` and `base/dropdown-menu` (bits-ui) | Both portal their content to `document.body` |
+| Theme toggle | `ThemeToggle` | `apps/dashboard/src/lib/features/ui/sidebar/footer/theme-toggle.svelte` — light/dark/system, `setMode` + `markColorModeExplicit()` |
+| Account menu reference implementation | `menu.svelte` | `apps/dashboard/src/lib/features/ui/sidebar/footer/menu.svelte` — identity block, theme row, separators, log out |
+| Landing theme variables | `themeStyle(theme)` | `packages/ui/src/custom/org-landing-page/theme-style.ts` — serialises a theme's `--landing-*` vars to an inline style string. Applied by `landing-theme-scope.svelte` |
+| Landing dark mode | Does not exist | No `.dark` selector or `prefers-color-scheme` query in `org-landing-page/` |
+| Landing page edit preview | `edit-context.ts` + `editable-section.svelte` | Settings preview renders the same theme components; interactive chrome must be inert there |
+| LMS destinations | Exist | `/lms`, `/lms/certificates`, `/lms/settings`, `/lms/mylearning`, `/lms/community`, `/lms/explore` |
+
+## Product Goals
+
+1. A signed-in learner can tell, from the academy's front door, that they are signed in and which account they are using.
+2. Entering the LMS stays one click; everything else a returning learner wants is one click plus one.
+3. Certificates become reachable from the public site — the single strongest return-visit motivator for customer-education and compliance academies.
+4. Log out is possible without entering the app.
+5. The menu looks native in all 11 landing themes, driven by theme variables rather than hard-coded colour.
+6. No behaviour change whatsoever for logged-out visitors.
+
+## Non-Goals (v1)
+
+- **Resume-last-lesson deep links.** No last-activity or progress lookup on the public site (Decision 3). `Continue Learning` goes to `/lms`.
+- **Progress display in the popover.** No course title, no percentage, no progress bar.
+- **Dark variants for the landing themes.** Adding a dark palette to each theme's `vars.ts` is a separate PRD.
+- **Switch-academy list.** Learners in multiple academies are not offered a switcher here.
+- **Staff shortcuts.** No "Dashboard", no "Edit landing page" (Decision 6).
+- **Notifications, "What's new", feedback, docs, or support entries.** Those stay in the app shell menu.
+- **Org-configurable menu items.** The item list is fixed; academies cannot add or reorder entries.
+
+## Functional Requirements
+
+### FR-1 — Nav trigger (all themes)
+
+Prototype: `learner-member.html`, `themes.html`.
+
+- The avatar renders as the last element in the landing nav's right-hand cluster, after the CTA button, with a `12px` gap.
+- Trigger is a `32px` circular button showing `UserAvatar`; on hover and on open it gains a ring in `--landing-border`; focus-visible gets a `--landing-accent` ring, matching `LandingButton`.
+- Accessible name comes from a translation key, not the person's name: `landing.learner_menu.trigger_label` → "Account menu". `aria-haspopup="menu"`, `aria-expanded` reflects open state.
+- The trigger renders **only** when the learner is signed in and `appInitApi` has initialised. States:
+  - **Logged out** — no avatar, nav is byte-identical to today.
+  - **Signed in, not yet initialised** — a `32px` skeleton circle in `--landing-border-soft` occupies the slot, so the nav does not reflow when data lands. The existing loading behaviour of the CTA button (`authAction.loading`) is unchanged.
+  - **Signed in, initialised** — avatar renders.
+- On mobile (`< 768px`) the nav's centre links are already hidden; the avatar stays visible and the CTA button collapses to icon-only. The popover anchors to the right edge with an `8px` viewport inset.
+
+### FR-2 — Popover content, member of this academy
+
+Prototype: `learner-member.html`, `menu-states.html` (panel 1).
+
+Card is `280px` wide, `--landing-card` background, `--landing-border` hairline, `--landing-radius-card` corners, `--landing-shadow-card`, aligned to the trigger's right edge with a `8px` offset.
+
+| Row | Content | Behaviour |
+| --- | --- | --- |
+| Identity | `fullname` in `--landing-fg`, 15px semibold; `email` in `--landing-fg-muted`, 13px, truncated | Not a link. If `fullname` is empty, the email moves up and the muted line is omitted |
+| Divider | `--landing-divider` | |
+| My Courses | `landing.learner_menu.my_courses` | → `/lms` |
+| My Certificates | `landing.learner_menu.my_certificates` | → `/lms/certificates` |
+| Account Settings | `landing.learner_menu.account_settings` | → `/lms/settings` |
+| Divider | | |
+| Theme | `landing.learner_menu.theme` label left, 3-button segmented control right (light / dark / system) | Sets app/LMS preference; popover stays open on click |
+| Divider | | |
+| Log Out | `settings.profile.logout` (existing key) with a `log-out` icon on the right | → `/logout` |
+| CTA | Full-width filled `LandingButton variant="primary"`, label `navigation.goto_lms` rendered as "Continue Learning" | → `/lms` |
+
+- Every row except Theme closes the popover on activation.
+- Item rows are `36px` tall, `14px` text in `--landing-fg`, hover background `--landing-button-tertiary-bg-hover`.
+- Keyboard: `Escape` closes and returns focus to the trigger; `Tab` moves through rows in visual order; arrow keys move between rows.
+
+### FR-3 — Popover content, signed in but not a member
+
+Prototype: `learner-non-member.html`, `menu-states.html` (panel 2).
+
+- Identity block, `Account Settings`, `Theme`, `Log Out` — unchanged.
+- `My Courses` and `My Certificates` are **absent** (not disabled).
+- CTA reads `navigation.join_academy` → `/join-academy`.
+- When the academy is invite-only, has `disableSignup`, or the learner has a pending invite, the CTA button and the nav CTA are both omitted; the popover ends at `Log Out`.
+- Self-hosted non-members follow the existing `getOrgLandingAuthAction()` fallbacks unchanged: a managed org yields `Dashboard` → `/org/<siteName>`, otherwise no CTA.
+
+### FR-4 — Theme fidelity
+
+Prototype: `themes.html`.
+
+- The card, dividers, text, hover states and CTA read **only** from `--landing-*` variables. No `ui:text-muted-foreground`-style app tokens, no literal hex.
+- The theme's own personality carries through automatically: square corners in quartz (`--landing-radius-card: 0px`), heavy borders in bold, monospace in terminal.
+- Because bits-ui portals popover content to `document.body`, outside `landing-theme-scope`'s inline style, the popover content element must re-apply `style={themeStyle(theme)}` itself. Each theme's `nav.svelte` passes its own `theme` key to `LearnerMenu`.
+
+### FR-5 — Landing page editor preview
+
+- In the settings landing-page preview and the `/settings/landingpage/edit` screen, the avatar renders (so the academy owner sees the real nav) but the popover does **not** open, matching how `disableCourseLinks` neutralises course links today.
+- The trigger is `aria-disabled` and non-focusable in that context; the `navigation` editable section cap continues to select the nav as a whole.
+
+### FR-6 — Coverage
+
+The menu appears anywhere a landing `nav.svelte` renders:
+
+- Org landing page — `apps/dashboard/src/routes/+page.svelte` (org-site) and `$features/org/components/landing-page/landing-page.svelte`
+- Public catalog — `apps/dashboard/src/routes/(org-site)/courses/+page.svelte`
+- Public course landing page — `$features/ui/course-landing-page/course-landing-page.svelte`
+
+## Technical Design
+
+### Data
+
+No new tables, no new columns, no new endpoints. Every value the menu renders is already in the client:
+
+| Value | Source |
+| --- | --- |
+| `fullname`, `email`, `avatarUrl` | `$profile` (`apps/dashboard/src/lib/utils/store/user.ts`) |
+| `isLoggedIn` | `$user.isLoggedIn` |
+| initialisation | `appInitApi.isInitializedAndReady` |
+| membership | `appInitApi.data.organizations` matched against `org.id` |
+| gating | `org.settings.signup.inviteOnly`, `org.disableSignup`, `appInitApi.pendingOrgInvite` |
+
+### Prop shape
+
+`OrgLandingPageProps` gains one optional field beside `authAction` (`packages/ui/src/custom/org-landing-page/types.ts`):
+
+```ts
+export interface LandingLearnerAccount {
+  fullname: string;
+  email: string;
+  avatarUrl?: string;
+  /** Learner-scoped destinations; empty when the viewer is not a member of this academy. */
+  items: { key: 'myCourses' | 'myCertificates' | 'accountSettings'; label: string; href: string }[];
+  logoutLabel: string;
+  logoutHref: string;
+  themeLabel: string;
+  triggerLabel: string;
+  /** True while the account payload is still loading — render a skeleton trigger. */
+  loading?: boolean;
+  /** True in the settings preview — render the trigger but do not open the popover. */
+  inert?: boolean;
+}
+
+export interface OrgLandingPageProps {
+  // …existing fields
+  authAction?: { label: string; href: string; loading?: boolean; disabled?: boolean };
+  learnerAccount?: LandingLearnerAccount;
+}
+```
+
+The UI package receives finished labels and hrefs, never translation keys and never raw membership data — copy stays in the dashboard, matching how `labels` and `authAction` already work.
+
+### Builder
+
+New pure helper beside the existing auth-action helper:
+
+```ts
+// apps/dashboard/src/lib/features/org/utils/org-landing-learner-account.ts
+export function getOrgLandingLearnerAccount({
+  isLoggedIn, isInitialized, profile, org, organizations, inert
+}: OrgLandingLearnerAccountOptions): LandingLearnerAccount | undefined {
+  if (!isLoggedIn) return undefined;
+
+  if (!isInitialized) {
+    return { /* identity blank */ loading: true, /* …labels */ };
+  }
+
+  const isMember = organizations.some((organization) => organization.id === org.id);
+  const items = isMember ? buildLearnerItems() : [buildAccountSettingsItem()];
+
+  return { fullname: profile.fullname, email: profile.email ?? '', avatarUrl: profile.avatarUrl ?? undefined, items, /* …labels */ inert };
+}
+```
+
+- `getOrgLandingAuthAction()` is **not modified**. The CTA label and href the popover renders are the ones it already returns, passed straight through — so the menu can never disagree with the nav button.
+- Both helpers are called from the four call sites that already build `authAction`, and the result is threaded through `buildOrgLandingPageProps()` as a new optional argument.
+
+### Component
+
+```
+packages/ui/src/custom/org-landing-page/learner-menu.svelte
+```
+
+- Props: `account: LandingLearnerAccount`, `authAction?`, `theme: OrgLandingPageTheme`.
+- Uses `base/popover` for the shell, `custom/user-avatar` for the trigger, `LandingButton variant="primary"` for the CTA.
+- `Popover.Content` carries `style={themeStyle(theme)}` so the portalled card inherits the landing palette.
+- The theme segmented control is a small local sub-component reading `userPrefersMode` and calling `setMode` from `@cio/ui/base/dark-mode` — the same API `ThemeToggle` uses. `markColorModeExplicit()` lives in the dashboard, so it is passed in as an `onThemeChange` callback rather than imported into the UI package.
+- All classes carry the `ui:` prefix.
+- Ships with a Storybook story at `packages/storybook/src/molecules/landing-learner-menu/` covering: member, non-member, non-member with no CTA, loading, missing avatar, missing fullname, inert, and each of the 11 themes.
+
+### Wiring
+
+Every `nav.svelte` gains the same two lines: accept `learnerAccount` and render `<LearnerMenu … theme="<key>" />` after the existing `authAction` block.
+
+### Translations
+
+New keys under `landing.learner_menu` in `apps/dashboard/src/lib/utils/translations/en.json`: `trigger_label`, `my_courses`, `my_certificates`, `account_settings`, `theme`, `continue_learning`. Existing keys reused: `settings.profile.logout`, `navigation.join_academy`, `navigation.goto_dashboard`. All other locale files updated via `cd apps/dashboard && pnpm translate`.
+
+## Implementation Order
+
+1. **Types + builder.** Add `LandingLearnerAccount` to `types.ts`; add `org-landing-learner-account.ts`; add the translation keys and run `pnpm translate`.
+2. **Component.** Build `learner-menu.svelte` + the theme segmented control. Run `pnpm --filter @cio/ui prefix` and verify with `pnpm --filter @cio/ui prefix:check`.
+3. **Storybook.** Add the story file and `fields.ts` in the same change.
+4. **Quartz wiring.** Thread `learnerAccount` through `buildOrgLandingPageProps()` and into `quartz/nav.svelte`. Verify against `prototypes/landing-learner-menu/learner-member.html`.
+5. **Remaining 10 themes.** Same two lines per `nav.svelte`; check each against `themes.html`.
+6. **Call sites.** Wire `+page.svelte`, `landing-page.svelte`, `(org-site)/courses/+page.svelte`, `course-landing-page.svelte`, and the two settings preview screens (with `inert: true`).
+7. **Verify.**
+   ```bash
+   export PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH"
+   test -f apps/dashboard/.env || cp apps/dashboard/.env.example apps/dashboard/.env
+   pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build
+   pnpm --filter @cio/ui prefix:check
+   pnpm format:check
+   ```
+8. **Manual pass** in cloud mode against the seeded tenants: `?org=udemy-test` as `student@test.com` (member), as `enterprise-student@test.com` (non-member), and logged out.
+
+## Acceptance Criteria
+
+1. Logged out, the landing nav renders exactly as it does today in all 11 themes — no avatar, no skeleton, no layout shift.
+2. Signed in as a member, the nav shows the CTA button and an avatar; the popover opens with identity, three learner items, theme row, log out, and a `Continue Learning` CTA to `/lms`.
+3. Signed in as a non-member of an open academy, the popover omits `My Courses` and `My Certificates` and the CTA reads `Join Academy` → `/join-academy`.
+4. Signed in as a non-member of an invite-only academy, or with `disableSignup`, or with a pending invite: no CTA renders in the nav or the popover; the popover still offers Account Settings, Theme and Log Out.
+5. Self-hosted admin/tutor behaviour from `getOrgLandingAuthAction()` is unchanged.
+6. `Log Out` navigates to `/logout` and the subsequent landing render shows the logged-out nav.
+7. Changing the theme in the popover persists and is in effect on arrival in `/lms`; the landing page's own appearance does not change.
+8. The popover's colours, radii and typography match the surrounding theme in all 11 themes, with no app-token or hex colour in the component.
+9. Between page load and `appInitApi` initialisation, the nav does not reflow — the skeleton occupies the avatar's final size.
+10. In the settings landing-page preview the avatar renders and the popover does not open.
+11. Keyboard: the trigger is reachable by `Tab`, `Enter` opens, arrows move between rows, `Escape` closes and restores focus.
+12. All copy resolves through translation keys; no literal strings in components; every locale file updated.
+13. A Storybook story exists covering all states listed in the Component section.
+14. Zero regression on existing features: public catalog, public course landing page, landing-page editor, `authAction` behaviour, and the LMS sidebar menu are unaffected.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Portalled popover loses `--landing-*` variables and renders unstyled or with app colours | `Popover.Content` re-applies `themeStyle(theme)`; each `nav.svelte` passes its theme key. Covered by the Storybook story across all 11 themes |
+| The theme toggle changes nothing visible on the page the learner is looking at, reading as broken | Keep the label plainly "Theme" (it is a preference, not a page switch); no dark-mode promise is made on the landing page. If support signal shows confusion, the fallback is dropping the row (Decision 7's rejected option), not adding landing dark mode |
+| 11 near-identical `nav.svelte` edits drift over time | One shared component, one prop, two lines per nav. Any styling change lands in `learner-menu.svelte` only |
+| Popover overflows on small screens or under a sticky nav | Right-aligned with an `8px` viewport inset and `z-index` above the sticky nav; mobile state is in `menu-states.html` |
+| `$profile` is briefly empty on org sites, flashing an empty identity block | `loading: true` renders a skeleton trigger and suppresses the popover until `appInitApi.isInitializedAndReady` |
+| Adding a second interactive control to the nav complicates the landing-page editor's section selection | `inert: true` in preview contexts; the `navigation` section cap keeps selecting the nav as a whole |
+| Academies that use the landing page purely as marketing may not want an account affordance | Not configurable in v1 by design (Non-Goals). If asked for, it becomes a `landingpage.navigation.showAccountMenu` boolean — additive, no migration |

--- a/prd/landing-learner-menu/README.md
+++ b/prd/landing-learner-menu/README.md
@@ -8,7 +8,7 @@
 
 UX for this feature comes from the prototype folder, not from prose. Where this document and a prototype disagree on a UI detail, **the prototype wins** and this document must be corrected.
 
-```
+```text
 prototypes/landing-learner-menu/index.html
 ```
 
@@ -92,10 +92,11 @@ Prototype: `learner-member.html`, `themes.html`.
 
 - The avatar renders as the last element in the landing nav's right-hand cluster, after the CTA button, with a `12px` gap.
 - Trigger is a `32px` circular button showing `UserAvatar`; on hover and on open it gains a ring in `--landing-border`; focus-visible gets a `--landing-accent` ring, matching `LandingButton`.
-- Accessible name comes from a translation key, not the person's name: `landing.learner_menu.trigger_label` → "Account menu". `aria-haspopup="menu"`, `aria-expanded` reflects open state.
+- Accessible name comes from a translation key with the account interpolated, so a screen-reader user learns which account is signed in without opening the card: `landing.learner_menu.trigger_label` → "Account menu, signed in as {email}" (falls back to "Account menu" when the email is null). `aria-haspopup="menu"`, `aria-expanded` reflects open state.
 - The trigger renders **only** when the learner is signed in and `appInitApi` has initialised. States:
   - **Logged out** — no avatar, nav is byte-identical to today.
   - **Signed in, not yet initialised** — a `32px` skeleton circle in `--landing-border-soft` occupies the slot, so the nav does not reflow when data lands. The existing loading behaviour of the CTA button (`authAction.loading`) is unchanged.
+    **This state must be driven by the server-known session, not by `$user.isLoggedIn`.** `defaultUserState.isLoggedIn` is `false` and root `+layout.svelte` only flips it inside `onMount`, independently of `appInitApi`. Keying off the store would render three successive nav layouts for a signed-in learner — nothing, then skeleton, then avatar — which violates AC-9. The builder takes the session from `data.locals.user` (available on the first server render) and uses `appInitApi.isInitializedAndReady` only to decide skeleton vs. avatar.
   - **Signed in, initialised** — avatar renders.
 - On mobile (`< 768px`) the nav's centre links are already hidden; the avatar stays visible and the CTA button collapses to icon-only. The popover anchors to the right edge with an `8px` viewport inset.
 
@@ -116,11 +117,16 @@ Card is `280px` wide, `--landing-card` background, `--landing-border` hairline, 
 | Theme | `landing.learner_menu.theme` label left, 3-button segmented control right (light / dark / system) | Sets app/LMS preference; popover stays open on click |
 | Divider | | |
 | Log Out | `settings.profile.logout` (existing key) with a `log-out` icon on the right | → `/logout` |
-| CTA | Full-width filled `LandingButton variant="primary"`, label `navigation.goto_lms` rendered as "Continue Learning" | → `/lms` |
+| CTA | Full-width filled `LandingButton variant="primary"`, label and href taken verbatim from `authAction` (`landing.learner_menu.continue_learning` → "Continue Learning") | → `/lms` |
 
 - Every row except Theme closes the popover on activation.
 - Item rows are `36px` tall, `14px` text in `--landing-fg`, hover background `--landing-button-tertiary-bg-hover`.
-- Keyboard: `Escape` closes and returns focus to the trigger; `Tab` moves through rows in visual order; arrow keys move between rows.
+- **Focus model.** The card is a `menu`, but it also contains two controls that are not destinations, so the two mechanisms are scoped rather than mixed:
+  - The link rows (`My Courses`, `My Certificates`, `Account Settings`, `Log Out`) are `role="menuitem"` and form a **single roving-tabindex group**: exactly one carries `tabindex="0"`, arrow keys move between them and wrap, `Home`/`End` jump to the ends.
+  - The theme segmented control and the CTA button are **not** menu items. They sit outside the roving group as ordinary tab stops, in visual order: roving group → theme control (its three buttons are a `radiogroup`, arrow keys move within it) → CTA.
+  - So `Tab` moves *between* those three zones, and arrow keys move *within* whichever zone has focus. `Tab` does not step through every link row.
+  - The identity block is presentational: `aria-hidden` from the menu's perspective, not focusable, and announced instead through the trigger's `aria-label` (`Account menu, signed in as <email>`).
+  - `Escape` closes from anywhere in the card and returns focus to the trigger. Focus is trapped inside the card while open.
 
 ### FR-3 — Popover content, signed in but not a member
 
@@ -143,7 +149,8 @@ Prototype: `themes.html`.
 ### FR-5 — Landing page editor preview
 
 - In the settings landing-page preview and the `/settings/landingpage/edit` screen, the avatar renders (so the academy owner sees the real nav) but the popover does **not** open, matching how `disableCourseLinks` neutralises course links today.
-- The trigger is `aria-disabled` and non-focusable in that context; the `navigation` editable section cap continues to select the nav as a whole.
+- `aria-disabled` and non-focusability are **not** sufficient — they do not block pointer, `Enter`, `Space`, or programmatic activation. When `account.inert` is true the component must additionally: never mount `Popover.Root` in an openable state (render the trigger as a plain `<span>`, not a `<button>`), and render every row and the CTA as non-interactive elements rather than `<a href>`/`<button>` — so no code path can reach `/logout` or `/lms` from a preview.
+- The `navigation` editable section cap continues to select the nav as a whole.
 
 ### FR-6 — Coverage
 
@@ -219,12 +226,29 @@ export function getOrgLandingLearnerAccount({
 }
 ```
 
-- `getOrgLandingAuthAction()` is **not modified**. The CTA label and href the popover renders are the ones it already returns, passed straight through — so the menu can never disagree with the nav button.
-- Both helpers are called from the four call sites that already build `authAction`, and the result is threaded through `buildOrgLandingPageProps()` as a new optional argument.
+- **`authAction` stays the single source of truth for the CTA.** The popover renders the label and href `getOrgLandingAuthAction()` returns, passed straight through, so the nav button and the popover CTA can never diverge by locale or by state.
+- `getOrgLandingAuthAction()` changes in exactly one place: the member branch returns `t.get('landing.learner_menu.continue_learning')` instead of `t.get('navigation.goto_lms')`. `navigation.goto_lms` keeps its current copy ("Go to LMS") and its other consumers — `components/Navigation/index.svelte` and `routes/invite/[hash]/+page.svelte` — are untouched.
+- The three call sites that build an `authAction` inline for the `/lms` case (`course-landing-page.svelte`, `settings/pages/landingpage.svelte`, `settings/landingpage/edit/+page.svelte`) switch to the same key, so every landing surface says "Continue Learning".
+- **`profile.email` may be `null`** (`TProfile.email` is nullable). The builder coerces to `''` and the component omits the muted line, the same fallback the missing-`fullname` case uses.
+
+#### Producer paths
+
+There are **six** places that build landing props, and only four go through `buildOrgLandingPageProps()`. The two that bypass it need the same wiring or the menu silently disappears from surfaces FR-6 requires:
+
+| # | Call site | Builder | `learnerAccount` |
+| --- | --- | --- | --- |
+| 1 | `routes/+page.svelte` (org-site root) | `buildOrgLandingPageProps()` | live |
+| 2 | `features/org/components/landing-page/landing-page.svelte` | `buildOrgLandingPageProps()` | live |
+| 3 | `features/settings/pages/landingpage.svelte` (preview) | `buildOrgLandingPageProps()` | `inert: true` |
+| 4 | `routes/(app)/org/[slug]/settings/landingpage/edit/+page.svelte` (preview) | `buildOrgLandingPageProps()` | `inert: true` |
+| 5 | `routes/(org-site)/courses/+page.svelte` (public catalog) | **none** — passes `authAction` straight into `NavComponent` | live, passed directly as a new `NavComponent` prop |
+| 6 | `features/ui/course-landing-page/course-landing-page.svelte` | **`buildCourseLandingPageProps()`** (separate builder in `course-landing-page/utils.ts`) | live, via a new optional argument on that builder |
+
+`buildOrgLandingPageProps()` and `buildCourseLandingPageProps()` each take `learnerAccount` as a new optional argument; paths 5 and 6 are the ones an implementer is most likely to miss.
 
 ### Component
 
-```
+```text
 packages/ui/src/custom/org-landing-page/learner-menu.svelte
 ```
 
@@ -241,7 +265,7 @@ Every `nav.svelte` gains the same two lines: accept `learnerAccount` and render 
 
 ### Translations
 
-New keys under `landing.learner_menu` in `apps/dashboard/src/lib/utils/translations/en.json`: `trigger_label`, `my_courses`, `my_certificates`, `account_settings`, `theme`, `continue_learning`. Existing keys reused: `settings.profile.logout`, `navigation.join_academy`, `navigation.goto_dashboard`. All other locale files updated via `cd apps/dashboard && pnpm translate`.
+New keys under `landing.learner_menu` in `apps/dashboard/src/lib/utils/translations/en.json`: `trigger_label` (takes an `{email}` placeholder), `trigger_label_anonymous`, `my_courses`, `my_certificates`, `account_settings`, `theme`, `continue_learning`. Existing keys reused: `settings.profile.logout`, `navigation.join_academy`, `navigation.goto_dashboard`. All other locale files updated via `cd apps/dashboard && pnpm translate`.
 
 ## Implementation Order
 
@@ -250,8 +274,9 @@ New keys under `landing.learner_menu` in `apps/dashboard/src/lib/utils/translati
 3. **Storybook.** Add the story file and `fields.ts` in the same change.
 4. **Quartz wiring.** Thread `learnerAccount` through `buildOrgLandingPageProps()` and into `quartz/nav.svelte`. Verify against `prototypes/landing-learner-menu/learner-member.html`.
 5. **Remaining 10 themes.** Same two lines per `nav.svelte`; check each against `themes.html`.
-6. **Call sites.** Wire `+page.svelte`, `landing-page.svelte`, `(org-site)/courses/+page.svelte`, `course-landing-page.svelte`, and the two settings preview screens (with `inert: true`).
+6. **Call sites.** Wire all six producer paths from the table in Technical Design → Builder, including the two that bypass `buildOrgLandingPageProps()` (`(org-site)/courses/+page.svelte`, which passes props straight to `NavComponent`, and `course-landing-page.svelte`, which uses `buildCourseLandingPageProps()`). Both settings previews get `inert: true`.
 7. **Verify.**
+
    ```bash
    export PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH"
    test -f apps/dashboard/.env || cp apps/dashboard/.env.example apps/dashboard/.env
@@ -259,24 +284,30 @@ New keys under `landing.learner_menu` in `apps/dashboard/src/lib/utils/translati
    pnpm --filter @cio/ui prefix:check
    pnpm format:check
    ```
+
 8. **Manual pass** in cloud mode against the seeded tenants: `?org=udemy-test` as `student@test.com` (member), as `enterprise-student@test.com` (non-member), and logged out.
 
 ## Acceptance Criteria
 
 1. Logged out, the landing nav renders exactly as it does today in all 11 themes — no avatar, no skeleton, no layout shift.
-2. Signed in as a member, the nav shows the CTA button and an avatar; the popover opens with identity, three learner items, theme row, log out, and a `Continue Learning` CTA to `/lms`.
+2. Signed in as a member, the nav shows the CTA button and an avatar; the popover opens with identity, three learner items, theme row, log out, and a `Continue Learning` CTA (`landing.learner_menu.continue_learning`) to `/lms`.
 3. Signed in as a non-member of an open academy, the popover omits `My Courses` and `My Certificates` and the CTA reads `Join Academy` → `/join-academy`.
 4. Signed in as a non-member of an invite-only academy, or with `disableSignup`, or with a pending invite: no CTA renders in the nav or the popover; the popover still offers Account Settings, Theme and Log Out.
-5. Self-hosted admin/tutor behaviour from `getOrgLandingAuthAction()` is unchanged.
+5. Self-hosted admin/tutor behaviour from `getOrgLandingAuthAction()` is unchanged; the helper's only change is the member branch's label key.
 6. `Log Out` navigates to `/logout` and the subsequent landing render shows the logged-out nav.
 7. Changing the theme in the popover persists and is in effect on arrival in `/lms`; the landing page's own appearance does not change.
 8. The popover's colours, radii and typography match the surrounding theme in all 11 themes, with no app-token or hex colour in the component.
 9. Between page load and `appInitApi` initialisation, the nav does not reflow — the skeleton occupies the avatar's final size.
 10. In the settings landing-page preview the avatar renders and the popover does not open.
-11. Keyboard: the trigger is reachable by `Tab`, `Enter` opens, arrows move between rows, `Escape` closes and restores focus.
-12. All copy resolves through translation keys; no literal strings in components; every locale file updated.
-13. A Storybook story exists covering all states listed in the Component section.
-14. Zero regression on existing features: public catalog, public course landing page, landing-page editor, `authAction` behaviour, and the LMS sidebar menu are unaffected.
+11. Keyboard, per the FR-2 focus model: the trigger is reachable by `Tab` and opens on `Enter` or `Space`; inside the card `Tab` moves between the three zones (link rows → theme control → CTA) and never steps row by row; arrow keys move within the focused zone and wrap; `Home`/`End` jump to the ends of the link group; focus stays trapped in the card; `Escape` closes from anywhere and restores focus to the trigger.
+12. A screen reader announces the trigger as "Account menu, signed in as <email>", the link rows as menu items, and the theme control as a radio group. The identity block is not announced twice.
+13. The menu renders on all six producer paths in the Builder table — including the public catalog and the public course landing page, which bypass `buildOrgLandingPageProps()`.
+14. In both settings previews the trigger is not a button, no row is a link, and no interaction — pointer, `Enter`, `Space`, or programmatic `.click()` — can navigate or reach `/logout`.
+15. A signed-in learner's nav renders at most two states between first paint and ready (skeleton, then avatar), never a logged-out nav first.
+16. The nav CTA and the popover CTA always show identical label and href, in every locale and every state.
+17. All copy resolves through translation keys; no literal strings in components; every locale file updated.
+18. A Storybook story exists covering all states listed in the Component section.
+19. Zero regression on existing features: public catalog, public course landing page, landing-page editor, `authAction` behaviour, and the LMS sidebar menu are unaffected.
 
 ## Risks and Mitigations
 

--- a/prototypes/landing-learner-menu/avatar.svg
+++ b/prototypes/landing-learner-menu/avatar.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <clipPath id="c"><circle cx="32" cy="32" r="32" /></clipPath>
+  </defs>
+  <g clip-path="url(#c)">
+    <rect width="64" height="64" fill="#e7ddd2" />
+    <circle cx="32" cy="25" r="12" fill="#7b5540" />
+    <path d="M20 20a12 12 0 0 1 24 0c0 2-2 1-4-1s-5 3-10 3-6-4-8-2-2 2-2 0z" fill="#2b1d16" />
+    <path d="M8 64c1.5-13 11-20 24-20s22.5 7 24 20z" fill="#2f4f6f" />
+    <path d="M26 44h12l-6 8z" fill="#f4f2ee" />
+  </g>
+</svg>

--- a/prototypes/landing-learner-menu/index.html
+++ b/prototypes/landing-learner-menu/index.html
@@ -1,0 +1,210 @@
+<!doctype html>
+<html lang="en" data-landing-theme="quartz">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Landing learner menu — prototype map</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="landing-theme.css" />
+    <style>
+      body {
+        padding: 0 0 120px;
+      }
+      .head {
+        border-bottom: 1px solid var(--landing-border);
+        padding: 64px 0 44px;
+      }
+      .head .eyebrow {
+        font-size: 11.5px;
+        letter-spacing: 0.09em;
+        text-transform: uppercase;
+        color: var(--landing-fg-faint);
+      }
+      .head h1 {
+        margin-top: 12px;
+        font-size: 42px;
+        max-width: 760px;
+      }
+      .head p {
+        margin-top: 16px;
+        max-width: 660px;
+        color: var(--landing-fg-muted);
+        font-size: 15.5px;
+      }
+      .head .prd {
+        margin-top: 22px;
+        display: inline-flex;
+        gap: 8px;
+        font-size: 13px;
+        color: var(--landing-fg-muted);
+      }
+      .head .prd code {
+        background: var(--landing-card);
+        border: 1px solid var(--landing-border);
+        padding: 3px 8px;
+        border-radius: 5px;
+        font-size: 12.5px;
+      }
+      .group {
+        padding: 40px 0 0;
+      }
+      .group h2 {
+        font-size: 13px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--landing-fg-faint);
+        font-weight: 600;
+      }
+      .cards {
+        margin-top: 18px;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        gap: 16px;
+      }
+      .card {
+        display: block;
+        background: var(--landing-card);
+        border: 1px solid var(--landing-border);
+        border-radius: var(--landing-radius-card);
+        padding: 20px;
+        transition:
+          transform 0.16s cubic-bezier(0.2, 0.9, 0.3, 1.1),
+          border-color 0.16s;
+      }
+      .card:hover {
+        transform: translateY(-2px);
+        border-color: var(--landing-fg);
+      }
+      .card h3 {
+        font-size: 16.5px;
+      }
+      .card p {
+        margin-top: 8px;
+        font-size: 13.5px;
+        color: var(--landing-fg-muted);
+      }
+      .card .file {
+        margin-top: 14px;
+        font-size: 11.5px;
+        color: var(--landing-fg-faint);
+        font-family: ui-monospace, monospace;
+      }
+      .decisions {
+        margin-top: 44px;
+        border-top: 1px solid var(--landing-border);
+        padding-top: 28px;
+      }
+      .decisions ol {
+        margin: 16px 0 0;
+        padding-left: 20px;
+        max-width: 760px;
+        font-size: 14px;
+        color: var(--landing-fg-muted);
+        line-height: 1.7;
+      }
+      .decisions ol b {
+        color: var(--landing-fg);
+        font-weight: 600;
+      }
+      @media (max-width: 700px) {
+        .head h1 {
+          font-size: 30px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="head">
+      <div class="shell">
+        <div class="eyebrow">Prototype · UX source of truth</div>
+        <h1>Learner account menu on the academy landing page</h1>
+        <p>
+          A signed-in learner arriving at an academy's front door should be able to see who they are
+          signed in as, reach their courses and certificates, set their theme, and sign out — without
+          entering the LMS first.
+        </p>
+        <div class="prd"><span>Spec:</span> <code>prd/landing-learner-menu/README.md</code></div>
+      </div>
+    </div>
+
+    <div class="shell">
+      <section class="group">
+        <h2>Learner journey</h2>
+        <div class="cards">
+          <a class="card" href="learner-member.html">
+            <h3>Signed in · member →</h3>
+            <p>
+              The main screen. Nav shows Continue Learning plus the avatar; the popover opens on load
+              so the whole card is visible.
+            </p>
+            <div class="file">learner-member.html</div>
+          </a>
+          <a class="card" href="learner-non-member.html">
+            <h3>Signed in · not a member →</h3>
+            <p>
+              Avatar still renders. Learner destinations drop out, CTA becomes Join Academy.
+            </p>
+            <div class="file">learner-non-member.html</div>
+          </a>
+          <a class="card" href="learner-logged-out.html">
+            <h3>Logged out →</h3>
+            <p>The unchanged baseline. No avatar, no skeleton, no reserved slot.</p>
+            <div class="file">learner-logged-out.html</div>
+          </a>
+        </div>
+      </section>
+
+      <section class="group">
+        <h2>Component reference</h2>
+        <div class="cards">
+          <a class="card" href="menu-states.html">
+            <h3>Every state →</h3>
+            <p>
+              Member, non-member, invite-only, loading skeleton, missing avatar and name, editor
+              preview, and mobile — side by side.
+            </p>
+            <div class="file">menu-states.html</div>
+          </a>
+          <a class="card" href="themes.html">
+            <h3>Theme fidelity →</h3>
+            <p>
+              The same component in quartz, bold, terminal, editorial and vibrant, driven entirely by
+              <code>--landing-*</code> variables.
+            </p>
+            <div class="file">themes.html</div>
+          </a>
+        </div>
+      </section>
+
+      <section class="decisions">
+        <h2 style="font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--landing-fg-faint)">
+          Decisions these screens encode
+        </h2>
+        <ol>
+          <li><b>CTA button + avatar</b> — the avatar does not replace the nav button.</li>
+          <li><b>The CTA repeats</b> at the bottom of the card, filled and full width.</li>
+          <li><b>Continue Learning goes to /lms</b> — no resume-last-lesson, no progress fetch in v1.</li>
+          <li><b>Items:</b> My Courses, My Certificates, Account Settings, Theme, Log Out.</li>
+          <li><b>Non-members keep the avatar</b> and get Join Academy, subject to existing invite-only gating.</li>
+          <li><b>Staff see what learners see</b> — no Dashboard or edit shortcuts.</li>
+          <li>
+            <b>Theme sets the app/LMS preference</b>, not this page. Landing themes are fixed
+            palettes with no dark variant.
+          </li>
+          <li><b>One shared component</b> dropped into all 11 theme navs.</li>
+        </ol>
+      </section>
+    </div>
+
+    <div class="proto-bar">
+      <span class="proto-tag">Start page</span>
+      <a href="learner-member.html">Member</a>
+      <a href="learner-non-member.html">Non-member</a>
+      <a href="learner-logged-out.html">Logged out</a>
+      <a href="menu-states.html">States</a>
+      <a href="themes.html">Themes</a>
+    </div>
+
+    <script src="menu.js"></script>
+  </body>
+</html>

--- a/prototypes/landing-learner-menu/landing-theme.css
+++ b/prototypes/landing-learner-menu/landing-theme.css
@@ -1,0 +1,583 @@
+/*
+  Landing theme tokens for the learner-menu prototypes.
+
+  Mirrors packages/ui/src/custom/org-landing-page/theme-vars-base.ts and the
+  per-theme vars.ts files. `data-landing-theme` on <html> swaps the palette the
+  same way `themeStyle(theme)` does at runtime.
+
+  Landing themes have NO light/dark variants — each theme is one fixed palette.
+  That is the constraint this whole feature has to live inside.
+*/
+
+/* ---------- quartz (default) ---------- */
+:root,
+[data-landing-theme='quartz'] {
+  --landing-bg: #f3f3f4;
+  --landing-bg-section: #ffffff;
+  --landing-card: #ffffff;
+  --landing-card-soft: #fafafb;
+  --landing-fg: #111114;
+  --landing-fg-muted: #6e6e77;
+  --landing-fg-faint: #9a9aa3;
+  --landing-border: #e3e3e6;
+  --landing-border-soft: #ededf0;
+  --landing-accent: #111114;
+  --landing-accent-fg: #ffffff;
+  --landing-button-primary-bg: #111114;
+  --landing-button-primary-fg: #ffffff;
+  --landing-button-primary-bg-hover: #2b2b33;
+  --landing-button-secondary-bg: #ffffff;
+  --landing-button-secondary-fg: #111114;
+  --landing-button-secondary-border: #e3e3e6;
+  --landing-button-secondary-bg-hover: #fafafb;
+  --landing-button-tertiary-fg: #111114;
+  --landing-button-tertiary-bg-hover: #ededf0;
+  --landing-heading-weight: 600;
+  --landing-heading-tracking: -0.032em;
+  --landing-radius-card: 0px;
+  --landing-radius-pill: 9999px;
+  --landing-shadow-card: 0 18px 46px -22px rgba(17, 17, 20, 0.3);
+  --landing-divider: 1px solid #e3e3e6;
+  --landing-font: 'Inter', system-ui, -apple-system, sans-serif;
+  --landing-mono-family: ui-sans-serif, system-ui, sans-serif;
+}
+
+/* ---------- bold ---------- */
+[data-landing-theme='bold'] {
+  --landing-bg: #fffdf7;
+  --landing-bg-section: #ffffff;
+  --landing-card: #ffffff;
+  --landing-card-soft: #fff8e6;
+  --landing-fg: #0a0a0a;
+  --landing-fg-muted: #4d4d4d;
+  --landing-fg-faint: #7a7a7a;
+  --landing-border: #0a0a0a;
+  --landing-border-soft: #d6d2c4;
+  --landing-accent: #ff5c26;
+  --landing-accent-fg: #ffffff;
+  --landing-button-primary-bg: #0a0a0a;
+  --landing-button-primary-fg: #ffffff;
+  --landing-button-primary-bg-hover: #ff5c26;
+  --landing-button-tertiary-fg: #0a0a0a;
+  --landing-button-tertiary-bg-hover: #ffe9c9;
+  --landing-heading-weight: 800;
+  --landing-heading-tracking: -0.04em;
+  --landing-radius-card: 14px;
+  --landing-shadow-card: 6px 6px 0 #0a0a0a;
+  --landing-divider: 2px solid #0a0a0a;
+  --landing-font: 'Inter', system-ui, sans-serif;
+}
+
+/* ---------- terminal ---------- */
+[data-landing-theme='terminal'] {
+  --landing-bg: #0b0f0c;
+  --landing-bg-section: #0e1310;
+  --landing-card: #0e1310;
+  --landing-card-soft: #121814;
+  --landing-fg: #d7f5df;
+  --landing-fg-muted: #7fa98c;
+  --landing-fg-faint: #557a61;
+  --landing-border: #1e2b22;
+  --landing-border-soft: #17211b;
+  --landing-accent: #4ade80;
+  --landing-accent-fg: #05130a;
+  --landing-button-primary-bg: #4ade80;
+  --landing-button-primary-fg: #05130a;
+  --landing-button-primary-bg-hover: #86efac;
+  --landing-button-tertiary-fg: #d7f5df;
+  --landing-button-tertiary-bg-hover: #16211a;
+  --landing-heading-weight: 500;
+  --landing-heading-tracking: -0.01em;
+  --landing-radius-card: 4px;
+  --landing-shadow-card: none;
+  --landing-divider: 1px solid #1e2b22;
+  --landing-font: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+  --landing-mono-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+/* ---------- editorial ---------- */
+[data-landing-theme='editorial'] {
+  --landing-bg: #fbf9f4;
+  --landing-bg-section: #ffffff;
+  --landing-card: #ffffff;
+  --landing-card-soft: #f6f2e9;
+  --landing-fg: #1c1a17;
+  --landing-fg-muted: #6b6459;
+  --landing-fg-faint: #989184;
+  --landing-border: #ddd6c8;
+  --landing-border-soft: #ebe5da;
+  --landing-accent: #7a2e2e;
+  --landing-accent-fg: #ffffff;
+  --landing-button-primary-bg: #1c1a17;
+  --landing-button-primary-fg: #fbf9f4;
+  --landing-button-primary-bg-hover: #7a2e2e;
+  --landing-button-tertiary-fg: #1c1a17;
+  --landing-button-tertiary-bg-hover: #f0ebe0;
+  --landing-heading-weight: 500;
+  --landing-heading-tracking: -0.02em;
+  --landing-radius-card: 2px;
+  --landing-shadow-card: none;
+  --landing-divider: 1px solid #ddd6c8;
+  --landing-font: 'Georgia', 'Times New Roman', serif;
+}
+
+/* ---------- vibrant ---------- */
+[data-landing-theme='vibrant'] {
+  --landing-bg: #0f0524;
+  --landing-bg-section: #17082f;
+  --landing-card: #1c0a38;
+  --landing-card-soft: #24104a;
+  --landing-fg: #f6f0ff;
+  --landing-fg-muted: #b9a6d9;
+  --landing-fg-faint: #8b78ad;
+  --landing-border: #34195e;
+  --landing-border-soft: #2a1350;
+  --landing-accent: #c084fc;
+  --landing-accent-fg: #16062b;
+  --landing-button-primary-bg: linear-gradient(92deg, #c084fc, #f472b6);
+  --landing-button-primary-fg: #16062b;
+  --landing-button-primary-bg-hover: linear-gradient(92deg, #d8b4fe, #f9a8d4);
+  --landing-button-tertiary-fg: #f6f0ff;
+  --landing-button-tertiary-bg-hover: #2a1350;
+  --landing-heading-weight: 700;
+  --landing-heading-tracking: -0.035em;
+  --landing-radius-card: 18px;
+  --landing-shadow-card: 0 24px 60px -24px rgba(192, 132, 252, 0.5);
+  --landing-divider: 1px solid #34195e;
+  --landing-font: 'Inter', system-ui, sans-serif;
+}
+
+/* =======================================================================
+   Base page
+   ======================================================================= */
+* {
+  box-sizing: border-box;
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+body {
+  background: var(--landing-bg);
+  color: var(--landing-fg);
+  font-family: var(--landing-font);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+button {
+  font: inherit;
+  cursor: pointer;
+}
+h1,
+h2,
+h3 {
+  margin: 0;
+  font-weight: var(--landing-heading-weight);
+  letter-spacing: var(--landing-heading-tracking);
+  line-height: 1.08;
+}
+p {
+  margin: 0;
+}
+ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+img,
+svg {
+  display: block;
+}
+
+.shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+/* =======================================================================
+   Nav — mirrors quartz/nav.svelte
+   ======================================================================= */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  background: color-mix(in oklab, var(--landing-bg) 85%, transparent);
+  backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--landing-border-soft);
+}
+.nav-in {
+  max-width: 1200px;
+  margin: 0 auto;
+  height: 58px;
+  padding: 0 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: -0.022em;
+}
+.logo i {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  background: var(--landing-fg);
+  position: relative;
+  flex: none;
+}
+.logo i::after {
+  content: '';
+  position: absolute;
+  inset: 5px;
+  border-radius: 3px;
+  background: var(--landing-bg);
+}
+.nav-mid {
+  display: flex;
+  gap: 28px;
+}
+.nav-mid a {
+  font-size: 14px;
+  color: var(--landing-fg-muted);
+  transition: color 0.15s;
+}
+.nav-mid a:hover {
+  color: var(--landing-fg);
+}
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* =======================================================================
+   Buttons — mirrors landing-button.svelte
+   ======================================================================= */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 36px;
+  padding: 0 16px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+.btn-sm {
+  height: 32px;
+  padding: 0 12px;
+}
+.btn-lg {
+  height: 44px;
+  padding: 0 22px;
+}
+.btn-primary {
+  background: var(--landing-button-primary-bg);
+  color: var(--landing-button-primary-fg);
+}
+.btn-primary:hover {
+  background: var(--landing-button-primary-bg-hover);
+}
+.btn-secondary {
+  background: var(--landing-button-secondary-bg, var(--landing-card));
+  color: var(--landing-button-secondary-fg, var(--landing-fg));
+  border-color: var(--landing-button-secondary-border, var(--landing-border));
+}
+.btn-full {
+  width: 100%;
+}
+
+/* =======================================================================
+   Learner menu — the feature
+   ======================================================================= */
+.lm {
+  position: relative;
+}
+
+.lm-trigger {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+  background: transparent;
+  display: grid;
+  place-items: center;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+}
+.lm-trigger img,
+.lm-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  object-fit: cover;
+  display: block;
+}
+.lm-trigger:hover,
+.lm-trigger[aria-expanded='true'] {
+  border-color: var(--landing-border);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--landing-fg) 8%, transparent);
+}
+.lm-trigger:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--landing-accent) 45%, transparent);
+}
+.lm-trigger[aria-disabled='true'] {
+  cursor: default;
+}
+
+/* fallback avatar (no avatarUrl) */
+.lm-avatar-fallback {
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  background: var(--landing-card-soft);
+  border: 1px solid var(--landing-border);
+  display: grid;
+  place-items: center;
+  color: var(--landing-fg-muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+/* loading skeleton — same 32px so the nav never reflows */
+.lm-skeleton {
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  background: var(--landing-border-soft);
+  animation: lm-pulse 1.4s ease-in-out infinite;
+}
+@keyframes lm-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+.lm-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 280px;
+  background: var(--landing-card);
+  border: 1px solid var(--landing-border);
+  border-radius: var(--landing-radius-card);
+  box-shadow: var(--landing-shadow-card);
+  padding: 6px;
+  z-index: 80;
+  opacity: 0;
+  transform: translateY(-6px) scale(0.98);
+  transform-origin: top right;
+  pointer-events: none;
+  transition:
+    opacity 0.14s ease,
+    transform 0.14s cubic-bezier(0.2, 0.9, 0.3, 1.2);
+}
+.lm.open .lm-panel {
+  opacity: 1;
+  transform: none;
+  pointer-events: auto;
+}
+/* static panels (menu-states.html, themes.html) render open, no animation */
+.lm-panel.static {
+  position: static;
+  opacity: 1;
+  transform: none;
+  pointer-events: auto;
+  width: 280px;
+}
+
+.lm-identity {
+  padding: 10px 10px 12px;
+}
+.lm-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--landing-fg);
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.lm-email {
+  font-size: 13px;
+  color: var(--landing-fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.lm-sep {
+  height: 0;
+  border-top: var(--landing-divider);
+  margin: 4px -6px;
+}
+
+.lm-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  height: 36px;
+  padding: 0 10px;
+  border-radius: calc(var(--landing-radius-card) + 4px);
+  font-size: 14px;
+  color: var(--landing-fg);
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  transition: background 0.12s;
+}
+.lm-item:hover {
+  background: var(--landing-button-tertiary-bg-hover);
+}
+.lm-item:focus-visible {
+  outline: none;
+  background: var(--landing-button-tertiary-bg-hover);
+  box-shadow: inset 0 0 0 2px color-mix(in oklab, var(--landing-accent) 40%, transparent);
+}
+.lm-item svg {
+  color: var(--landing-fg-muted);
+  flex: none;
+}
+
+/* theme row */
+.lm-theme-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 10px;
+  font-size: 14px;
+}
+.lm-seg {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--landing-border);
+  border-radius: 9999px;
+  background: var(--landing-card-soft);
+}
+.lm-seg button {
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border: none;
+  background: transparent;
+  border-radius: 9999px;
+  color: var(--landing-fg-muted);
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+.lm-seg button:hover {
+  color: var(--landing-fg);
+}
+.lm-seg button[aria-pressed='true'] {
+  background: var(--landing-card);
+  color: var(--landing-fg);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+}
+
+.lm-cta {
+  padding: 6px 4px 4px;
+}
+
+.lm-note {
+  padding: 0 10px 8px;
+  font-size: 12px;
+  color: var(--landing-fg-faint);
+  line-height: 1.4;
+}
+
+/* =======================================================================
+   Prototype chrome — not part of the product
+   ======================================================================= */
+.proto-bar {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border-radius: 9999px;
+  background: rgba(16, 16, 20, 0.92);
+  color: #fff;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 12px;
+  box-shadow: 0 12px 34px -12px rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(8px);
+}
+.proto-bar a,
+.proto-bar button,
+.proto-bar select {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.12);
+  border: none;
+  border-radius: 9999px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: inherit;
+}
+.proto-bar a:hover,
+.proto-bar button:hover {
+  background: rgba(255, 255, 255, 0.24);
+}
+.proto-bar select option {
+  color: #111;
+}
+.proto-tag {
+  opacity: 0.55;
+  padding-left: 4px;
+}
+
+@media (max-width: 768px) {
+  .nav-mid {
+    display: none;
+  }
+  .shell,
+  .nav-in {
+    padding: 0 18px;
+  }
+  .lm-panel {
+    right: -8px;
+    width: min(280px, calc(100vw - 32px));
+  }
+  .nav-right .btn-label {
+    display: none;
+  }
+  .nav-right .btn {
+    padding: 0 10px;
+  }
+}

--- a/prototypes/landing-learner-menu/learner-logged-out.html
+++ b/prototypes/landing-learner-menu/learner-logged-out.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en" data-landing-theme="quartz">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SMI Consulting — logged out (unchanged baseline)</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="landing-theme.css" />
+    <style>
+      .hero {
+        padding: 84px 0 64px;
+        max-width: 780px;
+      }
+      .hero h1 {
+        font-size: 56px;
+      }
+      .hero h1 span {
+        color: var(--landing-fg-muted);
+      }
+      .hero .lede {
+        margin-top: 22px;
+        font-size: 17px;
+        color: var(--landing-fg-muted);
+        max-width: 620px;
+      }
+      .hero-acts {
+        margin-top: 30px;
+        display: flex;
+        gap: 12px;
+      }
+      .resume {
+        margin-top: 40px;
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 14px;
+        border: 1px solid var(--landing-border);
+        background: var(--landing-card);
+        border-radius: var(--landing-radius-card);
+        font-size: 13.5px;
+        color: var(--landing-fg-muted);
+      }
+      .resume b {
+        color: var(--landing-fg);
+        font-weight: 600;
+      }
+      .catalog {
+        border-top: 1px solid var(--landing-border);
+        padding: 44px 0 90px;
+      }
+      .eyebrow {
+        font-size: 11.5px;
+        letter-spacing: 0.09em;
+        text-transform: uppercase;
+        color: var(--landing-fg-faint);
+      }
+      .grid {
+        margin-top: 24px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 18px;
+      }
+      .card {
+        background: var(--landing-card);
+        border: 1px solid var(--landing-border);
+        border-radius: var(--landing-radius-card);
+        padding: 20px;
+      }
+      .card h3 {
+        font-size: 17px;
+      }
+      .card p {
+        margin-top: 8px;
+        font-size: 13.5px;
+        color: var(--landing-fg-muted);
+      }
+      .card .meta {
+        margin-top: 16px;
+        font-size: 12px;
+        color: var(--landing-fg-faint);
+      }
+      @media (max-width: 900px) {
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .hero h1 {
+          font-size: 38px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="nav">
+      <div class="nav-in">
+        <a class="logo" href="index.html"><i></i> SMI Consulting</a>
+        <nav class="nav-mid">
+          <a href="#catalog">Courses</a><a href="#">Certifications</a><a href="#">Pricing</a><a href="#">Company</a>
+        </nav>
+
+        <div class="nav-right">
+          <!-- Logged out: byte-identical to today. No avatar, no skeleton, no extra slot. -->
+          <a class="btn btn-sm btn-primary" href="#">
+            <span class="btn-label">Login</span>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M5 12h14M13 6l6 6-6 6" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <div class="shell">
+      <header class="hero">
+        <h1>Compliance and product training, <span>done properly.</span></h1>
+        <p class="lede">
+          Certification tracks built by practising consultants. Finish a track, earn a verifiable
+          certificate, and prove it to your auditor.
+        </p>
+        <div class="hero-acts">
+          <a class="btn btn-lg btn-primary" href="#catalog">Browse catalog</a>
+          <a class="btn btn-lg btn-secondary" href="#">Talk to us</a>
+        </div>
+      </header>
+    </div>
+
+    <div class="catalog">
+      <div class="shell" id="catalog">
+        <div class="eyebrow">Catalog</div>
+        <div class="grid">
+          <div class="card">
+            <h3>SOC 2 Security Basics</h3>
+            <p>The controls, the evidence, and what an auditor actually asks for.</p>
+            <div class="meta">8 lessons · Certificate</div>
+          </div>
+          <div class="card">
+            <h3>HIPAA Awareness 2026</h3>
+            <p>Annual refresher for everyone who touches protected health information.</p>
+            <div class="meta">6 lessons · Certificate</div>
+          </div>
+          <div class="card">
+            <h3>Incident Response Drills</h3>
+            <p>Run a tabletop exercise your team will not sleep through.</p>
+            <div class="meta">11 lessons · Certificate</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="proto-bar">
+      <span class="proto-tag">Logged out · AC-1 baseline</span>
+      <a href="index.html">Map</a>
+      <a href="learner-non-member.html">Non-member</a>
+      <a href="learner-member.html">Member</a>
+      <a href="menu-states.html">States</a>
+      <select data-proto-theme aria-label="Landing theme">
+        <option value="quartz">quartz</option>
+        <option value="bold">bold</option>
+        <option value="terminal">terminal</option>
+        <option value="editorial">editorial</option>
+        <option value="vibrant">vibrant</option>
+      </select>
+    </div>
+
+    <script src="menu.js"></script>
+  </body>
+</html>

--- a/prototypes/landing-learner-menu/learner-member.html
+++ b/prototypes/landing-learner-menu/learner-member.html
@@ -1,0 +1,245 @@
+<!doctype html>
+<html lang="en" data-landing-theme="quartz">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SMI Consulting — signed-in learner (member)</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="landing-theme.css" />
+    <style>
+      .hero {
+        padding: 84px 0 64px;
+        max-width: 780px;
+      }
+      .hero h1 {
+        font-size: 56px;
+      }
+      .hero h1 span {
+        color: var(--landing-fg-muted);
+      }
+      .hero .lede {
+        margin-top: 22px;
+        font-size: 17px;
+        color: var(--landing-fg-muted);
+        max-width: 620px;
+      }
+      .hero-acts {
+        margin-top: 30px;
+        display: flex;
+        gap: 12px;
+      }
+      .resume {
+        margin-top: 40px;
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 14px;
+        border: 1px solid var(--landing-border);
+        background: var(--landing-card);
+        border-radius: var(--landing-radius-card);
+        font-size: 13.5px;
+        color: var(--landing-fg-muted);
+      }
+      .resume b {
+        color: var(--landing-fg);
+        font-weight: 600;
+      }
+      .catalog {
+        border-top: 1px solid var(--landing-border);
+        padding: 44px 0 90px;
+      }
+      .eyebrow {
+        font-size: 11.5px;
+        letter-spacing: 0.09em;
+        text-transform: uppercase;
+        color: var(--landing-fg-faint);
+      }
+      .grid {
+        margin-top: 24px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 18px;
+      }
+      .card {
+        background: var(--landing-card);
+        border: 1px solid var(--landing-border);
+        border-radius: var(--landing-radius-card);
+        padding: 20px;
+      }
+      .card h3 {
+        font-size: 17px;
+      }
+      .card p {
+        margin-top: 8px;
+        font-size: 13.5px;
+        color: var(--landing-fg-muted);
+      }
+      .card .meta {
+        margin-top: 16px;
+        font-size: 12px;
+        color: var(--landing-fg-faint);
+      }
+      @media (max-width: 900px) {
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .hero h1 {
+          font-size: 38px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="nav">
+      <div class="nav-in">
+        <a class="logo" href="index.html"><i></i> SMI Consulting</a>
+        <nav class="nav-mid">
+          <a href="#catalog">Courses</a><a href="#">Certifications</a><a href="#">Pricing</a><a href="#">Company</a>
+        </nav>
+
+        <div class="nav-right">
+          <!-- Existing authAction button — unchanged, still one click to the LMS -->
+          <a class="btn btn-sm btn-primary" href="#">
+            <span class="btn-label">Continue Learning</span>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M5 12h14M13 6l6 6-6 6" />
+            </svg>
+          </a>
+
+          <!-- FR-1 / FR-2: the learner menu -->
+          <div class="lm" data-open-on-load>
+            <button class="lm-trigger" aria-haspopup="menu" aria-expanded="false" aria-label="Account menu">
+              <img src="avatar.svg" alt="" />
+            </button>
+
+            <div class="lm-panel" role="menu">
+              <div class="lm-identity">
+                <div class="lm-name">Rotimi Best</div>
+                <div class="lm-email">rotimi@northwind.com</div>
+              </div>
+
+              <div class="lm-sep"></div>
+
+              <a class="lm-item" role="menuitem" href="#" tabindex="-1">
+                My Courses
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+                  <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+                </svg>
+              </a>
+              <a class="lm-item" role="menuitem" href="#" tabindex="-1">
+                My Certificates
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <circle cx="12" cy="8" r="6" />
+                  <path d="M15.5 13.5 17 22l-5-3-5 3 1.5-8.5" />
+                </svg>
+              </a>
+              <a class="lm-item" role="menuitem" href="#" tabindex="-1">
+                Account Settings
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <circle cx="12" cy="12" r="3" />
+                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6h.09A1.65 1.65 0 0 0 10.6 3.09V3a2 2 0 1 1 4 0v.09A1.65 1.65 0 0 0 16.11 4.6a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 20.4 9v.09a1.65 1.65 0 0 0 1.51 1.51H22a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                </svg>
+              </a>
+
+              <div class="lm-sep"></div>
+
+              <!-- FR-2 theme row: sets the APP/LMS preference, not this page -->
+              <div class="lm-theme-row">
+                <span>Theme</span>
+                <div class="lm-seg" role="group" aria-label="Theme">
+                  <button type="button" aria-pressed="true" title="Light">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <circle cx="12" cy="12" r="4" />
+                      <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+                    </svg>
+                  </button>
+                  <button type="button" aria-pressed="false" title="Dark">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
+                    </svg>
+                  </button>
+                  <button type="button" aria-pressed="false" title="System">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <rect x="2" y="3" width="20" height="14" rx="2" />
+                      <path d="M8 21h8M12 17v4" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+
+              <div class="lm-sep"></div>
+
+              <a class="lm-item" role="menuitem" href="#" tabindex="-1">
+                Log Out
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                  <path d="m16 17 5-5-5-5M21 12H9" />
+                </svg>
+              </a>
+
+              <!-- Decision 2: the CTA repeats at the bottom, filled, full width -->
+              <div class="lm-cta">
+                <a class="btn btn-primary btn-full" href="#">Continue Learning</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="shell">
+      <header class="hero">
+        <h1>Compliance and product training, <span>done properly.</span></h1>
+        <p class="lede">
+          Certification tracks built by practising consultants. Finish a track, earn a verifiable
+          certificate, and prove it to your auditor.
+        </p>
+        <div class="hero-acts">
+          <a class="btn btn-lg btn-primary" href="#catalog">Browse catalog</a>
+          <a class="btn btn-lg btn-secondary" href="#">Talk to us</a>
+        </div>
+      </header>
+    </div>
+
+    <div class="catalog">
+      <div class="shell" id="catalog">
+        <div class="eyebrow">Catalog</div>
+        <div class="grid">
+          <div class="card">
+            <h3>SOC 2 Security Basics</h3>
+            <p>The controls, the evidence, and what an auditor actually asks for.</p>
+            <div class="meta">8 lessons · Certificate</div>
+          </div>
+          <div class="card">
+            <h3>HIPAA Awareness 2026</h3>
+            <p>Annual refresher for everyone who touches protected health information.</p>
+            <div class="meta">6 lessons · Certificate</div>
+          </div>
+          <div class="card">
+            <h3>Incident Response Drills</h3>
+            <p>Run a tabletop exercise your team will not sleep through.</p>
+            <div class="meta">11 lessons · Certificate</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="proto-bar">
+      <span class="proto-tag">Member · menu open</span>
+      <a href="index.html">Map</a>
+      <a href="learner-non-member.html">Non-member</a>
+      <a href="learner-logged-out.html">Logged out</a>
+      <a href="menu-states.html">States</a>
+      <select data-proto-theme aria-label="Landing theme">
+        <option value="quartz">quartz</option>
+        <option value="bold">bold</option>
+        <option value="terminal">terminal</option>
+        <option value="editorial">editorial</option>
+        <option value="vibrant">vibrant</option>
+      </select>
+    </div>
+
+    <script src="menu.js"></script>
+  </body>
+</html>

--- a/prototypes/landing-learner-menu/learner-non-member.html
+++ b/prototypes/landing-learner-menu/learner-non-member.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="en" data-landing-theme="quartz">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SMI Consulting — signed in, not a member of this academy</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="landing-theme.css" />
+    <style>
+      .hero {
+        padding: 84px 0 64px;
+        max-width: 780px;
+      }
+      .hero h1 {
+        font-size: 56px;
+      }
+      .hero h1 span {
+        color: var(--landing-fg-muted);
+      }
+      .hero .lede {
+        margin-top: 22px;
+        font-size: 17px;
+        color: var(--landing-fg-muted);
+        max-width: 620px;
+      }
+      .hero-acts {
+        margin-top: 30px;
+        display: flex;
+        gap: 12px;
+      }
+      .resume {
+        margin-top: 40px;
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 14px;
+        border: 1px solid var(--landing-border);
+        background: var(--landing-card);
+        border-radius: var(--landing-radius-card);
+        font-size: 13.5px;
+        color: var(--landing-fg-muted);
+      }
+      .resume b {
+        color: var(--landing-fg);
+        font-weight: 600;
+      }
+      .catalog {
+        border-top: 1px solid var(--landing-border);
+        padding: 44px 0 90px;
+      }
+      .eyebrow {
+        font-size: 11.5px;
+        letter-spacing: 0.09em;
+        text-transform: uppercase;
+        color: var(--landing-fg-faint);
+      }
+      .grid {
+        margin-top: 24px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 18px;
+      }
+      .card {
+        background: var(--landing-card);
+        border: 1px solid var(--landing-border);
+        border-radius: var(--landing-radius-card);
+        padding: 20px;
+      }
+      .card h3 {
+        font-size: 17px;
+      }
+      .card p {
+        margin-top: 8px;
+        font-size: 13.5px;
+        color: var(--landing-fg-muted);
+      }
+      .card .meta {
+        margin-top: 16px;
+        font-size: 12px;
+        color: var(--landing-fg-faint);
+      }
+      @media (max-width: 900px) {
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .hero h1 {
+          font-size: 38px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="nav">
+      <div class="nav-in">
+        <a class="logo" href="index.html"><i></i> SMI Consulting</a>
+        <nav class="nav-mid">
+          <a href="#catalog">Courses</a><a href="#">Certifications</a><a href="#">Pricing</a><a href="#">Company</a>
+        </nav>
+
+        <div class="nav-right">
+          <!-- Existing authAction button — unchanged, still one click to the LMS -->
+          <a class="btn btn-sm btn-primary" href="#">
+            <span class="btn-label">Join Academy</span>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M5 12h14M13 6l6 6-6 6" />
+            </svg>
+          </a>
+
+          <!-- FR-1 / FR-2: the learner menu -->
+          <div class="lm" data-open-on-load>
+            <button class="lm-trigger" aria-haspopup="menu" aria-expanded="false" aria-label="Account menu">
+              <img src="avatar.svg" alt="" />
+            </button>
+
+            <div class="lm-panel" role="menu">
+              <div class="lm-identity">
+                <div class="lm-name">Dayo Adeyemi</div>
+                <div class="lm-email">dayo@contoso.com</div>
+              </div>
+
+              <div class="lm-sep"></div>
+
+              <a class="lm-item" role="menuitem" href="#" tabindex="-1">
+                Account Settings
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <circle cx="12" cy="12" r="3" />
+                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6h.09A1.65 1.65 0 0 0 10.6 3.09V3a2 2 0 1 1 4 0v.09A1.65 1.65 0 0 0 16.11 4.6a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 20.4 9v.09a1.65 1.65 0 0 0 1.51 1.51H22a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                </svg>
+              </a>
+
+              <div class="lm-sep"></div>
+
+              <!-- FR-2 theme row: sets the APP/LMS preference, not this page -->
+              <div class="lm-theme-row">
+                <span>Theme</span>
+                <div class="lm-seg" role="group" aria-label="Theme">
+                  <button type="button" aria-pressed="true" title="Light">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <circle cx="12" cy="12" r="4" />
+                      <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+                    </svg>
+                  </button>
+                  <button type="button" aria-pressed="false" title="Dark">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
+                    </svg>
+                  </button>
+                  <button type="button" aria-pressed="false" title="System">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <rect x="2" y="3" width="20" height="14" rx="2" />
+                      <path d="M8 21h8M12 17v4" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+
+              <div class="lm-sep"></div>
+
+              <a class="lm-item" role="menuitem" href="#" tabindex="-1">
+                Log Out
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                  <path d="m16 17 5-5-5-5M21 12H9" />
+                </svg>
+              </a>
+
+              <!-- Decision 2: the CTA repeats at the bottom, filled, full width -->
+              <div class="lm-note">
+                Not enrolled in this academy yet — learner destinations appear after joining.
+              </div>
+
+              <div class="lm-cta">
+                <a class="btn btn-primary btn-full" href="#">Join Academy</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="shell">
+      <header class="hero">
+        <h1>Compliance and product training, <span>done properly.</span></h1>
+        <p class="lede">
+          Certification tracks built by practising consultants. Finish a track, earn a verifiable
+          certificate, and prove it to your auditor.
+        </p>
+        <div class="hero-acts">
+          <a class="btn btn-lg btn-primary" href="#catalog">Browse catalog</a>
+          <a class="btn btn-lg btn-secondary" href="#">Talk to us</a>
+        </div>
+      </header>
+    </div>
+
+    <div class="catalog">
+      <div class="shell" id="catalog">
+        <div class="eyebrow">Catalog</div>
+        <div class="grid">
+          <div class="card">
+            <h3>SOC 2 Security Basics</h3>
+            <p>The controls, the evidence, and what an auditor actually asks for.</p>
+            <div class="meta">8 lessons · Certificate</div>
+          </div>
+          <div class="card">
+            <h3>HIPAA Awareness 2026</h3>
+            <p>Annual refresher for everyone who touches protected health information.</p>
+            <div class="meta">6 lessons · Certificate</div>
+          </div>
+          <div class="card">
+            <h3>Incident Response Drills</h3>
+            <p>Run a tabletop exercise your team will not sleep through.</p>
+            <div class="meta">11 lessons · Certificate</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="proto-bar">
+      <span class="proto-tag">Non-member · open academy</span>
+      <a href="index.html">Map</a>
+      <a href="learner-member.html">Member</a>
+      <a href="learner-logged-out.html">Logged out</a>
+      <a href="menu-states.html">States</a>
+      <select data-proto-theme aria-label="Landing theme">
+        <option value="quartz">quartz</option>
+        <option value="bold">bold</option>
+        <option value="terminal">terminal</option>
+        <option value="editorial">editorial</option>
+        <option value="vibrant">vibrant</option>
+      </select>
+    </div>
+
+    <script src="menu.js"></script>
+  </body>
+</html>

--- a/prototypes/landing-learner-menu/menu-states.html
+++ b/prototypes/landing-learner-menu/menu-states.html
@@ -1,0 +1,344 @@
+<!doctype html>
+<html lang="en" data-landing-theme="quartz">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Learner menu — every state</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="landing-theme.css" />
+    <style>
+      body {
+        padding: 40px 0 120px;
+      }
+      .page-head {
+        max-width: 760px;
+        margin-bottom: 40px;
+      }
+      .page-head h1 {
+        font-size: 30px;
+      }
+      .page-head p {
+        margin-top: 12px;
+        color: var(--landing-fg-muted);
+        font-size: 14.5px;
+      }
+      .board {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: 28px;
+        align-items: start;
+      }
+      .state {
+        border: 1px solid var(--landing-border);
+        background: var(--landing-bg-section);
+        border-radius: var(--landing-radius-card);
+        padding: 20px;
+      }
+      .state h2 {
+        font-size: 15px;
+        font-weight: 600;
+      }
+      .state .why {
+        margin: 6px 0 18px;
+        font-size: 12.5px;
+        color: var(--landing-fg-muted);
+        line-height: 1.5;
+      }
+      .state .ac {
+        margin-top: 14px;
+        font-size: 11.5px;
+        color: var(--landing-fg-faint);
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .navstrip {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 12px;
+        padding: 10px 12px;
+        border: 1px dashed var(--landing-border);
+        border-radius: 8px;
+        margin-bottom: 16px;
+      }
+      .phone {
+        width: 300px;
+        border: 1px solid var(--landing-border);
+        border-radius: 20px;
+        overflow: hidden;
+        background: var(--landing-bg);
+      }
+      .phone .nav-in {
+        padding: 0 14px;
+        gap: 10px;
+      }
+      .phone .lm-panel.static {
+        margin: 10px 14px 14px auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="shell">
+      <div class="page-head">
+        <h1>Learner menu — every state</h1>
+        <p>
+          One shared component. What changes between states is the item list and the CTA, never the
+          shell. Panels here are rendered statically so all states are visible at once; in the product
+          they are popovers anchored to the avatar.
+        </p>
+      </div>
+
+      <div class="board">
+        <!-- 1. member -->
+        <section class="state">
+          <h2>1 · Member of this academy</h2>
+          <p class="why">Signed in and enrolled. Full item list, CTA goes to the LMS.</p>
+          <div class="navstrip">
+            <a class="btn btn-sm btn-primary" href="#">Continue Learning</a>
+            <span class="lm-avatar"><img class="lm-avatar" src="avatar.svg" alt="" /></span>
+          </div>
+          <div class="lm">
+            <div class="lm-panel static">
+              <div class="lm-identity">
+                <div class="lm-name">Rotimi Best</div>
+                <div class="lm-email">rotimi@northwind.com</div>
+              </div>
+              <div class="lm-sep"></div>
+              <a class="lm-item" href="#">My Courses</a>
+              <a class="lm-item" href="#">My Certificates</a>
+              <a class="lm-item" href="#">Account Settings</a>
+              <div class="lm-sep"></div>
+              <div class="lm-theme-row">
+                <span>Theme</span>
+                <div class="lm-seg">
+                  <button type="button" aria-pressed="true">☀</button>
+                  <button type="button" aria-pressed="false">☾</button>
+                  <button type="button" aria-pressed="false">▭</button>
+                </div>
+              </div>
+              <div class="lm-sep"></div>
+              <a class="lm-item" href="#">Log Out</a>
+              <div class="lm-cta"><a class="btn btn-primary btn-full" href="#">Continue Learning</a></div>
+            </div>
+          </div>
+          <div class="ac">AC-2</div>
+        </section>
+
+        <!-- 2. non-member, open academy -->
+        <section class="state">
+          <h2>2 · Not a member · open academy</h2>
+          <p class="why">
+            Learner destinations are absent, not disabled. CTA switches to Join Academy.
+          </p>
+          <div class="navstrip">
+            <a class="btn btn-sm btn-primary" href="#">Join Academy</a>
+            <img class="lm-avatar" src="avatar.svg" alt="" />
+          </div>
+          <div class="lm">
+            <div class="lm-panel static">
+              <div class="lm-identity">
+                <div class="lm-name">Dayo Adeyemi</div>
+                <div class="lm-email">dayo@contoso.com</div>
+              </div>
+              <div class="lm-sep"></div>
+              <a class="lm-item" href="#">Account Settings</a>
+              <div class="lm-sep"></div>
+              <div class="lm-theme-row">
+                <span>Theme</span>
+                <div class="lm-seg">
+                  <button type="button" aria-pressed="true">☀</button>
+                  <button type="button" aria-pressed="false">☾</button>
+                  <button type="button" aria-pressed="false">▭</button>
+                </div>
+              </div>
+              <div class="lm-sep"></div>
+              <a class="lm-item" href="#">Log Out</a>
+              <div class="lm-note">Not enrolled in this academy yet.</div>
+              <div class="lm-cta"><a class="btn btn-primary btn-full" href="#">Join Academy</a></div>
+            </div>
+          </div>
+          <div class="ac">AC-3</div>
+        </section>
+
+        <!-- 3. non-member, invite-only -->
+        <section class="state">
+          <h2>3 · Not a member · invite-only</h2>
+          <p class="why">
+            <code>inviteOnly</code>, <code>disableSignup</code>, or a pending invite: no CTA anywhere.
+            The panel ends at Log Out — existing gating preserved exactly.
+          </p>
+          <div class="navstrip">
+            <img class="lm-avatar" src="avatar.svg" alt="" />
+          </div>
+          <div class="lm">
+            <div class="lm-panel static">
+              <div class="lm-identity">
+                <div class="lm-name">Dayo Adeyemi</div>
+                <div class="lm-email">dayo@contoso.com</div>
+              </div>
+              <div class="lm-sep"></div>
+              <a class="lm-item" href="#">Account Settings</a>
+              <div class="lm-sep"></div>
+              <div class="lm-theme-row">
+                <span>Theme</span>
+                <div class="lm-seg">
+                  <button type="button" aria-pressed="false">☀</button>
+                  <button type="button" aria-pressed="true">☾</button>
+                  <button type="button" aria-pressed="false">▭</button>
+                </div>
+              </div>
+              <div class="lm-sep"></div>
+              <a class="lm-item" href="#">Log Out</a>
+            </div>
+          </div>
+          <div class="ac">AC-4</div>
+        </section>
+
+        <!-- 4. loading -->
+        <section class="state">
+          <h2>4 · Loading</h2>
+          <p class="why">
+            Signed in, <code>appInitApi</code> not ready. A 32px skeleton holds the avatar's final
+            size so the nav does not reflow when data lands. Panel cannot open.
+          </p>
+          <div class="navstrip">
+            <a class="btn btn-sm btn-primary" href="#" style="opacity: 0.5; pointer-events: none">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</a>
+            <span class="lm-skeleton"></span>
+          </div>
+          <div class="ac">AC-9</div>
+        </section>
+
+        <!-- 5. no avatar / no fullname -->
+        <section class="state">
+          <h2>5 · No avatar, no full name</h2>
+          <p class="why">
+            <code>avatarUrl</code> empty falls back to initials. Empty <code>fullname</code> promotes
+            the email to the first line and drops the muted line.
+          </p>
+          <div class="navstrip">
+            <a class="btn btn-sm btn-primary" href="#">Continue Learning</a>
+            <span class="lm-avatar-fallback">AK</span>
+          </div>
+          <div class="lm">
+            <div class="lm-panel static">
+              <div class="lm-identity">
+                <div class="lm-name">amaka.k@verylongcompanydomainname.example</div>
+              </div>
+              <div class="lm-sep"></div>
+              <a class="lm-item" href="#">My Courses</a>
+              <a class="lm-item" href="#">My Certificates</a>
+              <a class="lm-item" href="#">Account Settings</a>
+              <div class="lm-sep"></div>
+              <div class="lm-theme-row">
+                <span>Theme</span>
+                <div class="lm-seg">
+                  <button type="button" aria-pressed="false">☀</button>
+                  <button type="button" aria-pressed="false">☾</button>
+                  <button type="button" aria-pressed="true">▭</button>
+                </div>
+              </div>
+              <div class="lm-sep"></div>
+              <a class="lm-item" href="#">Log Out</a>
+              <div class="lm-cta"><a class="btn btn-primary btn-full" href="#">Continue Learning</a></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- 6. editor preview -->
+        <section class="state">
+          <h2>6 · Landing-page editor preview</h2>
+          <p class="why">
+            In settings the avatar renders so the owner sees the real nav, but the popover never
+            opens — same treatment <code>disableCourseLinks</code> gives course links today.
+          </p>
+          <div class="navstrip" style="border-style: solid; border-color: var(--landing-accent); position: relative">
+            <span
+              style="
+                position: absolute;
+                top: -10px;
+                left: 10px;
+                font-size: 10.5px;
+                letter-spacing: 0.06em;
+                text-transform: uppercase;
+                background: var(--landing-accent);
+                color: var(--landing-accent-fg);
+                padding: 1px 7px;
+                border-radius: 4px;
+              "
+              >Navigation</span
+            >
+            <a class="btn btn-sm btn-primary" href="#">Continue Learning</a>
+            <div class="lm">
+              <button class="lm-trigger" aria-disabled="true" aria-expanded="false" aria-label="Account menu">
+                <img src="avatar.svg" alt="" />
+              </button>
+            </div>
+          </div>
+          <div class="ac">AC-10</div>
+        </section>
+
+        <!-- 7. mobile -->
+        <section class="state">
+          <h2>7 · Mobile</h2>
+          <p class="why">
+            Centre links already hide below 768px. The avatar stays; the CTA collapses to its icon;
+            the panel anchors right with an 8px viewport inset.
+          </p>
+          <div class="phone">
+            <div class="nav-in">
+              <a class="logo" href="#"><i></i> SMI</a>
+              <div class="nav-right">
+                <a class="btn btn-sm btn-primary" href="#" style="padding: 0 10px">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M5 12h14M13 6l6 6-6 6" />
+                  </svg>
+                </a>
+                <img class="lm-avatar" src="avatar.svg" alt="" />
+              </div>
+            </div>
+            <div class="lm">
+              <div class="lm-panel static">
+                <div class="lm-identity">
+                  <div class="lm-name">Rotimi Best</div>
+                  <div class="lm-email">rotimi@northwind.com</div>
+                </div>
+                <div class="lm-sep"></div>
+                <a class="lm-item" href="#">My Courses</a>
+                <a class="lm-item" href="#">My Certificates</a>
+                <a class="lm-item" href="#">Account Settings</a>
+                <div class="lm-sep"></div>
+                <div class="lm-theme-row">
+                  <span>Theme</span>
+                  <div class="lm-seg">
+                    <button type="button" aria-pressed="true">☀</button>
+                    <button type="button" aria-pressed="false">☾</button>
+                    <button type="button" aria-pressed="false">▭</button>
+                  </div>
+                </div>
+                <div class="lm-sep"></div>
+                <a class="lm-item" href="#">Log Out</a>
+                <div class="lm-cta"><a class="btn btn-primary btn-full" href="#">Continue Learning</a></div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+
+    <div class="proto-bar">
+      <span class="proto-tag">All states</span>
+      <a href="index.html">Map</a>
+      <a href="learner-member.html">Member</a>
+      <a href="themes.html">Themes</a>
+      <select data-proto-theme aria-label="Landing theme">
+        <option value="quartz">quartz</option>
+        <option value="bold">bold</option>
+        <option value="terminal">terminal</option>
+        <option value="editorial">editorial</option>
+        <option value="vibrant">vibrant</option>
+      </select>
+    </div>
+
+    <script src="menu.js"></script>
+  </body>
+</html>

--- a/prototypes/landing-learner-menu/menu-states.html
+++ b/prototypes/landing-learner-menu/menu-states.html
@@ -269,9 +269,10 @@
             >
             <a class="btn btn-sm btn-primary" href="#">Continue Learning</a>
             <div class="lm">
-              <button class="lm-trigger" aria-disabled="true" aria-expanded="false" aria-label="Account menu">
+              <!-- inert: a span, not a button — aria-disabled alone would still be clickable -->
+              <span class="lm-trigger" aria-hidden="true">
                 <img src="avatar.svg" alt="" />
-              </button>
+              </span>
             </div>
           </div>
           <div class="ac">AC-10</div>

--- a/prototypes/landing-learner-menu/menu.js
+++ b/prototypes/landing-learner-menu/menu.js
@@ -1,0 +1,113 @@
+/*
+  Learner menu prototype behaviour.
+
+  Stands in for base/popover (bits-ui) + the theme segmented control.
+  Only the interactions that matter for review: open/close, escape-to-close,
+  outside click, arrow-key roving, and the theme row not closing the panel.
+*/
+
+(function () {
+  function closeAll(except) {
+    document.querySelectorAll('.lm.open').forEach(function (menu) {
+      if (menu === except) return;
+
+      menu.classList.remove('open');
+      menu.querySelector('.lm-trigger').setAttribute('aria-expanded', 'false');
+    });
+  }
+
+  function wireMenu(menu) {
+    var trigger = menu.querySelector('.lm-trigger');
+    var panel = menu.querySelector('.lm-panel');
+    if (!trigger || !panel || panel.classList.contains('static')) return;
+
+    if (trigger.getAttribute('aria-disabled') === 'true') {
+      trigger.addEventListener('click', function (event) {
+        event.preventDefault();
+      });
+      return;
+    }
+
+    trigger.addEventListener('click', function (event) {
+      event.stopPropagation();
+      var willOpen = !menu.classList.contains('open');
+      closeAll(menu);
+      menu.classList.toggle('open', willOpen);
+      trigger.setAttribute('aria-expanded', String(willOpen));
+
+      if (willOpen) {
+        var first = panel.querySelector('.lm-item');
+        if (first) first.setAttribute('tabindex', '0');
+      }
+    });
+
+    panel.addEventListener('click', function (event) {
+      // The theme row is a preference control, not a destination — keep the panel open.
+      if (event.target.closest('.lm-theme-row')) {
+        event.stopPropagation();
+        return;
+      }
+    });
+
+    panel.addEventListener('keydown', function (event) {
+      if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+
+      event.preventDefault();
+      var rows = Array.prototype.slice.call(panel.querySelectorAll('.lm-item'));
+      var index = rows.indexOf(document.activeElement);
+      var next = event.key === 'ArrowDown' ? index + 1 : index - 1;
+      if (next < 0) next = rows.length - 1;
+      if (next >= rows.length) next = 0;
+      rows[next].focus();
+    });
+  }
+
+  function wireThemeSegments() {
+    document.querySelectorAll('.lm-seg').forEach(function (seg) {
+      seg.addEventListener('click', function (event) {
+        var button = event.target.closest('button');
+        if (!button) return;
+
+        seg.querySelectorAll('button').forEach(function (other) {
+          other.setAttribute('aria-pressed', String(other === button));
+        });
+      });
+    });
+  }
+
+  function wireThemeSwitcher() {
+    var select = document.querySelector('[data-proto-theme]');
+    if (!select) return;
+
+    select.addEventListener('change', function () {
+      document.documentElement.setAttribute('data-landing-theme', select.value);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.lm').forEach(wireMenu);
+    wireThemeSegments();
+    wireThemeSwitcher();
+
+    document.addEventListener('click', function () {
+      closeAll(null);
+    });
+
+    document.addEventListener('keydown', function (event) {
+      if (event.key !== 'Escape') return;
+
+      var open = document.querySelector('.lm.open');
+      if (!open) return;
+
+      closeAll(null);
+      open.querySelector('.lm-trigger').focus();
+    });
+
+    // Pages can request the menu render open on load (the reference screenshot state).
+    var autoOpen = document.querySelector('.lm[data-open-on-load]');
+    if (autoOpen) {
+      autoOpen.classList.add('open');
+      autoOpen.querySelector('.lm-trigger').setAttribute('aria-expanded', 'true');
+    }
+  });
+})();

--- a/prototypes/landing-learner-menu/menu.js
+++ b/prototypes/landing-learner-menu/menu.js
@@ -21,12 +21,9 @@
     var panel = menu.querySelector('.lm-panel');
     if (!trigger || !panel || panel.classList.contains('static')) return;
 
-    if (trigger.getAttribute('aria-disabled') === 'true') {
-      trigger.addEventListener('click', function (event) {
-        event.preventDefault();
-      });
-      return;
-    }
+    // Inert (settings preview): the trigger is a <span>, never a <button>, so there is
+    // no activation path at all — aria-disabled alone would still fire on click/Enter.
+    if (trigger.tagName !== 'BUTTON') return;
 
     trigger.addEventListener('click', function (event) {
       event.stopPropagation();

--- a/prototypes/landing-learner-menu/themes.html
+++ b/prototypes/landing-learner-menu/themes.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Learner menu — theme fidelity</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="landing-theme.css" />
+    <style>
+      html,
+      body {
+        background: #f3f3f4;
+        color: #111114;
+        font-family: 'Inter', system-ui, sans-serif;
+      }
+      .wrap {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 40px 32px 120px;
+      }
+      .page-head {
+        max-width: 760px;
+        margin-bottom: 36px;
+      }
+      .page-head h1 {
+        font-size: 30px;
+        letter-spacing: -0.03em;
+      }
+      .page-head p {
+        margin-top: 12px;
+        color: #6e6e77;
+        font-size: 14.5px;
+      }
+      .page-head code {
+        background: #e7e7ea;
+        padding: 1px 5px;
+        border-radius: 4px;
+        font-size: 12.5px;
+      }
+      .themes {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
+        gap: 26px;
+      }
+      /* Each tile is its own theme scope — exactly what themeStyle(theme) does at runtime. */
+      .tile {
+        border-radius: 12px;
+        overflow: hidden;
+        border: 1px solid #dedee2;
+        background: var(--landing-bg);
+        color: var(--landing-fg);
+        font-family: var(--landing-font);
+      }
+      .tile-label {
+        font-family: 'Inter', system-ui, sans-serif;
+        font-size: 11.5px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        padding: 9px 14px;
+        background: #111114;
+        color: #fff;
+      }
+      .tile-body {
+        padding: 16px;
+      }
+      .tile .nav-in {
+        height: 50px;
+        padding: 0;
+        gap: 10px;
+      }
+      .tile .lm-panel.static {
+        margin-left: auto;
+        margin-top: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="page-head">
+        <h1>Theme fidelity across the 11 landing themes</h1>
+        <p>
+          The menu reads only from <code>--landing-*</code> variables, so each theme's radius, border
+          weight, palette and typeface carry through with no per-theme code. Five representative
+          themes shown; the Storybook story covers all eleven. Note the portalled popover must
+          re-apply <code>themeStyle(theme)</code> — each tile below is its own theme scope,
+          demonstrating that.
+        </p>
+      </div>
+
+      <div class="themes" id="themes"></div>
+    </div>
+
+    <div class="proto-bar">
+      <span class="proto-tag">Theme fidelity</span>
+      <a href="index.html">Map</a>
+      <a href="learner-member.html">Member</a>
+      <a href="menu-states.html">States</a>
+    </div>
+
+    <template id="tpl">
+      <div class="tile-body">
+        <div class="nav-in">
+          <a class="logo" href="#"><i></i> <span class="org"></span></a>
+          <div class="nav-right">
+            <a class="btn btn-sm btn-primary" href="#">Continue Learning</a>
+            <img class="lm-avatar" src="avatar.svg" alt="" />
+          </div>
+        </div>
+        <div class="lm">
+          <div class="lm-panel static">
+            <div class="lm-identity">
+              <div class="lm-name">Rotimi Best</div>
+              <div class="lm-email">rotimi@northwind.com</div>
+            </div>
+            <div class="lm-sep"></div>
+            <a class="lm-item" href="#">My Courses</a>
+            <a class="lm-item" href="#">My Certificates</a>
+            <a class="lm-item" href="#">Account Settings</a>
+            <div class="lm-sep"></div>
+            <div class="lm-theme-row">
+              <span>Theme</span>
+              <div class="lm-seg">
+                <button type="button" aria-pressed="true">☀</button>
+                <button type="button" aria-pressed="false">☾</button>
+                <button type="button" aria-pressed="false">▭</button>
+              </div>
+            </div>
+            <div class="lm-sep"></div>
+            <a class="lm-item" href="#">Log Out</a>
+            <div class="lm-cta"><a class="btn btn-primary btn-full" href="#">Continue Learning</a></div>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <script>
+      const THEMES = [
+        { key: 'quartz', org: 'SMI Consulting' },
+        { key: 'bold', org: 'Northwind Labs' },
+        { key: 'terminal', org: 'runtime.sh' },
+        { key: 'editorial', org: 'The Practice' },
+        { key: 'vibrant', org: 'Kite Academy' }
+      ];
+
+      const host = document.getElementById('themes');
+      const tpl = document.getElementById('tpl');
+
+      THEMES.forEach(function (theme) {
+        const tile = document.createElement('div');
+        tile.className = 'tile';
+        tile.setAttribute('data-landing-theme', theme.key);
+
+        const label = document.createElement('div');
+        label.className = 'tile-label';
+        label.textContent = theme.key;
+        tile.appendChild(label);
+
+        const body = tpl.content.cloneNode(true);
+        body.querySelector('.org').textContent = theme.org;
+        tile.appendChild(body);
+
+        host.appendChild(tile);
+      });
+    </script>
+    <script src="menu.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## What

Spec + clickable prototypes for a **learner account menu** on the org landing page: when someone is already signed in and lands on an academy's public site, an avatar appears at the far right of the nav and opens a popover with their identity, learner destinations, theme preference, log out, and a `Continue Learning` CTA.

No product code in this PR — `prd/landing-learner-menu/README.md` plus `prototypes/landing-learner-menu/`.

## Start here

```
prototypes/landing-learner-menu/index.html
```

| Screen | File |
| --- | --- |
| Signed in, member (menu open) | `learner-member.html` |
| Signed in, not a member | `learner-non-member.html` |
| Logged out (unchanged baseline) | `learner-logged-out.html` |
| Every state side by side | `menu-states.html` |
| Theme fidelity across landing themes | `themes.html` |

## Decisions the spec locks

1. **CTA button + avatar** — the avatar sits beside `Continue Learning`, it does not replace it. LMS access stays one click.
2. **The CTA repeats** as a filled, full-width button at the bottom of the popover card.
3. **`Continue Learning` → `/lms`** — no resume-last-lesson and no progress fetch on the public site in v1.
4. **Items:** My Courses, My Certificates, Account Settings, Theme, Log Out.
5. **Non-members keep the avatar**, CTA becomes `Join Academy`, and existing invite-only / `disableSignup` / pending-invite gating is preserved exactly (no CTA at all in those cases).
6. **Staff see what learners see** — no Dashboard or edit shortcut. The existing self-hosted admin/tutor `Dashboard` behaviour is untouched.
7. **The theme row sets the app/LMS preference, not the landing page.** Landing themes are fixed single palettes — there is no `.dark` selector or `prefers-color-scheme` anywhere in `packages/ui/src/custom/org-landing-page/`.
8. **One shared component** dropped into all 11 theme navs, styled entirely from `--landing-*` variables.

## Notes for review

- `getOrgLandingAuthAction()` is **not** modified by the proposed design. The popover renders the label and href it already returns, so the nav button and the popover CTA can never disagree.
- No new tables, columns or endpoints — every value is already in the client via `$profile` and `appInitApi`.
- Known risk called out in the spec: bits-ui portals popover content to `document.body`, outside `landing-theme-scope`'s inline style, so `Popover.Content` has to re-apply `themeStyle(theme)`. Each tile in `themes.html` is its own theme scope to demonstrate the fix.
- `prototypes/` is excluded from CodeRabbit/Greptile per `.coderabbit.yaml` and `.greptile/config.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added product requirements for a learner account menu on organization landing pages.
  - Documents navigation to courses, certificates, account settings, theme selection, logout, and continued learning.
  - Defines display rules for members, non-members, invite-only academies, pending invites, and disabled signup.
  - Specifies loading states and non-interactive editor previews.
  - Includes localization, accessibility, styling, and acceptance criteria requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defines the requirements and implementation plan for adding a signed-in learner account menu to organization landing pages.

- Specifies member, non-member, loading, preview, mobile, and theme behavior.
- Reuses the existing authentication action so the navigation and popover CTAs remain consistent.
- Covers the proposed shared UI component, data builder, translations, Storybook states, and landing-page integration surfaces.
- The wiring section needs clarification for public surfaces that bypass `buildOrgLandingPageProps()`.

<h3>Confidence Score: 4/5</h3>

The documentation is safe to merge after a non-blocking clarification of the separate public catalog and course-page wiring paths.

The proposed behavior is consistent with existing authentication and route contracts, but the technical design could lead implementers to omit the learner menu from two required surfaces because they do not use `buildOrgLandingPageProps()`.

**Files Needing Attention:** prd/landing-learner-menu/README.md

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| prd/landing-learner-menu/README.md | Defines the learner-menu product and technical design comprehensively, but its builder-based wiring description does not cover two required public surfaces. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Account and authentication state] --> B[Learner account builder]
  B --> C[buildOrgLandingPageProps]
  B --> D[Public catalog nav props]
  B --> E[buildCourseLandingPageProps]
  C --> F[Organization landing pages]
  C --> G[Settings previews]
  D --> H[Public catalog]
  E --> I[Public course landing page]
  F --> J[Shared learner menu]
  G --> J
  H --> J
  I --> J
```

<sub>Reviews (1): Last reviewed commit: ["docs(prd): add landing page learner acco..."](https://github.com/classroomio/classroomio/commit/162c59d4ce9d31113228ae8761008dc031b75367) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61049281)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->