### PR TITLE
docs(prd): add Embedded Academy PRD and prototypes

### DIFF
--- a/prd/embedded-academy/README.md
+++ b/prd/embedded-academy/README.md
@@ -1,0 +1,476 @@
+# Embedded Academy PRD (Full-Page Widget / Page Template)
+
+## Status
+
+- Draft (ready for prototype review)
+
+## Date
+
+- September 6, 2026
+
+## Prototypes — the UX source of truth
+
+**The UX of this feature must be taken from the prototype folder.** Interactive HTML prototypes for every surface live in [`prototypes/embedded-academy/`](../../prototypes/embedded-academy/) and are the approved design reference for layout, states (signed-in / anonymous / locked / empty / paid), copy, and navigation flow. When this document and a prototype disagree on a UI detail, the prototype wins.
+
+**Start here:**
+
+```
+prototypes/embedded-academy/index.html
+```
+
+Open it in a browser (`open prototypes/embedded-academy/index.html`) — it maps both journeys (admin author → embedded learner) and every page cross-links so you can click through each flow end to end. Each page has a light/dark toggle.
+
+The prototypes are built on the real design tokens. `app-theme.css` mirrors `packages/ui/src/index.css` (OKLCH palette, Geist, radii, and the Button/Badge/Item/Progress recipes) for the dashboard screens; `academy.css` holds the embedded runtime's own namespaced `--ac-*` tokens plus the mock host-app chrome, so the "native to the customer's product" requirement is visible on every learner screen.
+
+Every page carries a state switcher in the bottom-right. On the learner screens it also toggles **Bounds** (where the embed starts and ends on the host page) and **Inherit host** (the `theme.mode: 'inherit-host'` behavior).
+
+| Surface | Files |
+| --- | --- |
+| Admin (dashboard) | `admin-academies.html`, `admin-editor.html`, `admin-embed.html`, `admin-analytics.html` |
+| Embedded runtime (in host app) | `embed-learn.html`, `embed-learn-anon.html`, `embed-category.html`, `embed-course.html`, `embed-lesson.html`, `embed-exercise.html` |
+
+## Purpose
+
+Let an organization embed its **entire academy** — a branded Learn page, category browsing, course detail, and the lesson/exercise player — directly inside its own product, as a single copy-paste script. The learner is identified by the host app, sees their own progress and recommendations, and never leaves the host application.
+
+Reference experience: the **Claude app's "Learn" page** (Featured courses, Getting started tutorials, Browse by role with a "For you" badge). Today a ClassroomIO widget renders one block of course cards; this feature makes a widget render a whole page, and then makes that page a working LMS.
+
+## Problem Statement
+
+- A widget is capped at **one layout and one course list** (`widget.layout_type` is a single enum column). A real Learn page needs many blocks with different sources — featured, getting-started, browse-by-role.
+- The embed is **anonymous**. There is no way to show progress, "Continue where you left off", or a personalized "For you" badge, which is exactly what makes an in-product academy useful rather than decorative.
+- Every CTA **ejects the learner** to the academy on another domain. For customer education inside a SaaS product, that context switch is the main reason embedded academies get rejected.
+- Customers who want an in-app academy today must build it themselves against the public API, re-implementing course detail and the lesson player that we already ship.
+- Org landing pages are hosted by us and themed per template; there is no equivalent surface a customer can drop into their own React/Vue/Rails app.
+
+## Confirmed Decisions
+
+1. **Primary use case is an in-app authenticated Learn page** inside the customer's own product, modeled on the Claude Learn page. Public/anonymous rendering is a supported fallback state, not the target.
+2. **Full mini-app depth.** Index → category → course detail → lesson player → exercise player all render inside the embed. The learner never leaves the host app.
+3. **One deliberate exception to (2): paid checkout.** Free and admin-assigned enrollment happens inline; a paid course opens the academy in a new tab for checkout. Payment does not run inside a third-party frame.
+4. **Grow the existing plain-Svelte shadow-DOM runtime** in `apps/embeds` rather than iframing a SvelteKit route. This must be a **route-split** build with per-chunk budgets, not one bundle.
+5. **Section renderers are built once in `packages/ui`** as a shared set. Migrating the org landing page onto the same section system is an explicit **non-goal** of v1.
+6. **Naming: "Embedded Academy."** The widget list separates **Blocks** (today's single-layout widgets) from **Academies** (pages).
+7. **Router uses a pluggable history adapter.** Default `memory` (zero host-router conflict), upgradeable to query-param sync with `data-cio-router="query"`, plus `window.CIO.learn.navigate()` / `onNavigate()` for hosts that own their routing.
+8. **Two-request data model.** An anonymous, CDN-cached payload snapshot drives first paint; a separate uncached per-learner overlay supplies progress, resume, and "For you". The overlay merges client-side.
+9. **Cookie-free auth.** Third-party cookies are blocked by default in Safari and Firefox, so the embed cannot carry a session cookie. The host signs a JWT with the org's existing token-auth secret; the embed exchanges it for a short-lived access token held in memory and sent as a bearer header.
+10. **Gating: the Embedded Academy page requires a paid plan; the identity overlay and the embedded LMS require Enterprise** (they ride `organization_token_auth`, which is already Enterprise-gated).
+11. **v1 section catalog**: `page_header`, `card_grid`, `compact_list`, `category_grid`, `continue_learning`, `carousel`, `editorial_spotlight`, `cta_banner`, `rich_text`. `path_list` is **reserved** in the enum for the drafted Learning Paths feature but not implemented. `certificate_showcase` is deferred.
+12. **Editor UX is a section list panel plus live preview** — add / drag-reorder / delete in the left panel, selecting a section opens its settings. Click-in-preview selection is deferred.
+13. **Embed-only.** The same sections are not published to a hosted org-site route in v1; the org landing page remains the hosted surface.
+14. **Section-level analytics ship in v1**, populating the `widget_analytics_event` schema reserved by the shipped widget PRD. *(Author's call — see Open Calls.)*
+
+## Current-State Audit
+
+The audit changed the shape of this feature twice: the lesson/exercise player and the identity plumbing already exist and are reusable, which is what makes "full mini-app" tractable on a plain-Svelte runtime.
+
+| Capability | Current state | Notes for this feature |
+| --- | --- | --- |
+| Widget entity | `widget`, `widget_course`, `widget_version` in `packages/db/src/schema.ts:2407-2530` | Reuse wholesale. Add a `kind` column; add section tables. Versioning, publish, rollback, soft-delete all carry over. |
+| Layout catalog | 7 layouts in `packages/ui/src/custom/widget-layouts/` | Six become section types with no rewrite. Only `page_header`, `category_grid`, `continue_learning`, `cta_banner`, `rich_text` are new. |
+| Payload builder | `buildWidgetPayload()` in `packages/utils/src/validation/widget/build-payload.ts` | Resolve → filter by tag → sort → slice already exists. Page payload runs the same resolver **once per section**. |
+| Public payload endpoint | `GET /widgets/:publicKey/payload`, `Cache-Control: public, max-age=60, stale-while-revalidate=300` (`apps/api/src/routes/widgets/widgets.ts:35`) | Extend to emit `sections[]` when `kind = 'page'`. Cache policy unchanged. |
+| Third-party CORS | `publicApiCors` (`origin: '*'`, `credentials: false`) already applies to the `/widgets/` prefix; `Authorization` is already an allowed header (`apps/api/src/middlewares/cors.ts`) | The cookie-free bearer pattern is **already established**. All embed traffic stays under `/widgets/` so the wildcard-CORS surface remains auditable. |
+| Org → learner identity | `organization_token_auth` (Enterprise, HS256 signing secret) + `exchangeToken()` in `packages/db/src/auth/token-exchange.ts`, which verifies the JWT, finds-or-creates the user, and ensures org membership. Its docstring: *"Caller is responsible for creating session and setting cookie."* | The verification half is **done**. We add a second caller that returns a bearer token as JSON instead of setting a cookie and redirecting. |
+| Bearer sessions | Better Auth `bearer()` plugin is **not** in the plugin list (`packages/db/src/auth.ts:135-159`) | Must be added, or the access token must be resolved by a dedicated embed middleware. This is the one genuinely missing auth primitive. |
+| Course detail + player UI | `packages/ui/src/custom/public-course/` ships `PublicCourseShell`, `PublicCourseSidebar`, `PublicLessonView`, `PublicExerciseView`, `PublicCourseCallout`, plus attempt storage — all plain-data props | **The hardest part of the mini-app already exists as reusable UI.** The org-site route `(org-site)/course/[slug]/lesson/[itemSlug]/+page.svelte` is a thin wrapper around it; the embed becomes a second wrapper. |
+| Public course data | `GET /org-site/course/:courseSlug` and `/item/:itemSlug` (`apps/api/src/routes/org-site/public-course.ts`) | Same service layer feeds the embed's course and item routes. |
+| Learner write endpoints | `POST /course/:courseId/enroll`, `GET /course/:courseId/progress`, `PUT /course/:courseId/lesson/:lessonId/completion`, `POST /course/:courseId/exercise/:exerciseId/submission` | All exist and are session-authed under `sessionCors`. The embed cannot call them cross-origin; mirror them under `/widgets/:publicKey/...` as thin routes delegating to the **same services**. |
+| Widget editor | `apps/dashboard/src/lib/features/widget/` — icon rail + `select-courses`/`layout`/`design`/`embed` panels, iframe preview over `postMessage`, save/publish/rollback header | Add a `sections` panel to the rail. Preview protocol (`READY/RENDER/ERROR/RESIZE`) is reused unchanged. |
+| Embed build | `apps/embeds` Vite multi-mode build, one entry per widget, `vite-plugin-css-injected-by-js`, upload via `scripts/upload-embeds.ts` | Add a third entry. Route splitting needs dynamic `import()` boundaries and a per-chunk size gate. |
+| Current bundle | loader 6.41 kB (2.20 kB gz), runtime 80.03 kB (22.35 kB gz); documented budget ≤ 35 kB gz | The single global budget **cannot survive a player**. Replaced by per-chunk budgets below. |
+| Analytics | `widget_analytics_event` schema reserved in the shipped PRD, never implemented | Implemented here, with `section_id` added. |
+| Learning Paths | Drafted, not built (`prd/learning-paths/README.md`) | `path_list` reserved in the section-type enum so paths slot in without a migration. |
+
+## Product Goals
+
+1. Let an admin compose a full academy page from ordered sections, each with its own source and layout, in the existing widget editor.
+2. Let a learner browse, enrol, read lessons, and submit exercises **without leaving the host application**.
+3. Personalize the page to the signed-in learner — progress, resume, recommended-for-role — using identity the host already has.
+4. Reuse the shipped course/lesson/exercise UI and services rather than re-implementing them in the embed.
+5. Keep first paint fast and the CDN cache model intact despite personalization.
+6. Make the page feel native to the host app rather than isolated inside it.
+
+## Non-Goals (v1)
+
+- Migrating the org landing page onto the section system (renderers are built to allow it later).
+- A hosted twin of the academy page on the org site.
+- Paid checkout inside the embed.
+- Course authoring, grading, or any admin surface inside the embed.
+- `certificate_showcase` and `path_list` section implementations.
+- Server-side rendering or SEO support for the embedded page.
+- Community, newsfeed, cohorts, and AI tutor inside the embed.
+- Multi-language runtime; the embed uses the org's default locale, as the shipped widget does.
+
+## Functional Requirements
+
+### 1. Admin — Academy list (`prototypes/embedded-academy/admin-academies.html`)
+
+The existing `/org/[slug]/widgets` list gains a kind split.
+
+- Two tabs: **Blocks** (existing single-layout widgets, unchanged) and **Academies** (pages).
+- Create flow asks for a name and a starting template: **Blank**, **Learn page** (page_header + compact_list + card_grid + category_grid, pre-filled), or **Catalog** (page_header + category_grid + card_grid).
+- Each card shows status (Draft / Published / Archived), section count, last published, and whether identity is configured for the org.
+- States to show: empty (no academies yet), draft with unpublished changes, published, archived.
+- Free-plan orgs see the Academies tab with an upgrade lock over create, following the existing `UpgradeBanner` / `UpgradeLock` pattern.
+
+### 2. Admin — Academy editor (`prototypes/embedded-academy/admin-editor.html`)
+
+Extends `apps/dashboard/src/lib/features/widget/pages/widget-editor.svelte`. The icon rail gains a **Sections** entry, which becomes the default panel for `kind = 'page'`.
+
+- **Sections panel**: ordered list of sections, each row showing type icon, heading, and source summary ("12 courses · tag: Engineering"). Drag to reorder, duplicate, delete, and an **Add section** menu grouped as *Content* (page_header, rich_text, cta_banner) and *Courses* (card_grid, compact_list, carousel, editorial_spotlight, category_grid, continue_learning).
+- **Selecting a section** opens its settings in place: heading, subheading, source mode (manual / tag / all published / continue learning), the source picker for that mode, and the layout options that already exist for that layout type.
+- `continue_learning` has no source picker — it is driven entirely by the learner overlay — and shows an inline note that it renders nothing for anonymous viewers.
+- `category_grid` picks ordered tags, each with an optional icon and a per-tag destination (filtered category view).
+- **Design panel** is unchanged except for a new **Theme mode** control: `preset` (today's behavior), `inherit-host` (adopt the host page's font stack and surface colors), or `custom`.
+- **Preview** reuses the existing iframe + `postMessage` pipeline. A toggle switches between **Anonymous** and **Signed-in (sample learner)** so the admin can see both states; the signed-in preview uses synthetic overlay data.
+- Save / discard / publish / rollback behave exactly as they do for block widgets. Validation blocks publish when a section has no resolvable source.
+- States to show: empty (no sections), a section selected, drag in progress, validation error on publish, unsaved-changes bar.
+
+### 3. Admin — Embed & identity (`prototypes/embedded-academy/admin-embed.html`)
+
+- Copy-paste snippet:
+
+```html
+<div data-cio-widget="academy" data-widget-key="wgt_xxx"></div>
+<script async type="module" src="https://<embed-host>/embeds/academy/academy.js"></script>
+```
+
+- **Identity setup** section: shows whether org token auth is active (linking to the existing `/org/[slug]/settings/auth/token-auth` page), and a copyable server-side snippet showing how to sign a learner JWT and hand it to the embed:
+
+```js
+// server-side, per request
+const token = await new SignJWT({ sub: user.id, email: user.email, name: user.name })
+  .setProtectedHeader({ alg: 'HS256' })
+  .setIssuedAt()
+  .setExpirationTime('2m')
+  .sign(new TextEncoder().encode(process.env.CIO_TOKEN_AUTH_SECRET));
+```
+
+```html
+<div data-cio-widget="academy" data-widget-key="wgt_xxx" data-cio-token="<%= token %>"></div>
+```
+
+- **Router mode** selector writes the `data-cio-router` attribute into the snippet and documents the `window.CIO.learn` API.
+- **Allowed origins** field: the origins permitted to mount this academy, so a leaked public key cannot be re-hosted elsewhere.
+- States: identity not configured (Enterprise upsell), configured but inactive, active.
+
+### 4. Admin — Analytics (`prototypes/embedded-academy/admin-analytics.html`)
+
+- Per-section impressions and CTA clicks, ranked, over a date range.
+- Top courses by click, and — when identity is on — enrolments and completions attributed to the academy.
+- Empty state before any events land.
+
+### 5. Learner — Academy index, signed in (`prototypes/embedded-academy/embed-learn.html`)
+
+Rendered inside a mock host-app chrome so the embed's boundaries are visible.
+
+- Sections render in configured order. This is the screen that mirrors the reference: page header, a `compact_list` of featured courses with arrow CTAs, a `card_grid` of short tutorials with duration badges, and a `category_grid` of roles.
+- With an overlay present: enrolled courses show a progress bar and a **Continue** CTA resolving to the learner's last lesson; the `continue_learning` section appears at the top; the category matching the learner's role trait carries a **For you** badge.
+- Section-level impression events fire once per section per session; CTA clicks fire on navigation.
+- States to show: fully personalized, overlay still loading (skeleton on progress affordances only — never block first paint), overlay failed (degrade silently to anonymous).
+
+### 6. Learner — Academy index, anonymous (`prototypes/embedded-academy/embed-learn-anon.html`)
+
+- Identical layout from the cached snapshot, with no progress, no Continue, no For-you badge.
+- `continue_learning` renders nothing and collapses without leaving a gap.
+- CTAs read "View course" and open course detail in the embed; enrolment prompts sign-in on the academy.
+
+### 7. Learner — Category view (`prototypes/embedded-academy/embed-category.html`)
+
+- Reached by clicking a `category_grid` tile. Shows the tag name, description, and the filtered course list.
+- Back returns to the index; with `data-cio-router="query"` the browser back button does the same.
+- States: results, empty category, loading.
+
+### 8. Learner — Course detail (`prototypes/embedded-academy/embed-course.html`)
+
+- Renders the public course view — hero, description, outcomes, curriculum, instructor — using the same `packages/ui/src/custom/public-course` primitives as the org-site route.
+- CTA resolves by state: **Enrol** (free, signed-in — inline, no navigation), **Continue** (already enrolled), **Sign in to enrol** (anonymous), **Get this course** (paid — opens the academy checkout in a new tab, the one deliberate ejection).
+- States to show: free/not enrolled, enrolled with progress, paid, anonymous, unpublished/unavailable.
+
+### 9. Learner — Lesson player (`prototypes/embedded-academy/embed-lesson.html`)
+
+- `PublicCourseShell` with the course sidebar, `PublicLessonView` for the body, and footer next/previous navigation.
+- Video plays via the existing HLS path; the embed mints its playback cookie through a widget-scoped endpoint rather than the org-site one.
+- Marking complete writes through to the same completion service the LMS uses — one source of truth for progress.
+- States: in progress, complete, locked (not enrolled), mobile sheet open.
+
+### 10. Learner — Exercise player (`prototypes/embedded-academy/embed-exercise.html`)
+
+- `PublicExerciseView` with the shipped question types.
+- Signed-in submissions post to the same submission service; anonymous attempts fall back to the existing local-storage attempt store (`public-exercise-attempts-storage.ts`) exactly as the public course does today.
+- States: unanswered, in progress, submitted, graded, anonymous attempt.
+
+## Technical Design
+
+### Data model
+
+`kind` separates the two widget shapes without disturbing anything shipped.
+
+```sql
+CREATE TYPE "WIDGET_KIND" AS ENUM ('block', 'page');
+
+ALTER TABLE widget ADD COLUMN kind "WIDGET_KIND" NOT NULL DEFAULT 'block';
+```
+
+Sections are relational, not jsonb blobs — course and tag references are real foreign keys so cascade deletes stay correct and a deleted course cannot leave a dangling id inside a config document. `config` holds **presentational options only** (columns, density, badge style, icon name), never relational ids and never computed values.
+
+```ts
+// packages/db/src/schema.ts
+export const widgetSectionType = pgEnum('WIDGET_SECTION_TYPE', [
+  'page_header',
+  'rich_text',
+  'cta_banner',
+  'card_grid',
+  'compact_list',
+  'carousel',
+  'editorial_spotlight',
+  'category_grid',
+  'continue_learning',
+  'path_list' // reserved for Learning Paths; rejected by validation in v1
+]);
+
+export const widgetSectionSource = pgEnum('WIDGET_SECTION_SOURCE', [
+  'manual',
+  'tag',
+  'published',
+  'overlay' // continue_learning: resolved per learner, never in the snapshot
+]);
+
+export const widgetSection = pgTable('widget_section', {
+  id: uuid().default(sql`gen_random_uuid()`).primaryKey().notNull(),
+  widgetId: uuid('widget_id').notNull(),
+  position: integer().default(0).notNull(),
+  type: widgetSectionType('type').notNull(),
+  sourceMode: widgetSectionSource('source_mode').default('manual').notNull(),
+  heading: varchar({ length: 160 }),
+  subheading: varchar({ length: 320 }),
+  config: jsonb('config').default(sql`'{}'::jsonb`).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`timezone('utc'::text, now())`).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' }).default(sql`timezone('utc'::text, now())`).notNull()
+}, (table) => [
+  foreignKey({ columns: [table.widgetId], foreignColumns: [widget.id], name: 'widget_section_widget_id_fkey' }).onDelete('cascade'),
+  index('idx_widget_section_widget_id').on(table.widgetId),
+  unique('widget_section_widget_position_key').on(table.widgetId, table.position)
+]);
+
+export const widgetSectionCourse = pgTable('widget_section_course', {
+  id: uuid().default(sql`gen_random_uuid()`).primaryKey().notNull(),
+  widgetSectionId: uuid('widget_section_id').notNull(),
+  courseId: uuid('course_id').notNull(),
+  order: integer().default(0).notNull()
+}, (table) => [
+  foreignKey({ columns: [table.widgetSectionId], foreignColumns: [widgetSection.id], name: 'widget_section_course_section_id_fkey' }).onDelete('cascade'),
+  foreignKey({ columns: [table.courseId], foreignColumns: [course.id], name: 'widget_section_course_course_id_fkey' }).onDelete('cascade'),
+  unique('widget_section_course_key').on(table.widgetSectionId, table.courseId)
+]);
+
+export const widgetSectionTagRole = pgEnum('WIDGET_SECTION_TAG_ROLE', ['include', 'exclude', 'category']);
+
+export const widgetSectionTag = pgTable('widget_section_tag', {
+  id: uuid().default(sql`gen_random_uuid()`).primaryKey().notNull(),
+  widgetSectionId: uuid('widget_section_id').notNull(),
+  tagId: uuid('tag_id').notNull(),
+  role: widgetSectionTagRole('role').default('include').notNull(),
+  order: integer().default(0).notNull(),
+  iconName: varchar('icon_name', { length: 64 })
+}, (table) => [
+  foreignKey({ columns: [table.widgetSectionId], foreignColumns: [widgetSection.id], name: 'widget_section_tag_section_id_fkey' }).onDelete('cascade'),
+  foreignKey({ columns: [table.tagId], foreignColumns: [tag.id], name: 'widget_section_tag_tag_id_fkey' }).onDelete('cascade'),
+  unique('widget_section_tag_key').on(table.widgetSectionId, table.tagId, table.role)
+]);
+```
+
+Analytics, implementing the schema the shipped widget PRD reserved, plus `section_id`:
+
+```ts
+export const widgetAnalyticsEvent = pgTable('widget_analytics_event', {
+  id: uuid().default(sql`gen_random_uuid()`).primaryKey().notNull(),
+  widgetId: uuid('widget_id').notNull(),
+  widgetVersionId: uuid('widget_version_id'),
+  widgetSectionId: uuid('widget_section_id'),
+  eventType: widgetEventType('event_type').notNull(), // impression | cta_click | category_click | enroll
+  courseId: uuid('course_id'),
+  sessionId: varchar('session_id', { length: 64 }).notNull(),
+  countryCode: varchar('country_code', { length: 2 }),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`timezone('utc'::text, now())`).notNull()
+});
+```
+
+`widget_course` is untouched and continues to serve block widgets.
+
+### Payload: snapshot + overlay
+
+The published snapshot stays anonymous and cacheable. Personalization is a second, uncached request the runtime merges in.
+
+```ts
+// packages/utils/src/validation/widget/build-page-payload.ts — pure, dependency-free
+export function buildWidgetPagePayload(input: BuildPagePayloadInput): TWidgetPagePayload {
+  const sections = input.sections
+    .filter((section) => section.sourceMode !== 'overlay') // continue_learning ships empty
+    .map((section) => {
+      const resolvedCourses = resolveSectionCourses(section, input); // reuses the existing
+                                                                    // filter → sort → slice pipeline
+      return {
+        id: section.id,
+        type: section.type,
+        heading: section.heading,
+        subheading: section.subheading,
+        options: section.config,
+        courses: resolvedCourses.map((course) => toPayloadCourse(course, input.orgBaseUrl)),
+        categories: buildSectionCategories(section, input)
+      };
+    });
+
+  return ZWidgetPagePayload.parse({ version: 'v1', kind: 'page', /* …org, design, labels… */ sections });
+}
+```
+
+The overlay is deliberately small — ids and numbers only, no course content, so it stays cheap and leaks nothing the snapshot did not already contain:
+
+```ts
+type TAcademyOverlay = {
+  learner: { id: string; name: string; roleTraits: string[] };
+  enrollments: Array<{
+    courseId: string;
+    progressPercent: number;      // computed at read time, never stored
+    resumeItemSlug: string | null;
+    lastActiveAt: string;
+  }>;
+  continueLearning: string[];      // ordered courseIds for the continue_learning section
+};
+```
+
+Merge rules in the runtime: a course in `enrollments` renders the Continue CTA and its progress bar; `continue_learning` renders only when the array is non-empty; a `category_grid` tile whose tag slug intersects `roleTraits` gets the For-you badge. Overlay failure is non-fatal — the page stays in its anonymous state.
+
+### Auth chain (cookie-free)
+
+```
+host server          embed runtime                     api
+    │                      │                            │
+    │ sign JWT (HS256,     │                            │
+    │ org token-auth       │                            │
+    │ secret, 2 min TTL)   │                            │
+    ├──── data-cio-token ─→│                            │
+    │                      ├─ POST /widgets/:key/session│
+    │                      │   { token }                │
+    │                      │                            ├─ exchangeToken(): verify sig,
+    │                      │                            │  find-or-create user,
+    │                      │                            │  ensure org membership
+    │                      │                            ├─ assert widget.org === token org
+    │                      │←── { accessToken, expiresAt, learner } ─┤
+    │                      │   (in memory only — never localStorage)
+    │                      ├─ Authorization: Bearer …  →│  embedLearnerMiddleware
+    │                      │                            │  resolves → c.set('user')
+```
+
+`exchangeToken()` already does the verification, user provisioning, and membership work; the new endpoint is a second caller of it that returns JSON instead of setting a cookie. Better Auth's `bearer()` plugin is added to `packages/db/src/auth.ts` so the issued session token resolves through the existing session path, and `embedLearnerMiddleware` additionally asserts that the bearer's org matches the widget's org before any handler runs.
+
+The access token lives in a closure inside the runtime — never `localStorage`, never a cookie — and is refreshed silently by re-posting the host's token when it expires.
+
+### API routes
+
+All embed traffic stays under the `/widgets/` prefix, which already has wildcard CORS with `credentials: false`. Nothing outside that prefix becomes reachable from a third-party origin.
+
+| Method | Route | Auth | Notes |
+| --- | --- | --- | --- |
+| `GET` | `/organization/widgets` | session + org | Extended with a `kind` filter |
+| `POST` | `/organization/widgets` | session + admin | Accepts `kind` and an optional starter template |
+| `GET` `PUT` | `/organization/widgets/:widgetId` | session + org | Returns/accepts sections for `kind = 'page'` |
+| `POST` | `/organization/widgets/:widgetId/sections` | session + org | Create a section |
+| `PUT` `DELETE` | `/organization/widgets/:widgetId/sections/:sectionId` | session + org | Update / delete |
+| `PUT` | `/organization/widgets/:widgetId/sections/order` | session + org | Reorder in one transaction |
+| `GET` | `/organization/widgets/:widgetId/analytics` | session + org | Section and course rollups |
+| `GET` | `/widgets/:publicKey/payload` | none | Extended to emit `sections[]`; cache policy unchanged |
+| `POST` | `/widgets/:publicKey/session` | org-signed JWT | Returns a short-lived bearer token. Rate limited hard. |
+| `GET` | `/widgets/:publicKey/me` | bearer | The overlay. `Cache-Control: private, no-store` |
+| `GET` | `/widgets/:publicKey/course/:courseSlug` | bearer optional | Course tree, via the existing public-course service |
+| `GET` | `/widgets/:publicKey/course/:courseSlug/item/:itemSlug` | bearer optional | Lesson/exercise view data |
+| `POST` | `/widgets/:publicKey/course/:courseSlug/item/:itemSlug/hls-cookie` | bearer optional | Widget-scoped mint of the existing playback cookie |
+| `POST` | `/widgets/:publicKey/course/:courseId/enroll` | bearer | Free/assigned only; paid returns `PAYMENT_REQUIRED` with a checkout URL |
+| `GET` | `/widgets/:publicKey/course/:courseId/progress` | bearer | Delegates to the existing progress service |
+| `PUT` | `/widgets/:publicKey/course/:courseId/lesson/:lessonId/completion` | bearer | Delegates to the existing completion service |
+| `POST` | `/widgets/:publicKey/course/:courseId/exercise/:exerciseId/submission` | bearer | Delegates to the existing submission service |
+| `POST` | `/widgets/:publicKey/events` | none | Batched analytics, fire-and-forget |
+
+Every one of these routes is thin: validate, call an existing service, return one type. No new business logic lands in the route layer, and no route opens a database transaction.
+
+### Runtime and bundle budgets
+
+The single 35 kB budget is replaced by per-chunk budgets, enforced in CI (the shipped PRD left budget enforcement unimplemented; this feature makes it mandatory).
+
+| Chunk | Loads when | Budget (gzip) |
+| --- | --- | --- |
+| `academy.js` loader | Always | ≤ 3 kB |
+| `index` (sections + cards + router) | Always | ≤ 30 kB |
+| `course` (course detail) | First course opened | ≤ 25 kB |
+| `player` (lesson + exercise + question types) | First lesson opened | ≤ 60 kB |
+
+First paint must still render the index from the cached snapshot before the overlay resolves. Course and player chunks are prefetched on hover/idle after first paint, never blocking it.
+
+Router adapters share one internal history stack:
+
+```ts
+type RouterAdapter = 'memory' | 'query' | 'custom';
+// memory: internal only (default)
+// query:  history.replaceState with ?cio=course/react-basics
+// custom: window.CIO.learn.navigate() / onNavigate()
+```
+
+Style isolation stays Shadow DOM. `theme.mode = 'inherit-host'` reads computed `font-family` and background/foreground from the mount point at boot and maps them onto the `--cio-*` custom properties, so the academy adopts the host's typography without letting host CSS reach inside the shadow root.
+
+### Frontend layering
+
+Following CLAUDE.md: validation in `packages/utils/src/validation/widget/` (`ZWidgetSection`, `ZWidgetPagePayload`, `ZAcademyOverlay`), pure queries in `packages/db/src/queries/widget/`, orchestration and transactions in `apps/api/src/services/widget-*.ts`, thin routes, and dashboard request types inferred in `apps/dashboard/src/lib/features/widget/utils/types.ts` with all logic in the API class. Section reordering and section-with-courses writes run inside one service-level transaction. All user-facing copy uses translation keys in `en.json`, with the other locales regenerated via `pnpm translate`.
+
+## Implementation Order
+
+1. **Validation and payload contracts.** `ZWidgetSection`, `ZWidgetPagePayload`, `ZAcademyOverlay`, section option schemas, and `buildWidgetPagePayload()` reusing the existing resolver. Unit tests for per-section resolution, ordering, and the reserved `path_list` rejection. → `pnpm --filter @cio/utils build`
+2. **Schema and queries.** `widget.kind`, `widget_section`, `widget_section_course`, `widget_section_tag`, `widget_analytics_event` plus the SQL migration, and query helpers accepting an optional `DbOrTxClient`. → `pnpm --filter @cio/db build`
+3. **Org-scoped API.** Section CRUD and reorder in one transaction, page-aware publish/version/rollback, analytics rollups. → `pnpm --filter @cio/api build`
+4. **Section renderers in `packages/ui`.** The five new section components plus adapters wrapping the six existing widget layouts, each with a Storybook story covering every state. → `pnpm --filter @cio/ui prefix && pnpm --filter @cio/storybook build`
+5. **Editor.** Sections panel with drag-reorder, per-section settings, theme-mode control, anonymous/signed-in preview toggle, embed + identity panel. → `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`
+6. **Runtime, phase 1 — index.** New `academy` embed entry, router with the three adapters, section rendering from the snapshot, analytics events, per-chunk size gate in CI. → `pnpm --filter @cio/embeds build`
+7. **Identity.** Better Auth `bearer()` plugin, `POST /widgets/:key/session` as a JSON caller of `exchangeToken()`, `embedLearnerMiddleware`, the `/me` overlay endpoint, and runtime merge. Integration tests for cross-org rejection and expiry.
+8. **Runtime, phase 2 — mini-app.** Course detail and player chunks wrapping `packages/ui/src/custom/public-course`, the widget-scoped course/item/HLS/enroll/completion/submission routes, and the paid-course ejection.
+9. **Docs and rollout.** `apps/docs` page for embedding and identity, feature flag, staged rollout.
+
+Verification before any commit or PR, per CLAUDE.md: `pnpm --filter @cio/api^... build && pnpm --filter @cio/api build`, `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`, `pnpm --filter @cio/embeds build`, and `pnpm format:check`.
+
+## Acceptance Criteria
+
+1. An admin on a paid plan can create an academy, add and reorder at least six section types, publish it, and roll back to a previous version.
+2. The published academy renders every configured section on a third-party origin with no host-page framework and no console errors.
+3. An anonymous visitor sees the full page; `continue_learning` collapses without leaving a gap, and no personalization affordance appears.
+4. A learner whose host app supplies a signed token sees their progress, a working Continue CTA that resumes at the correct item, and the For-you badge on the category matching their role trait.
+5. Overlay failure or expiry degrades to the anonymous state without blanking the page or blocking first paint.
+6. A signed-in learner can enrol in a free course, complete a lesson, and submit an exercise entirely inside the embed, and those writes appear in the LMS and admin reports as the same records the LMS would have created.
+7. A paid course opens academy checkout in a new tab; no payment UI renders inside the embed.
+8. Course detail, lesson, and exercise inside the embed are rendered by the same `packages/ui/src/custom/public-course` components the org-site route uses — no forked copies.
+9. Every chunk is within its gzip budget, enforced by a CI gate that fails the build on regression.
+10. A bearer token issued for one org is rejected on another org's widget key, and a widget key mounted on a non-allowlisted origin is refused.
+11. The access token is never written to `localStorage`, `sessionStorage`, or a cookie.
+12. Section impression and CTA-click events appear in the admin analytics view within one minute.
+13. All copy uses translation keys; `en.json` changes are propagated to every other locale via `pnpm translate`.
+14. Zero regression on existing features: block widgets, their payload endpoint, publish/rollback, the org landing page, and the org-site public course routes behave exactly as before, with the shipped widget test suite still green.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Scope: this is an LMS inside an embed, and the player is the largest piece | Phases 6 and 8 are separable releases. Phase 6 (index + sections, anonymous) is shippable value on its own; the mini-app can follow without rework because the router and chunk boundaries are designed for it in phase 6. |
+| Bundle growth swamps the "lightweight embed" promise | Per-chunk budgets with a CI gate, lazy route chunks, and index-first paint. The learner who only browses never downloads the player. |
+| Re-implementing the lesson player diverges from the LMS | Hard acceptance criterion (8): the embed must consume `packages/ui/src/custom/public-course`. Any prop the embed needs is added to the shared component, never forked. |
+| Third-party cookie policy shifts again | The design is already cookie-free; the token lives in memory and is re-minted from the host on expiry. |
+| A leaked public key lets someone re-host the academy | Per-widget allowed-origins list checked at session exchange, plus the existing per-key and per-IP rate limits. |
+| Wildcard CORS surface grows with each new embed route | Every embed route stays under `/widgets/:publicKey/`, scoped to a widget key and its org, and each one delegates to an existing service rather than adding new authorization logic. |
+| Personalization tempts us into leaking data into the cached snapshot | The snapshot builder physically cannot see learner data — `buildWidgetPagePayload` is pure and takes no learner argument. Personalization exists only in the `no-store` overlay. |
+| Host app CSS or routing conflicts | Shadow DOM for styling; the router defaults to the memory adapter so no host history is touched until the customer opts in. |
+| Section system diverges from the org landing page, leaving two page builders | Renderers are built in `packages/ui` with no embed-specific dependencies, so the landing page can adopt them later. Explicitly deferred, not designed out. |
+
+## Open Calls
+
+Two product calls were made without an explicit answer and can be vetoed:
+
+1. **Section-level analytics ship in v1** (Decision 14). The reserved schema plus an admin view is roughly a phase of work; cutting it defers phases 3-analytics and the analytics prototype.
+2. **`certificate_showcase` is deferred.** It was not selected for the v1 section catalog, so it is listed as a non-goal rather than reserved in the enum.

--- a/prototypes/embedded-academy/academy.css
+++ b/prototypes/embedded-academy/academy.css
@@ -1,0 +1,874 @@
+/*
+ * academy.css — the embedded runtime's own look, plus the mock host-app chrome
+ * used to show the embed sitting inside a customer's product.
+ *
+ * The academy renders inside a shadow root in production, so its tokens are
+ * namespaced --ac-* and never inherit from the host page. `theme.mode`
+ * = 'inherit-host' is simulated by the .ac-inherit class, which remaps the
+ * display font and surface colors onto whatever the host is using.
+ */
+
+/* ---------- mock host app chrome (NOT part of the product) ---------- */
+.host {
+  display: grid;
+  grid-template-columns: 232px 1fr;
+  min-height: 100dvh;
+  background: var(--host-bg);
+  color: var(--host-fg);
+}
+:root {
+  --host-bg: #fbfbf9;
+  --host-fg: #1d1c1a;
+  --host-side: #f4f3ef;
+  --host-line: #e6e4de;
+  --host-muted: #6b6862;
+  --host-accent: #2f6f4e;
+}
+.dark {
+  --host-bg: #16161a;
+  --host-fg: #ececea;
+  --host-side: #1c1c21;
+  --host-line: #2c2c33;
+  --host-muted: #97948e;
+  --host-accent: #6cc79a;
+}
+.host-side {
+  background: var(--host-side);
+  border-right: 1px solid var(--host-line);
+  padding: 16px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.host-brand {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 4px 8px 16px;
+  font-weight: 650;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+.host-brand .mk {
+  width: 24px;
+  height: 24px;
+  border-radius: 7px;
+  background: var(--host-accent);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 12px;
+  font-weight: 700;
+}
+.host-nav {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 9px;
+  border-radius: 8px;
+  font-size: 13.5px;
+  color: var(--host-muted);
+  text-decoration: none;
+}
+.host-nav svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 1.9;
+}
+.host-nav:hover {
+  background: rgb(0 0 0 / 0.04);
+  color: var(--host-fg);
+}
+.dark .host-nav:hover {
+  background: rgb(255 255 255 / 0.05);
+}
+.host-nav.on {
+  background: rgb(0 0 0 / 0.06);
+  color: var(--host-fg);
+  font-weight: 550;
+}
+.dark .host-nav.on {
+  background: rgb(255 255 255 / 0.08);
+}
+.host-sec {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--host-muted);
+  padding: 18px 9px 6px;
+  font-weight: 600;
+}
+.host-foot {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 8px 2px;
+  border-top: 1px solid var(--host-line);
+}
+.host-foot .av {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--host-accent);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  font-weight: 650;
+}
+.host-foot .nm {
+  font-size: 13px;
+  font-weight: 550;
+}
+.host-foot .rl {
+  font-size: 11.5px;
+  color: var(--host-muted);
+}
+.host-main {
+  overflow-y: auto;
+}
+
+/* embed boundary marker — a prototype affordance, not shipped chrome */
+.embed-wrap {
+  position: relative;
+}
+.embed-wrap.show-bounds {
+  outline: 1.5px dashed color-mix(in oklab, var(--primary) 55%, transparent);
+  outline-offset: -1px;
+  border-radius: 10px;
+}
+.embed-wrap.show-bounds::before {
+  content: 'ClassroomIO Embedded Academy · <div data-cio-widget="academy">';
+  position: absolute;
+  top: 0;
+  left: 14px;
+  transform: translateY(-50%);
+  background: var(--primary);
+  color: #fff;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  z-index: 5;
+}
+
+/* ---------- academy runtime tokens ---------- */
+.ac {
+  --ac-bg: transparent;
+  --ac-fg: #1d1c1a;
+  --ac-muted: #6b6862;
+  --ac-line: #e6e4de;
+  --ac-card: #ffffff;
+  --ac-accent: #c96442;
+  --ac-accent-fg: #ffffff;
+  --ac-radius: 12px;
+  --ac-display: 'Instrument Serif', 'Iowan Old Style', Georgia, serif;
+  --ac-body: Geist, ui-sans-serif, system-ui, sans-serif;
+  --ac-tint-a: #cfded3;
+  --ac-tint-b: #f4d8d2;
+  --ac-tint-c: #e2ddf0;
+  --ac-tint-d: #e9e3d5;
+  color: var(--ac-fg);
+  font-family: var(--ac-body);
+  background: var(--ac-bg);
+}
+.dark .ac {
+  --ac-fg: #ececea;
+  --ac-muted: #97948e;
+  --ac-line: #2c2c33;
+  --ac-card: #1e1e23;
+  --ac-tint-a: #33463a;
+  --ac-tint-b: #4a3630;
+  --ac-tint-c: #383150;
+  --ac-tint-d: #3b3629;
+}
+.ac-inherit {
+  --ac-display: Geist, ui-sans-serif, system-ui, sans-serif;
+  --ac-accent: var(--host-accent);
+}
+.ac-page {
+  max-width: 830px;
+  margin: 0 auto;
+  padding: 52px 32px 88px;
+}
+
+/* page_header */
+.ac-h1 {
+  font-family: var(--ac-display);
+  font-size: 40px;
+  font-weight: 400;
+  letter-spacing: -0.015em;
+  margin: 0;
+  line-height: 1.1;
+}
+.ac-lead {
+  font-size: 15px;
+  color: var(--ac-muted);
+  margin: 10px 0 0;
+}
+.ac-sec {
+  margin-top: 56px;
+}
+.ac-h2 {
+  font-family: var(--ac-display);
+  font-size: 27px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+.ac-sub {
+  font-size: 14px;
+  color: var(--ac-muted);
+  margin: 7px 0 0;
+}
+.ac-sec-body {
+  margin-top: 22px;
+}
+
+/* compact_list — featured rows */
+.ac-rows {
+  border: 1px solid var(--ac-line);
+  border-radius: var(--ac-radius);
+  overflow: hidden;
+  background: var(--ac-card);
+}
+.ac-row {
+  display: grid;
+  grid-template-columns: 132px 1fr 40px;
+  gap: 22px;
+  align-items: center;
+  padding: 18px;
+  text-decoration: none;
+  color: inherit;
+  border-bottom: 1px solid var(--ac-line);
+  transition: background 0.13s;
+}
+.ac-row:last-child {
+  border-bottom: 0;
+}
+.ac-row:hover {
+  background: color-mix(in oklab, var(--ac-fg) 3%, transparent);
+}
+.ac-row .thumb {
+  height: 96px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+}
+.ac-row .thumb svg {
+  width: 42px;
+  height: 42px;
+  opacity: 0.55;
+  stroke-width: 1.3;
+}
+.ac-eyebrow {
+  font-size: 11.5px;
+  color: var(--ac-muted);
+  letter-spacing: 0.02em;
+}
+.ac-row h3 {
+  font-family: var(--ac-display);
+  font-size: 23px;
+  font-weight: 400;
+  margin: 3px 0 6px;
+  letter-spacing: -0.01em;
+}
+.ac-row p {
+  font-size: 13.8px;
+  color: var(--ac-muted);
+  margin: 0;
+  line-height: 1.55;
+}
+.ac-arrow {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--ac-line);
+  display: grid;
+  place-items: center;
+  color: var(--ac-muted);
+  justify-self: end;
+}
+.ac-arrow svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 1.8;
+}
+.ac-row:hover .ac-arrow {
+  border-color: var(--ac-accent);
+  color: var(--ac-accent);
+}
+
+/* card_grid */
+.ac-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+.ac-card {
+  border: 1px solid var(--ac-line);
+  border-radius: var(--ac-radius);
+  overflow: hidden;
+  background: var(--ac-card);
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  transition:
+    border-color 0.13s,
+    transform 0.13s;
+}
+.ac-card:hover {
+  border-color: color-mix(in oklab, var(--ac-fg) 22%, transparent);
+  transform: translateY(-1px);
+}
+.ac-card .shot {
+  height: 118px;
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+.ac-card .shot svg {
+  width: 34px;
+  height: 34px;
+  opacity: 0.5;
+  stroke-width: 1.3;
+}
+.ac-card .dur {
+  position: absolute;
+  top: 9px;
+  right: 9px;
+  background: var(--ac-card);
+  border: 1px solid var(--ac-line);
+  border-radius: 999px;
+  font-size: 11.5px;
+  padding: 2px 9px;
+  font-weight: 500;
+}
+.ac-card .body {
+  padding: 13px 15px 16px;
+}
+.ac-card h4 {
+  font-size: 14.5px;
+  font-weight: 550;
+  margin: 4px 0 0;
+  line-height: 1.35;
+}
+
+/* category_grid */
+.ac-cats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+.ac-cat {
+  border: 1px solid var(--ac-line);
+  border-radius: var(--ac-radius);
+  background: var(--ac-card);
+  padding: 13px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.13s;
+}
+.ac-cat:hover {
+  border-color: color-mix(in oklab, var(--ac-fg) 22%, transparent);
+}
+.ac-cat .ico {
+  width: 40px;
+  height: 40px;
+  border-radius: 9px;
+  border: 1px solid var(--ac-line);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.ac-cat .ico svg {
+  width: 19px;
+  height: 19px;
+  stroke-width: 1.5;
+}
+.ac-cat .nm {
+  font-size: 13.5px;
+  font-weight: 550;
+  line-height: 1.25;
+}
+.ac-foryou {
+  display: inline-block;
+  margin-top: 4px;
+  background: #2f6fd0;
+  color: #fff;
+  font-size: 10.5px;
+  font-weight: 600;
+  padding: 1px 7px;
+  border-radius: 5px;
+  letter-spacing: 0.01em;
+}
+
+/* progress + continue */
+.ac-prog {
+  height: 4px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--ac-fg) 10%, transparent);
+  overflow: hidden;
+  margin-top: 11px;
+}
+.ac-prog > span {
+  display: block;
+  height: 100%;
+  background: var(--ac-accent);
+  border-radius: 999px;
+}
+.ac-pmeta {
+  font-size: 12px;
+  color: var(--ac-muted);
+  margin-top: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.ac-continue {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+.ac-cont-card {
+  border: 1px solid var(--ac-line);
+  border-radius: var(--ac-radius);
+  background: var(--ac-card);
+  padding: 16px;
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+.ac-cont-card:hover {
+  border-color: var(--ac-accent);
+}
+.ac-cont-card h4 {
+  font-size: 15px;
+  font-weight: 550;
+  margin: 5px 0 0;
+}
+.ac-cont-card .nxt {
+  font-size: 12.5px;
+  color: var(--ac-muted);
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.ac-cont-card .nxt svg {
+  width: 13px;
+  height: 13px;
+  stroke-width: 2;
+}
+
+/* buttons inside the academy */
+.ac-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 0;
+  border-radius: 9px;
+  padding: 9px 16px;
+  font-size: 13.5px;
+  font-weight: 550;
+  cursor: pointer;
+  text-decoration: none;
+  font-family: var(--ac-body);
+}
+.ac-btn-primary {
+  background: var(--ac-accent);
+  color: var(--ac-accent-fg);
+}
+.ac-btn-ghost {
+  background: transparent;
+  color: var(--ac-fg);
+  border: 1px solid var(--ac-line);
+}
+.ac-btn svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+}
+.ac-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  color: var(--ac-muted);
+  text-decoration: none;
+  margin-bottom: 22px;
+}
+.ac-back svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2;
+}
+.ac-back:hover {
+  color: var(--ac-fg);
+}
+.ac-note {
+  border: 1px dashed var(--ac-line);
+  border-radius: var(--ac-radius);
+  padding: 14px 16px;
+  font-size: 13px;
+  color: var(--ac-muted);
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+.ac-note svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+.ac-empty {
+  border: 1px dashed var(--ac-line);
+  border-radius: var(--ac-radius);
+  padding: 34px;
+  text-align: center;
+  color: var(--ac-muted);
+  font-size: 13.5px;
+}
+
+/* course detail */
+.ac-hero {
+  display: grid;
+  grid-template-columns: 1fr 268px;
+  gap: 34px;
+  align-items: start;
+}
+.ac-hero h1 {
+  font-family: var(--ac-display);
+  font-size: 36px;
+  font-weight: 400;
+  margin: 8px 0 0;
+  letter-spacing: -0.015em;
+  line-height: 1.12;
+}
+.ac-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--ac-muted);
+}
+.ac-facts .f {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.ac-facts svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 1.8;
+}
+.ac-buy {
+  border: 1px solid var(--ac-line);
+  border-radius: var(--ac-radius);
+  background: var(--ac-card);
+  padding: 18px;
+  position: sticky;
+  top: 24px;
+}
+.ac-buy .price {
+  font-family: var(--ac-display);
+  font-size: 29px;
+}
+.ac-curric {
+  border: 1px solid var(--ac-line);
+  border-radius: var(--ac-radius);
+  overflow: hidden;
+  background: var(--ac-card);
+}
+.ac-curric .grp {
+  padding: 11px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ac-muted);
+  background: color-mix(in oklab, var(--ac-fg) 3%, transparent);
+  border-bottom: 1px solid var(--ac-line);
+}
+.ac-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--ac-line);
+  font-size: 14px;
+  text-decoration: none;
+  color: inherit;
+}
+.ac-item:last-child {
+  border-bottom: 0;
+}
+.ac-item:hover {
+  background: color-mix(in oklab, var(--ac-fg) 3%, transparent);
+}
+.ac-item .ic {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1px solid var(--ac-line);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  color: var(--ac-muted);
+}
+.ac-item .ic svg {
+  width: 11px;
+  height: 11px;
+  stroke-width: 2.4;
+}
+.ac-item.done .ic {
+  background: var(--ac-accent);
+  border-color: var(--ac-accent);
+  color: #fff;
+}
+.ac-item .len {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--ac-muted);
+}
+.ac-lock {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--ac-muted);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+/* player shell */
+.ac-shell {
+  display: grid;
+  grid-template-columns: 268px 1fr;
+  min-height: 560px;
+  border: 1px solid var(--ac-line);
+  border-radius: var(--ac-radius);
+  overflow: hidden;
+  background: var(--ac-card);
+}
+.ac-side {
+  border-right: 1px solid var(--ac-line);
+  padding: 16px 0;
+  overflow-y: auto;
+  background: color-mix(in oklab, var(--ac-fg) 2%, transparent);
+}
+.ac-side-head {
+  padding: 0 16px 14px;
+  border-bottom: 1px solid var(--ac-line);
+  margin-bottom: 10px;
+}
+.ac-side-head .t {
+  font-size: 14px;
+  font-weight: 600;
+}
+.ac-srow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 16px;
+  font-size: 13.2px;
+  text-decoration: none;
+  color: var(--ac-muted);
+}
+.ac-srow:hover {
+  background: color-mix(in oklab, var(--ac-fg) 4%, transparent);
+  color: var(--ac-fg);
+}
+.ac-srow.on {
+  background: color-mix(in oklab, var(--ac-accent) 12%, transparent);
+  color: var(--ac-fg);
+  font-weight: 550;
+  box-shadow: inset 2px 0 0 var(--ac-accent);
+}
+.ac-srow .ic {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1px solid var(--ac-line);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.ac-srow .ic svg {
+  width: 9px;
+  height: 9px;
+  stroke-width: 3;
+}
+.ac-srow.done .ic {
+  background: var(--ac-accent);
+  border-color: var(--ac-accent);
+  color: #fff;
+}
+.ac-body {
+  padding: 30px 38px 38px;
+}
+.ac-body h1 {
+  font-family: var(--ac-display);
+  font-size: 30px;
+  font-weight: 400;
+  margin: 6px 0 20px;
+  letter-spacing: -0.012em;
+}
+.ac-prose {
+  font-size: 15px;
+  line-height: 1.72;
+  color: color-mix(in oklab, var(--ac-fg) 88%, transparent);
+}
+.ac-prose p {
+  margin: 0 0 16px;
+}
+.ac-prose h2 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 28px 0 10px;
+  font-family: var(--ac-body);
+}
+.ac-prose ul {
+  margin: 0 0 16px;
+  padding-left: 20px;
+}
+.ac-prose li {
+  margin-bottom: 7px;
+}
+.ac-video {
+  aspect-ratio: 16/9;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  margin-bottom: 24px;
+}
+.ac-video .play {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: rgb(0 0 0 / 0.55);
+  color: #fff;
+  display: grid;
+  place-items: center;
+}
+.ac-video .play svg {
+  width: 22px;
+  height: 22px;
+}
+.ac-footnav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 34px;
+  padding-top: 22px;
+  border-top: 1px solid var(--ac-line);
+}
+
+/* exercise */
+.ac-q {
+  border: 1px solid var(--ac-line);
+  border-radius: var(--ac-radius);
+  padding: 20px;
+  margin-bottom: 14px;
+  background: var(--ac-card);
+}
+.ac-q .qn {
+  font-size: 11.5px;
+  color: var(--ac-muted);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.ac-q .qt {
+  font-size: 15.5px;
+  font-weight: 550;
+  margin: 7px 0 15px;
+  line-height: 1.45;
+}
+.ac-opt {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 11px 13px;
+  border: 1px solid var(--ac-line);
+  border-radius: 9px;
+  margin-bottom: 8px;
+  font-size: 14px;
+  cursor: pointer;
+}
+.ac-opt:hover {
+  border-color: color-mix(in oklab, var(--ac-fg) 25%, transparent);
+}
+.ac-opt .rd {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1.5px solid var(--ac-line);
+  flex-shrink: 0;
+}
+.ac-opt.sel {
+  border-color: var(--ac-accent);
+  background: color-mix(in oklab, var(--ac-accent) 7%, transparent);
+}
+.ac-opt.sel .rd {
+  border-color: var(--ac-accent);
+  border-width: 5px;
+}
+.ac-opt.right {
+  border-color: #3f9c6d;
+  background: color-mix(in oklab, #3f9c6d 10%, transparent);
+}
+.ac-opt.wrong {
+  border-color: #c9524b;
+  background: color-mix(in oklab, #c9524b 10%, transparent);
+}
+
+/* prototype-only: state switcher pinned to the viewport */
+.proto-bar {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px;
+  box-shadow: var(--shadow-md);
+  font-family: Geist, sans-serif;
+}
+.proto-bar button {
+  border: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 550;
+  padding: 6px 11px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.proto-bar button.on {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+.proto-bar .lbl {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted-foreground);
+  padding-left: 8px;
+  font-weight: 600;
+}

--- a/prototypes/embedded-academy/admin-academies.html
+++ b/prototypes/embedded-academy/admin-academies.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Widgets · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&family=Instrument+Serif&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="academy.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .org-pill { display: flex; align-items: center; gap: 8px; padding: 7px 9px; margin: 4px 0 14px; border: 1px solid var(--sidebar-border); border-radius: var(--radius-md); font-size: 13px; }
+      .org-pill .l { width: 20px; height: 20px; border-radius: 5px; background: var(--primary); color: var(--primary-foreground); display: grid; place-items: center; font-size: 11px; font-weight: 700; }
+      .org-pill .n { font-weight: 550; }
+      .org-pill svg { width: 14px; height: 14px; stroke-width: 2; margin-left: auto; color: var(--muted-foreground); }
+      .wgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-top: 18px; }
+      .wcard { border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--card); overflow: hidden; box-shadow: var(--shadow-2xs); text-decoration: none; color: inherit; display: block; transition: border-color 0.12s, transform 0.12s; }
+      .wcard:hover { border-color: color-mix(in oklab, var(--foreground) 22%, transparent); transform: translateY(-1px); }
+      .wcard .mini-prev { height: 132px; padding: 12px; background: color-mix(in oklab, var(--foreground) 4%, transparent); border-bottom: 1px solid var(--border); display: flex; flex-direction: column; gap: 6px; }
+      .mini-prev .bar { height: 8px; border-radius: 3px; background: color-mix(in oklab, var(--foreground) 16%, transparent); }
+      .mini-prev .bar.w40 { width: 40%; } .mini-prev .bar.w60 { width: 60%; }
+      .mini-prev .strip { height: 26px; border-radius: 5px; background: color-mix(in oklab, var(--foreground) 9%, transparent); }
+      .mini-prev .cols { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }
+      .mini-prev .cols > div { height: 30px; border-radius: 5px; background: color-mix(in oklab, var(--foreground) 9%, transparent); }
+      .wcard .meta { padding: 13px 15px 15px; }
+      .wcard .tt { font-size: 14.5px; font-weight: 600; }
+      .wcard .sb { font-size: 12.3px; color: var(--muted-foreground); margin-top: 4px; display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+      .newcard { border: 1px dashed var(--border); border-radius: var(--radius-lg); display: grid; place-items: center; min-height: 244px; color: var(--muted-foreground); cursor: pointer; text-decoration: none; }
+      .newcard:hover { border-color: var(--primary); color: var(--primary); background: color-mix(in oklab, var(--primary) 4%, transparent); }
+      .newcard svg { width: 22px; height: 22px; stroke-width: 2; }
+      .tmpl { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 14px; }
+      .tmpl button { text-align: left; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--card); padding: 14px; cursor: pointer; font-family: inherit; color: inherit; }
+      .tmpl button:hover { border-color: var(--primary); }
+      .tmpl b { font-size: 13.5px; } .tmpl p { font-size: 12.3px; color: var(--muted-foreground); margin: 5px 0 0; line-height: 1.5; }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="brand"><div class="brand-mark">C</div><div class="brand-name">ClassroomIO</div></div>
+        <div class="org-pill"><span class="l">N</span><span class="n">Northwind Academy</span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m6 9 6 6 6-6"/></svg></div>
+        <div class="nav-label">Workspace</div>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>Dashboard</a>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Courses</a>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>Audience</a>
+        <a class="nav-item active" href="admin-academies.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>Widgets<span class="nav-tail tnum">4</span></a>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M14 9V5a3 3 0 0 0-6 0v4"/><rect x="4" y="9" width="16" height="12" rx="2"/></svg>Community</a>
+        <div class="nav-label">Settings</div>
+        <a class="nav-item" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="3"/><path d="M12 3v2M12 19v2M3 12h2M19 12h2"/></svg>Organization</a>
+        <div class="sidebar-foot"><div class="avatar">JD</div><div class="who"><div class="nm">Jordan Diallo</div><div class="rl">Admin</div></div></div>
+      </aside>
+
+      <div class="main">
+        <header class="topbar">
+          <nav class="crumbs"><span class="here">Widgets</span></nav>
+          <div class="top-actions"><button class="btn btn-sm btn-primary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 5v14M5 12h14"/></svg>New</button></div>
+        </header>
+
+        <div class="content">
+          <div class="wrap">
+            <div class="page-head">
+              <h1 class="page-title">Widgets</h1>
+              <p class="page-sub">Embed your courses on any site — a single block, or your whole academy.</p>
+            </div>
+
+            <div class="seg-toggle" style="width: fit-content">
+              <button onclick="showTab('blocks', this)">Blocks<span style="opacity: 0.6; margin-left: 6px">2</span></button>
+              <button class="on" onclick="showTab('academies', this)">Academies<span style="opacity: 0.6; margin-left: 6px">2</span></button>
+            </div>
+
+            <div id="tab-academies">
+              <div class="wgrid">
+                <a class="wcard" href="admin-editor.html">
+                  <div class="mini-prev">
+                    <div class="bar w40"></div>
+                    <div class="strip"></div>
+                    <div class="strip"></div>
+                    <div class="cols"><div></div><div></div><div></div></div>
+                  </div>
+                  <div class="meta">
+                    <div class="tt">Northwind Learn</div>
+                    <div class="sb"><span class="badge badge-warning">Draft</span><span>5 sections</span><span>Identity on</span></div>
+                  </div>
+                </a>
+                <a class="wcard" href="admin-editor.html">
+                  <div class="mini-prev">
+                    <div class="bar w60"></div>
+                    <div class="cols"><div></div><div></div><div></div></div>
+                    <div class="cols"><div></div><div></div><div></div></div>
+                  </div>
+                  <div class="meta">
+                    <div class="tt">Partner Enablement Hub</div>
+                    <div class="sb"><span class="badge badge-success">Published</span><span>3 sections</span><span>v4 · 6 days ago</span></div>
+                  </div>
+                </a>
+                <a class="newcard" href="#new" onclick="document.getElementById('new-panel').scrollIntoView({behavior:'smooth'})">
+                  <div style="text-align: center">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 5v14M5 12h14"/></svg>
+                    <div style="font-size: 13.5px; font-weight: 550; margin-top: 8px">New academy</div>
+                  </div>
+                </a>
+              </div>
+
+              <div id="new-panel" class="card card-pad" style="margin-top: 26px">
+                <h2 style="font-size: 14px; font-weight: 650; margin: 0">Start from a template</h2>
+                <p style="font-size: 12.8px; color: var(--muted-foreground); margin: 5px 0 0">Templates pre-fill sections. You can add, reorder, or remove any of them afterwards.</p>
+                <div class="tmpl">
+                  <button onclick="location.href='admin-editor.html'"><b>Learn page</b><p>Header, continue learning, featured list, tutorial grid, and browse-by-role. Matches the in-app academy pattern.</p></button>
+                  <button onclick="location.href='admin-editor.html'"><b>Catalog</b><p>Header, category grid, and a full card grid of every published course.</p></button>
+                  <button onclick="location.href='admin-editor.html'"><b>Blank</b><p>One empty page. Add your own sections from scratch.</p></button>
+                </div>
+              </div>
+            </div>
+
+            <div id="tab-blocks" style="display: none">
+              <div class="wgrid">
+                <a class="wcard" href="#"><div class="mini-prev"><div class="cols"><div></div><div></div><div></div></div></div><div class="meta"><div class="tt">Homepage course grid</div><div class="sb"><span class="badge badge-success">Published</span><span>card_grid · 6 courses</span></div></div></a>
+                <a class="wcard" href="#"><div class="mini-prev"><div class="strip"></div><div class="strip"></div><div class="strip"></div></div><div class="meta"><div class="tt">Docs sidebar list</div><div class="sb"><span class="badge badge-secondary">Archived</span><span>compact_list · 4 courses</span></div></div></a>
+                <a class="newcard" href="#"><div style="text-align: center"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 5v14M5 12h14"/></svg><div style="font-size: 13.5px; font-weight: 550; margin-top: 8px">New block</div></div></a>
+              </div>
+            </div>
+
+            <div id="tab-empty" style="display: none">
+              <div class="ac-empty" style="margin-top: 20px; border-color: var(--border); color: var(--muted-foreground)">
+                <div style="font-size: 15px; font-weight: 600; color: var(--foreground); margin-bottom: 6px">No academies yet</div>
+                An academy is a full page — your Learn tab, dropped into your own product with one script tag.
+                <div style="margin-top: 16px"><button class="btn btn-primary" onclick="location.href='admin-editor.html'">Create your first academy</button></div>
+              </div>
+            </div>
+
+            <div id="tab-locked" style="display: none">
+              <div class="card card-pad" style="margin-top: 20px; text-align: center">
+                <span class="badge badge-primary-soft">Paid plan</span>
+                <div style="font-size: 16px; font-weight: 600; margin: 12px 0 6px">Academies are available on paid plans</div>
+                <p style="font-size: 13.3px; color: var(--muted-foreground); max-width: 460px; margin: 0 auto 16px; line-height: 1.6">Blocks stay on your current plan. Full-page academies — and the learner personalization that comes with them — need an upgrade.</p>
+                <button class="btn btn-primary">See plans</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="proto-bar">
+      <span class="lbl">State</span>
+      <button class="on" onclick="showState('list', this)">Has academies</button>
+      <button onclick="showState('empty', this)">Empty</button>
+      <button onclick="showState('locked', this)">Free plan</button>
+      <button onclick="toggleTheme(this)">Dark</button>
+      <a class="btn btn-sm btn-ghost" href="index.html">Map</a>
+    </div>
+
+    <script>
+      function showTab(tab, el) {
+        el.parentElement.querySelectorAll('button').forEach((b) => b.classList.remove('on'));
+        el.classList.add('on');
+        document.getElementById('tab-academies').style.display = tab === 'academies' ? 'block' : 'none';
+        document.getElementById('tab-blocks').style.display = tab === 'blocks' ? 'block' : 'none';
+      }
+      function showState(state, el) {
+        el.parentElement.querySelectorAll('button').forEach((b) => b.classList.remove('on'));
+        el.classList.add('on');
+        document.getElementById('tab-academies').style.display = state === 'list' ? 'block' : 'none';
+        document.getElementById('tab-empty').style.display = state === 'empty' ? 'block' : 'none';
+        document.getElementById('tab-locked').style.display = state === 'locked' ? 'block' : 'none';
+      }
+      function toggleTheme(el) {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+        el.textContent = dark ? 'Light' : 'Dark';
+      }
+    </script>
+  </body>
+</html>

--- a/prototypes/embedded-academy/admin-analytics.html
+++ b/prototypes/embedded-academy/admin-analytics.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Academy analytics · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&family=Instrument+Serif&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="academy.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      body { margin: 0; }
+      .ed { display: flex; flex-direction: column; min-height: 100dvh; background: var(--background); color: var(--foreground); }
+      .ed-top { display: flex; align-items: center; gap: 12px; padding: 10px 14px; border-bottom: 1px solid var(--border); }
+      .ed-top .nm { font-size: 14.5px; font-weight: 600; } .ed-top .sp { flex: 1; }
+      .abody { padding: 28px 34px 70px; max-width: 940px; }
+      .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 26px; }
+      .sec-analytics { border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden; background: var(--card); }
+      .sa-row { display: grid; grid-template-columns: 26px 1fr 108px 108px 92px; align-items: center; gap: 14px; padding: 13px 16px; border-bottom: 1px solid var(--border); font-size: 13.5px; }
+      .sa-row:last-child { border-bottom: 0; }
+      .sa-row.head { font-size: 11.5px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted-foreground); font-weight: 650; background: color-mix(in oklab, var(--foreground) 3%, transparent); }
+      .sa-row .rk { color: var(--muted-foreground); font-size: 12px; }
+      .sa-row .nm { font-weight: 550; } .sa-row .ty { font-size: 11.8px; color: var(--muted-foreground); margin-top: 2px; }
+      .sa-row .num { text-align: right; font-variant-numeric: tabular-nums; }
+      .sa-row .ctr { text-align: right; font-variant-numeric: tabular-nums; font-weight: 600; }
+      .bar-mini { height: 5px; border-radius: 999px; background: color-mix(in oklab, var(--primary) 15%, transparent); overflow: hidden; margin-top: 6px; }
+      .bar-mini > span { display: block; height: 100%; background: var(--primary); }
+      h2.st { font-size: 14px; font-weight: 650; margin: 30px 0 12px; }
+    </style>
+  </head>
+  <body>
+    <div class="ed">
+      <header class="ed-top">
+        <a class="btn btn-sm btn-ghost" href="admin-academies.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>Academies</a>
+        <span class="nm">Northwind Learn</span>
+        <span class="badge badge-success">Published · v7</span>
+        <span class="sp"></span>
+        <div class="seg-toggle"><button>7 days</button><button class="on">30 days</button><button>90 days</button></div>
+        <a class="btn btn-sm btn-outline" href="admin-editor.html">Edit sections</a>
+      </header>
+
+      <div class="abody" id="filled">
+        <div class="stats">
+          <div class="card card-pad stat-card"><div class="k">Page views</div><div class="v tnum">12,480</div><div class="s">+18% vs previous 30 days</div></div>
+          <div class="card card-pad stat-card"><div class="k">Course clicks</div><div class="v tnum">3,207</div><div class="s">25.7% of views</div></div>
+          <div class="card card-pad stat-card"><div class="k">Enrolments</div><div class="v tnum">846</div><div class="s">26.4% of clicks</div></div>
+          <div class="card card-pad stat-card"><div class="k">Completions</div><div class="v tnum">291</div><div class="s">34.4% of enrolments</div></div>
+        </div>
+
+        <h2 class="st">By section</h2>
+        <div class="sec-analytics">
+          <div class="sa-row head"><span></span><span>Section</span><span class="num">Impressions</span><span class="num">Clicks</span><span class="ctr">CTR</span></div>
+          <div class="sa-row"><span class="rk">1</span><span><span class="nm">Jump back in</span><span class="ty">continue_learning</span><span class="bar-mini"><span style="width: 100%"></span></span></span><span class="num tnum">7,910</span><span class="num tnum">1,486</span><span class="ctr">18.8%</span></div>
+          <div class="sa-row"><span class="rk">2</span><span><span class="nm">Featured courses</span><span class="ty">compact_list</span><span class="bar-mini"><span style="width: 84%"></span></span></span><span class="num tnum">12,401</span><span class="num tnum">982</span><span class="ctr">7.9%</span></div>
+          <div class="sa-row"><span class="rk">3</span><span><span class="nm">Browse by role</span><span class="ty">category_grid</span><span class="bar-mini"><span style="width: 52%"></span></span></span><span class="num tnum">9,140</span><span class="num tnum">514</span><span class="ctr">5.6%</span></div>
+          <div class="sa-row"><span class="rk">4</span><span><span class="nm">Getting started</span><span class="ty">card_grid</span><span class="bar-mini"><span style="width: 24%"></span></span></span><span class="num tnum">10,882</span><span class="num tnum">225</span><span class="ctr">2.1%</span></div>
+        </div>
+        <p style="font-size: 12.5px; color: var(--muted-foreground); margin: 11px 2px 0; line-height: 1.6">Impressions count a section entering the viewport once per session. <b>Jump back in</b> is seen by fewer people — only signed-in learners with progress — but converts more than twice as well as anything else on the page.</p>
+
+        <h2 class="st">Top courses</h2>
+        <div class="sec-analytics">
+          <div class="sa-row head"><span></span><span>Course</span><span class="num">Clicks</span><span class="num">Enrolments</span><span class="ctr">Completed</span></div>
+          <div class="sa-row"><span class="rk">1</span><span class="nm">Automations for Support Teams</span><span class="num tnum">1,142</span><span class="num tnum">388</span><span class="ctr tnum">126</span></div>
+          <div class="sa-row"><span class="rk">2</span><span class="nm">Northwind 101</span><span class="num tnum">903</span><span class="num tnum">271</span><span class="ctr tnum">104</span></div>
+          <div class="sa-row"><span class="rk">3</span><span class="nm">Building on the Northwind API</span><span class="num tnum">618</span><span class="num tnum">122</span><span class="ctr tnum">39</span></div>
+          <div class="sa-row"><span class="rk">4</span><span class="nm">Advanced Data Modelling</span><span class="num tnum">544</span><span class="num tnum">65</span><span class="ctr tnum">22</span></div>
+        </div>
+        <p style="font-size: 12.5px; color: var(--muted-foreground); margin: 11px 2px 0">Enrolments and completions are attributed to this academy only when the learner arrived through it.</p>
+      </div>
+
+      <div class="abody" id="empty" style="display: none">
+        <div class="ac-empty" style="border-color: var(--border); color: var(--muted-foreground); padding: 52px">
+          <div style="font-size: 15px; font-weight: 600; color: var(--foreground); margin-bottom: 6px">No events yet</div>
+          Analytics start collecting the first time a learner loads the published academy. Events appear here within a minute.
+          <div style="margin-top: 16px"><a class="btn btn-outline" href="admin-embed.html">Get the embed code</a></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="proto-bar">
+      <span class="lbl">State</span>
+      <button class="on" onclick="setState('filled', this)">With data</button>
+      <button onclick="setState('empty', this)">Empty</button>
+      <button onclick="toggleTheme(this)">Dark</button>
+      <a class="btn btn-sm btn-ghost" href="index.html">Map</a>
+    </div>
+
+    <script>
+      function setState(state, el) {
+        el.parentElement.querySelectorAll('button').forEach((b) => b.classList.remove('on'));
+        el.classList.add('on');
+        document.getElementById('filled').style.display = state === 'filled' ? 'block' : 'none';
+        document.getElementById('empty').style.display = state === 'empty' ? 'block' : 'none';
+      }
+      function toggleTheme(el) {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+        el.textContent = dark ? 'Light' : 'Dark';
+      }
+    </script>
+  </body>
+</html>

--- a/prototypes/embedded-academy/admin-editor.html
+++ b/prototypes/embedded-academy/admin-editor.html
@@ -1,0 +1,268 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Academy editor · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&family=Instrument+Serif&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="academy.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      body { margin: 0; }
+      .ed { display: flex; flex-direction: column; height: 100dvh; background: var(--background); color: var(--foreground); }
+      .ed-top { display: flex; align-items: center; gap: 12px; padding: 10px 14px; border-bottom: 1px solid var(--border); flex-shrink: 0; }
+      .ed-top .nm { font-size: 14.5px; font-weight: 600; }
+      .ed-top .sp { flex: 1; }
+      .ed-main { display: flex; flex: 1; min-height: 0; }
+      .rail { width: 56px; flex-shrink: 0; border-right: 1px solid var(--border); background: var(--secondary); display: flex; flex-direction: column; align-items: center; gap: 6px; padding: 12px 0; }
+      .rail .ib { width: 34px; height: 34px; border-radius: var(--radius-md); border: 0; background: transparent; color: var(--muted-foreground); display: grid; place-items: center; cursor: pointer; }
+      .rail .ib:hover { background: var(--accent); color: var(--foreground); }
+      .rail .ib.on { background: var(--primary); color: var(--primary-foreground); }
+      .rail .ib svg { width: 16px; height: 16px; stroke-width: 2; }
+      .panel { width: 336px; flex-shrink: 0; border-right: 1px solid var(--border); overflow-y: auto; padding: 16px 14px 28px; }
+      .panel h2 { font-size: 13px; font-weight: 650; margin: 0 0 3px; }
+      .panel .ph { font-size: 12.3px; color: var(--muted-foreground); margin: 0 0 15px; line-height: 1.5; }
+      .sec-list { display: flex; flex-direction: column; gap: 7px; }
+      .sec-row { display: grid; grid-template-columns: 18px 30px 1fr auto; align-items: center; gap: 10px; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 9px 10px; cursor: pointer; box-shadow: var(--shadow-2xs); transition: border-color 0.12s, box-shadow 0.12s, opacity 0.12s; }
+      .sec-row:hover { border-color: color-mix(in oklab, var(--foreground) 22%, transparent); }
+      .sec-row.on { border-color: var(--primary); box-shadow: 0 0 0 3px color-mix(in oklab, var(--primary) 14%, transparent); }
+      .sec-row.dragging { opacity: 0.35; }
+      .sec-row.over { border-color: var(--primary); }
+      .sec-row .gr { color: var(--muted-foreground); cursor: grab; display: grid; place-items: center; }
+      .sec-row .gr svg { width: 14px; height: 14px; stroke-width: 2; }
+      .sec-row .ico { width: 28px; height: 28px; border-radius: 7px; background: color-mix(in oklab, var(--primary) 10%, transparent); color: var(--primary); display: grid; place-items: center; }
+      .sec-row .ico svg { width: 14px; height: 14px; stroke-width: 2; }
+      .sec-row .tt { font-size: 13px; font-weight: 550; line-height: 1.2; }
+      .sec-row .sb { font-size: 11.5px; color: var(--muted-foreground); margin-top: 2px; }
+      .sec-row .del { width: 24px; height: 24px; border: 0; background: transparent; border-radius: 6px; color: var(--muted-foreground); display: grid; place-items: center; cursor: pointer; }
+      .sec-row .del:hover { color: var(--destructive); background: color-mix(in oklab, var(--destructive) 10%, transparent); }
+      .sec-row .del svg { width: 13px; height: 13px; stroke-width: 2; }
+      .add-sec { width: 100%; margin-top: 9px; border: 1px dashed var(--border); border-radius: var(--radius-md); background: transparent; color: var(--muted-foreground); font-size: 13px; font-weight: 550; padding: 11px; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 7px; font-family: inherit; }
+      .add-sec:hover { border-color: var(--primary); color: var(--primary); background: color-mix(in oklab, var(--primary) 5%, transparent); }
+      .add-sec svg { width: 15px; height: 15px; stroke-width: 2.3; }
+      .add-menu { display: none; margin-top: 8px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--card); overflow: hidden; box-shadow: var(--shadow-md); }
+      .add-menu.open { display: block; }
+      .add-menu .grp { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 650; color: var(--muted-foreground); padding: 9px 12px 5px; }
+      .add-menu button { width: 100%; text-align: left; border: 0; background: transparent; padding: 8px 12px; font-size: 13px; cursor: pointer; color: var(--foreground); font-family: inherit; display: flex; align-items: center; gap: 9px; }
+      .add-menu button:hover { background: var(--accent); }
+      .add-menu button svg { width: 14px; height: 14px; stroke-width: 2; color: var(--muted-foreground); }
+      .add-menu button .rs { margin-left: auto; font-size: 10.5px; color: var(--muted-foreground); border: 1px solid var(--border); border-radius: 5px; padding: 1px 6px; }
+      .settings { display: none; }
+      .settings.open { display: block; }
+      .set-head { display: flex; align-items: center; gap: 8px; margin-bottom: 14px; }
+      .set-head button { border: 0; background: transparent; color: var(--muted-foreground); cursor: pointer; display: grid; place-items: center; padding: 0; }
+      .set-head svg { width: 15px; height: 15px; stroke-width: 2.2; }
+      .set-head .t { font-size: 13px; font-weight: 650; }
+      .prev { flex: 1; min-width: 0; background: color-mix(in oklab, var(--foreground) 4%, transparent); overflow-y: auto; position: relative; }
+      .prev-bar { position: sticky; top: 0; z-index: 4; display: flex; align-items: center; gap: 8px; padding: 9px 14px; background: var(--background); border-bottom: 1px solid var(--border); font-size: 12.5px; color: var(--muted-foreground); }
+      .prev-frame { margin: 22px auto; max-width: 880px; background: var(--host-bg); border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden; box-shadow: var(--shadow-md); }
+      .save-bar { position: fixed; left: 50%; bottom: 20px; transform: translateX(-50%); display: flex; align-items: center; gap: 10px; background: var(--card); border: 1px solid var(--border); border-radius: 999px; padding: 8px 8px 8px 18px; box-shadow: var(--shadow-md); z-index: 40; font-size: 13px; }
+      .lockbox { border: 1px solid var(--border); border-radius: var(--radius-md); padding: 11px 13px; font-size: 12.3px; color: var(--muted-foreground); line-height: 1.55; background: color-mix(in oklab, var(--primary) 4%, transparent); margin-top: 10px; }
+    </style>
+  </head>
+  <body>
+    <div class="ed">
+      <header class="ed-top">
+        <a class="btn btn-sm btn-ghost" href="admin-academies.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>Academies</a>
+        <span class="nm">Northwind Learn</span>
+        <span class="badge badge-warning">Draft · unpublished changes</span>
+        <span class="sp"></span>
+        <a class="btn btn-sm btn-ghost" href="admin-analytics.html">Analytics</a>
+        <button class="btn btn-sm btn-outline">Discard</button>
+        <button class="btn btn-sm btn-secondary">Save</button>
+        <button class="btn btn-sm btn-primary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 19V5M5 12l7-7 7 7"/></svg>Publish</button>
+      </header>
+
+      <div class="ed-main">
+        <nav class="rail">
+          <button class="ib on" title="Sections"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="18" height="6" rx="1"/><rect x="3" y="13" width="8" height="8" rx="1"/><rect x="14" y="13" width="7" height="8" rx="1"/></svg></button>
+          <button class="ib" title="Design"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="13.5" cy="6.5" r=".5"/><circle cx="17.5" cy="10.5" r=".5"/><circle cx="8.5" cy="7.5" r=".5"/><circle cx="6.5" cy="12.5" r=".5"/><path d="M12 2a10 10 0 1 0 0 20 2 2 0 0 0 0-4 2 2 0 0 1 0-4h3a5 5 0 0 0 5-5c0-4-4-7-8-7z"/></svg></button>
+          <button class="ib" title="Embed and identity" onclick="location.href='admin-embed.html'"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></button>
+        </nav>
+
+        <aside class="panel">
+          <div id="list-view">
+            <h2>Sections</h2>
+            <p class="ph">Drag to reorder. The academy renders sections top to bottom.</p>
+            <div class="sec-list" id="sections">
+              <div class="sec-row on" draggable="true" onclick="openSettings('Page header')"><span class="gr"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="9" cy="6" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="18" r="1"/><circle cx="15" cy="6" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="18" r="1"/></svg></span><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 6h16M4 12h10"/></svg></span><span><span class="tt">Learn</span><span class="sb">page_header</span></span><button class="del" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14"/></svg></button></div>
+              <div class="sec-row" draggable="true" onclick="openSettings('Jump back in')"><span class="gr"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="9" cy="6" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="18" r="1"/><circle cx="15" cy="6" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="18" r="1"/></svg></span><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 3v5h5"/></svg></span><span><span class="tt">Jump back in</span><span class="sb">continue_learning · per learner</span></span><button class="del" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14"/></svg></button></div>
+              <div class="sec-row" draggable="true" onclick="openSettings('Featured courses')"><span class="gr"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="9" cy="6" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="18" r="1"/><circle cx="15" cy="6" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="18" r="1"/></svg></span><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 6h18M3 12h18M3 18h18"/></svg></span><span><span class="tt">Featured courses</span><span class="sb">compact_list · 2 courses, manual</span></span><button class="del" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14"/></svg></button></div>
+              <div class="sec-row" draggable="true" onclick="openSettings('Getting started')"><span class="gr"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="9" cy="6" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="18" r="1"/><circle cx="15" cy="6" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="18" r="1"/></svg></span><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg></span><span><span class="tt">Getting started</span><span class="sb">card_grid · tag: Onboarding</span></span><button class="del" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14"/></svg></button></div>
+              <div class="sec-row" draggable="true" onclick="openSettings('Browse by role')"><span class="gr"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="9" cy="6" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="18" r="1"/><circle cx="15" cy="6" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="18" r="1"/></svg></span><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="8" height="8" rx="1"/><rect x="13" y="3" width="8" height="8" rx="1"/><rect x="3" y="13" width="8" height="8" rx="1"/><rect x="13" y="13" width="8" height="8" rx="1"/></svg></span><span><span class="tt">Browse by role</span><span class="sb">category_grid · 8 tags</span></span><button class="del" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14"/></svg></button></div>
+            </div>
+
+            <button class="add-sec" onclick="document.getElementById('add-menu').classList.toggle('open')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 5v14M5 12h14"/></svg>Add section</button>
+            <div class="add-menu" id="add-menu">
+              <div class="grp">Content</div>
+              <button onclick="addSection('Page header', 'page_header')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 6h16M4 12h10"/></svg>Page header</button>
+              <button onclick="addSection('Rich text', 'rich_text')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 6h16M4 12h16M4 18h10"/></svg>Rich text</button>
+              <button onclick="addSection('Banner', 'cta_banner')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="7" width="18" height="10" rx="2"/></svg>CTA banner</button>
+              <div class="grp">Courses</div>
+              <button onclick="addSection('New card grid', 'card_grid')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>Card grid</button>
+              <button onclick="addSection('New list', 'compact_list')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 6h18M3 12h18M3 18h18"/></svg>Compact list</button>
+              <button onclick="addSection('New carousel', 'carousel')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="6" y="5" width="12" height="14" rx="2"/><path d="M2 9v6M22 9v6"/></svg>Carousel</button>
+              <button onclick="addSection('New spotlight', 'editorial_spotlight')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="12" height="18" rx="1"/><rect x="17" y="3" width="4" height="8" rx="1"/></svg>Editorial spotlight</button>
+              <button onclick="addSection('Browse by role', 'category_grid')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="8" height="8" rx="1"/><rect x="13" y="3" width="8" height="8" rx="1"/><rect x="3" y="13" width="8" height="8" rx="1"/><rect x="13" y="13" width="8" height="8" rx="1"/></svg>Category grid</button>
+              <button onclick="addSection('Jump back in', 'continue_learning')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 3v5h5"/></svg>Continue learning</button>
+              <button disabled style="opacity: 0.5; cursor: not-allowed"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M6 3v12"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="6" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>Learning path list<span class="rs">Reserved</span></button>
+            </div>
+          </div>
+
+          <div class="settings" id="settings-view">
+            <div class="set-head">
+              <button onclick="closeSettings()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 12H5M12 19l-7-7 7-7"/></svg></button>
+              <span class="t" id="set-title">Featured courses</span>
+            </div>
+            <div class="field"><label class="label">Heading</label><input class="input" value="Featured courses" /></div>
+            <div class="field"><label class="label">Subheading</label><input class="input" value="Self-paced, multi-lesson courses from the Northwind Academy." /></div>
+            <div class="field">
+              <label class="label">Source</label>
+              <select class="select"><option>Selected courses (manual)</option><option>Courses with a tag</option><option>All published courses</option></select>
+              <p class="hint">Manual keeps the exact order you set below.</p>
+            </div>
+            <div class="field">
+              <label class="label">Courses</label>
+              <div class="item item-outline" style="margin-bottom: 6px"><span class="item-content"><span class="item-title">Automations for Support Teams</span><span class="item-desc">8 lessons · Free</span></span></div>
+              <div class="item item-outline"><span class="item-content"><span class="item-title">Northwind 101</span><span class="item-desc">6 lessons · Free</span></span></div>
+              <button class="add-sec" style="margin-top: 7px"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 5v14M5 12h14"/></svg>Add course</button>
+            </div>
+            <div class="field" style="display: flex; align-items: center; gap: 10px"><label class="switch"><input type="checkbox" checked /><span class="track"></span><span class="knob"></span></label><span style="font-size: 13.5px">Show course image</span></div>
+            <div class="field" style="display: flex; align-items: center; gap: 10px"><label class="switch"><input type="checkbox" checked /><span class="track"></span><span class="knob"></span></label><span style="font-size: 13.5px">Show description excerpt</span></div>
+            <div class="field" style="display: flex; align-items: center; gap: 10px"><label class="switch"><input type="checkbox" checked /><span class="track"></span><span class="knob"></span></label><span style="font-size: 13.5px">Show progress for signed-in learners</span></div>
+            <div class="field"><label class="label">CTA label</label><input class="input" value="View course" /></div>
+            <div class="lockbox">Progress, <b>Jump back in</b>, and <b>For you</b> only render when the host page supplies a learner token. Set that up in <a href="admin-embed.html" class="text-primary">Embed &amp; identity</a>.</div>
+          </div>
+        </aside>
+
+        <section class="prev">
+          <div class="prev-bar">
+            <span>Preview</span>
+            <div class="seg-toggle" style="margin-left: 6px">
+              <button class="on" onclick="setPreview('personal', this)">Signed in</button>
+              <button onclick="setPreview('anon', this)">Anonymous</button>
+            </div>
+            <div class="seg-toggle">
+              <button class="on">Desktop</button>
+              <button>Mobile</button>
+            </div>
+            <span style="margin-left: auto">Last synced 2 minutes ago</span>
+            <button class="icon-btn" title="Refresh"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 3v5h5"/></svg></button>
+          </div>
+
+          <div class="prev-frame">
+            <div class="ac">
+              <div class="ac-page" style="padding: 40px 30px 56px">
+                <h1 class="ac-h1">Learn</h1>
+                <p class="ac-lead">Courses, tutorials, and use cases from the Northwind Academy.</p>
+
+                <section class="ac-sec" data-personal>
+                  <h2 class="ac-h2">Jump back in</h2>
+                  <div class="ac-sec-body ac-continue">
+                    <a class="ac-cont-card" href="#"><div class="ac-eyebrow">Course · 62% complete</div><h4>Automations for Support Teams</h4><div class="ac-prog"><span style="width: 62%"></span></div></a>
+                    <a class="ac-cont-card" href="#"><div class="ac-eyebrow">Course · 40% complete</div><h4>Reporting Fundamentals</h4><div class="ac-prog"><span style="width: 40%"></span></div></a>
+                  </div>
+                </section>
+
+                <section class="ac-sec">
+                  <h2 class="ac-h2">Featured courses</h2>
+                  <p class="ac-sub">Self-paced, multi-lesson courses from the Northwind Academy.</p>
+                  <div class="ac-sec-body ac-rows">
+                    <a class="ac-row" href="#"><div class="thumb" style="background: var(--ac-tint-a)"></div><div><div class="ac-eyebrow">Course</div><h3>Automations for Support Teams</h3><p>Route, escalate, and resolve tickets automatically.</p></div><span class="ac-arrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span></a>
+                    <a class="ac-row" href="#"><div class="thumb" style="background: var(--ac-tint-b)"></div><div><div class="ac-eyebrow">Course</div><h3>Northwind 101</h3><p>Everything you need for your first week.</p></div><span class="ac-arrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span></a>
+                  </div>
+                </section>
+
+                <section class="ac-sec">
+                  <h2 class="ac-h2">Getting started</h2>
+                  <div class="ac-sec-body ac-grid">
+                    <a class="ac-card" href="#"><div class="shot" style="background: var(--ac-tint-a)"><span class="dur">4 min</span></div><div class="body"><div class="ac-eyebrow">Tutorial</div><h4>Set up your first workspace</h4></div></a>
+                    <a class="ac-card" href="#"><div class="shot" style="background: var(--ac-tint-b)"><span class="dur">4 min</span></div><div class="body"><div class="ac-eyebrow">Tutorial</div><h4>Delegating your first task</h4></div></a>
+                    <a class="ac-card" href="#"><div class="shot" style="background: var(--ac-tint-c)"><span class="dur">6 min</span></div><div class="body"><div class="ac-eyebrow">Tutorial</div><h4>Getting started with connectors</h4></div></a>
+                  </div>
+                </section>
+
+                <section class="ac-sec">
+                  <h2 class="ac-h2">Browse by role</h2>
+                  <div class="ac-sec-body ac-cats" style="grid-template-columns: repeat(3, 1fr)">
+                    <a class="ac-cat" href="#"><span class="ico"></span><span><span class="nm">Engineering</span><br /><span class="ac-foryou" data-personal>For you</span></span></a>
+                    <a class="ac-cat" href="#"><span class="ico"></span><span class="nm">Marketing</span></a>
+                    <a class="ac-cat" href="#"><span class="ico"></span><span class="nm">Sales</span></a>
+                  </div>
+                </section>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <div class="save-bar">
+        <span>Unsaved changes</span>
+        <button class="btn btn-sm btn-outline">Discard</button>
+        <button class="btn btn-sm btn-primary">Save changes</button>
+      </div>
+    </div>
+
+    <div class="proto-bar">
+      <button onclick="toggleTheme(this)">Dark</button>
+      <a class="btn btn-sm btn-ghost" href="index.html">Map</a>
+    </div>
+
+    <script>
+      function openSettings(title) {
+        document.getElementById('set-title').textContent = title;
+        document.getElementById('list-view').style.display = 'none';
+        document.getElementById('settings-view').classList.add('open');
+      }
+      function closeSettings() {
+        document.getElementById('list-view').style.display = 'block';
+        document.getElementById('settings-view').classList.remove('open');
+      }
+      function addSection(label, type) {
+        document.getElementById('add-menu').classList.remove('open');
+        const list = document.getElementById('sections');
+        const row = list.lastElementChild.cloneNode(true);
+        row.querySelector('.tt').textContent = label;
+        row.querySelector('.sb').textContent = type + ' · not configured';
+        row.classList.remove('on');
+        row.setAttribute('onclick', "openSettings('" + label + "')");
+        list.appendChild(row);
+        wireDrag();
+      }
+      let dragged = null;
+      function wireDrag() {
+        document.querySelectorAll('#sections .sec-row').forEach((row) => {
+          row.ondragstart = () => { dragged = row; row.classList.add('dragging'); };
+          row.ondragend = () => { row.classList.remove('dragging'); document.querySelectorAll('.sec-row').forEach((r) => r.classList.remove('over')); };
+          row.ondragover = (event) => { event.preventDefault(); if (row !== dragged) row.classList.add('over'); };
+          row.ondragleave = () => row.classList.remove('over');
+          row.ondrop = (event) => {
+            event.preventDefault();
+            row.classList.remove('over');
+            if (!dragged || row === dragged) return;
+
+            const list = document.getElementById('sections');
+            const rows = [...list.children];
+            if (rows.indexOf(dragged) < rows.indexOf(row)) row.after(dragged);
+            else row.before(dragged);
+          };
+        });
+      }
+      wireDrag();
+      function setPreview(mode, el) {
+        el.parentElement.querySelectorAll('button').forEach((b) => b.classList.remove('on'));
+        el.classList.add('on');
+        document.querySelectorAll('.prev [data-personal]').forEach((node) => (node.style.display = mode === 'anon' ? 'none' : ''));
+      }
+      function toggleTheme(el) {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+        el.textContent = dark ? 'Light' : 'Dark';
+      }
+    </script>
+  </body>
+</html>

--- a/prototypes/embedded-academy/admin-embed.html
+++ b/prototypes/embedded-academy/admin-embed.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Embed &amp; identity · ClassroomIO</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&family=Instrument+Serif&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="academy.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      body { margin: 0; }
+      .ed { display: flex; flex-direction: column; height: 100dvh; background: var(--background); color: var(--foreground); }
+      .ed-top { display: flex; align-items: center; gap: 12px; padding: 10px 14px; border-bottom: 1px solid var(--border); flex-shrink: 0; }
+      .ed-top .nm { font-size: 14.5px; font-weight: 600; }
+      .ed-top .sp { flex: 1; }
+      .ed-main { display: flex; flex: 1; min-height: 0; }
+      .rail { width: 56px; flex-shrink: 0; border-right: 1px solid var(--border); background: var(--secondary); display: flex; flex-direction: column; align-items: center; gap: 6px; padding: 12px 0; }
+      .rail .ib { width: 34px; height: 34px; border-radius: var(--radius-md); border: 0; background: transparent; color: var(--muted-foreground); display: grid; place-items: center; cursor: pointer; }
+      .rail .ib:hover { background: var(--accent); color: var(--foreground); }
+      .rail .ib.on { background: var(--primary); color: var(--primary-foreground); }
+      .rail .ib svg { width: 16px; height: 16px; stroke-width: 2; }
+      .doc { flex: 1; overflow-y: auto; padding: 30px 34px 70px; }
+      .doc-inner { max-width: 720px; }
+      h1.dt { font-size: 21px; font-weight: 650; margin: 0 0 5px; }
+      p.ds { font-size: 13.5px; color: var(--muted-foreground); margin: 0 0 26px; line-height: 1.6; }
+      .step { border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--card); padding: 18px 20px; margin-bottom: 14px; box-shadow: var(--shadow-2xs); }
+      .step-head { display: flex; align-items: center; gap: 11px; margin-bottom: 12px; }
+      .step-head .n { width: 24px; height: 24px; border-radius: 50%; background: var(--primary); color: var(--primary-foreground); display: grid; place-items: center; font-size: 12px; font-weight: 700; flex-shrink: 0; }
+      .step-head .t { font-size: 14.5px; font-weight: 600; }
+      .step-head .st { margin-left: auto; }
+      pre { background: color-mix(in oklab, var(--foreground) 5%, transparent); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 13px 15px; overflow-x: auto; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.2px; line-height: 1.65; margin: 0; }
+      pre .k { color: #b45309; } .dark pre .k { color: #f0b060; }
+      pre .s { color: #2f6f4e; } .dark pre .s { color: #7fc9a0; }
+      pre .c { color: var(--muted-foreground); }
+      .copy { float: right; margin: -2px 0 8px; }
+      .note { font-size: 12.5px; color: var(--muted-foreground); line-height: 1.6; margin: 11px 0 0; }
+    </style>
+  </head>
+  <body>
+    <div class="ed">
+      <header class="ed-top">
+        <a class="btn btn-sm btn-ghost" href="admin-academies.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>Academies</a>
+        <span class="nm">Northwind Learn</span>
+        <span class="badge badge-success">Published · v7</span>
+        <span class="sp"></span>
+        <a class="btn btn-sm btn-ghost" href="admin-analytics.html">Analytics</a>
+        <button class="btn btn-sm btn-primary">Publish</button>
+      </header>
+
+      <div class="ed-main">
+        <nav class="rail">
+          <button class="ib" title="Sections" onclick="location.href='admin-editor.html'"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="18" height="6" rx="1"/><rect x="3" y="13" width="8" height="8" rx="1"/><rect x="14" y="13" width="7" height="8" rx="1"/></svg></button>
+          <button class="ib" title="Design"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="13.5" cy="6.5" r=".5"/><circle cx="17.5" cy="10.5" r=".5"/><path d="M12 2a10 10 0 1 0 0 20 2 2 0 0 0 0-4 2 2 0 0 1 0-4h3a5 5 0 0 0 5-5c0-4-4-7-8-7z"/></svg></button>
+          <button class="ib on" title="Embed and identity"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></button>
+        </nav>
+
+        <div class="doc">
+          <div class="doc-inner">
+            <h1 class="dt">Embed &amp; identity</h1>
+            <p class="ds">Drop this academy into your product. Step 1 gets it rendering; steps 2 and 3 make it personal to each learner.</p>
+
+            <div class="step">
+              <div class="step-head"><span class="n">1</span><span class="t">Add the embed</span><span class="st"><span class="badge badge-success">Ready</span></span></div>
+              <button class="btn btn-sm btn-outline copy">Copy</button>
+              <pre><span class="c">&lt;!-- where the academy should render --&gt;</span>
+&lt;<span class="k">div</span> <span class="k">data-cio-widget</span>=<span class="s">"academy"</span> <span class="k">data-widget-key</span>=<span class="s">"wgt_7Kq2mBx9"</span>&gt;&lt;/<span class="k">div</span>&gt;
+&lt;<span class="k">script</span> async type=<span class="s">"module"</span> src=<span class="s">"https://embeds.classroomio.com/embeds/academy/academy.js"</span>&gt;&lt;/<span class="k">script</span>&gt;</pre>
+              <p class="note">The loader is 3 kB. Course detail and the lesson player load only when a learner opens one.</p>
+            </div>
+
+            <div class="step">
+              <div class="step-head"><span class="n">2</span><span class="t">Sign a learner token on your server</span><span class="st"><span class="badge badge-success">Token auth active</span></span></div>
+              <button class="btn btn-sm btn-outline copy">Copy</button>
+              <pre><span class="c">// server-side, per request — never in the browser</span>
+<span class="k">const</span> token = <span class="k">await new</span> SignJWT({ sub: user.id, email: user.email, name: user.name })
+  .setProtectedHeader({ alg: <span class="s">'HS256'</span> })
+  .setIssuedAt()
+  .setExpirationTime(<span class="s">'2m'</span>)
+  .sign(<span class="k">new</span> TextEncoder().encode(process.env.CIO_TOKEN_AUTH_SECRET));</pre>
+              <p class="note">Uses your organization's existing token-auth signing secret. Manage or rotate it in <a class="text-primary" href="#">Settings → Auth → Token auth</a>.</p>
+            </div>
+
+            <div class="step">
+              <div class="step-head"><span class="n">3</span><span class="t">Hand the token to the embed</span></div>
+              <button class="btn btn-sm btn-outline copy">Copy</button>
+              <pre>&lt;<span class="k">div</span> <span class="k">data-cio-widget</span>=<span class="s">"academy"</span>
+     <span class="k">data-widget-key</span>=<span class="s">"wgt_7Kq2mBx9"</span>
+     <span class="k">data-cio-token</span>=<span class="s">"&lt;%= token %&gt;"</span>&gt;&lt;/<span class="k">div</span>&gt;</pre>
+              <p class="note">The embed exchanges this for a short-lived access token held in memory. Nothing is written to cookies or local storage, so the academy works in browsers that block third-party cookies.</p>
+            </div>
+
+            <div class="step">
+              <div class="step-head"><span class="n">4</span><span class="t">Routing</span></div>
+              <div class="field">
+                <label class="label">History mode</label>
+                <select class="select" onchange="setRouter(this.value)">
+                  <option value="memory">In the embed only (default)</option>
+                  <option value="query">Sync to the page URL (?cio=…)</option>
+                  <option value="custom">My app owns routing</option>
+                </select>
+                <p class="hint" id="router-hint">Zero conflict with your router. Refreshing returns to the academy index.</p>
+              </div>
+              <pre id="router-code">&lt;<span class="k">div</span> <span class="k">data-cio-widget</span>=<span class="s">"academy"</span> <span class="k">data-widget-key</span>=<span class="s">"wgt_7Kq2mBx9"</span>&gt;&lt;/<span class="k">div</span>&gt;</pre>
+            </div>
+
+            <div class="step">
+              <div class="step-head"><span class="n">5</span><span class="t">Allowed origins</span></div>
+              <div class="field">
+                <label class="label">Only mount this academy on</label>
+                <input class="input" value="https://app.northwind.com, https://staging.northwind.com" />
+                <p class="hint">A leaked widget key cannot be re-hosted anywhere else. Leave blank to allow any origin.</p>
+              </div>
+            </div>
+
+            <div class="step" id="locked-step" style="display: none; border-color: color-mix(in oklab, var(--primary) 35%, transparent)">
+              <div class="step-head"><span class="n">!</span><span class="t">Personalization needs Enterprise</span></div>
+              <p class="note" style="margin-top: 0">Token auth is an Enterprise feature. Without it the academy still renders for everyone — it just cannot show progress, <b>Jump back in</b>, or <b>For you</b>, and learners enrol on the academy rather than in place.</p>
+              <button class="btn btn-sm btn-primary" style="margin-top: 12px">See Enterprise</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="proto-bar">
+      <span class="lbl">State</span>
+      <button class="on" onclick="setIdentity(true, this)">Identity active</button>
+      <button onclick="setIdentity(false, this)">Not configured</button>
+      <button onclick="toggleTheme(this)">Dark</button>
+      <a class="btn btn-sm btn-ghost" href="index.html">Map</a>
+    </div>
+
+    <script>
+      const ROUTER = {
+        memory: { hint: 'Zero conflict with your router. Refreshing returns to the academy index.', code: '&lt;<span class="k">div</span> <span class="k">data-cio-widget</span>=<span class="s">"academy"</span> <span class="k">data-widget-key</span>=<span class="s">"wgt_7Kq2mBx9"</span>&gt;&lt;/<span class="k">div</span>&gt;' },
+        query: { hint: 'Writes ?cio=course/automations to your page URL. Back button and shared links work.', code: '&lt;<span class="k">div</span> <span class="k">data-cio-widget</span>=<span class="s">"academy"</span> <span class="k">data-widget-key</span>=<span class="s">"wgt_7Kq2mBx9"</span>\n     <span class="k">data-cio-router</span>=<span class="s">"query"</span>&gt;&lt;/<span class="k">div</span>&gt;' },
+        custom: { hint: 'Wire the academy into your own router with navigate() and onNavigate().', code: 'window.CIO.learn.navigate(<span class="s">\'course/automations\'</span>);\nwindow.CIO.learn.onNavigate((route) =&gt; myRouter.push(<span class="s">\'/learn/\'</span> + route));' }
+      };
+      function setRouter(mode) {
+        document.getElementById('router-hint').textContent = ROUTER[mode].hint;
+        document.getElementById('router-code').innerHTML = ROUTER[mode].code;
+      }
+      function setIdentity(active, el) {
+        el.parentElement.querySelectorAll('button').forEach((b) => b.classList.remove('on'));
+        el.classList.add('on');
+        document.querySelectorAll('.step')[1].style.display = active ? 'block' : 'none';
+        document.querySelectorAll('.step')[2].style.display = active ? 'block' : 'none';
+        document.getElementById('locked-step').style.display = active ? 'none' : 'block';
+      }
+      function toggleTheme(el) {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+        el.textContent = dark ? 'Light' : 'Dark';
+      }
+    </script>
+  </body>
+</html>

--- a/prototypes/embedded-academy/app-theme.css
+++ b/prototypes/embedded-academy/app-theme.css
@@ -1,0 +1,1178 @@
+/*
+ * app-theme.css — shared theme for the embedded-academy prototypes.
+ *
+ * Tokens mirror packages/ui/src/index.css (shadcn-svelte) exactly:
+ * OKLCH palette, Geist, --radius: 0.625rem, shadow-2xs, and the component
+ * recipes from @cio/ui base components (Button, Badge, Item, Progress, Sidebar).
+ * Dark mode uses the same `.dark` class convention as the app.
+ */
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.488 0.243 264.376);
+  --primary-foreground: oklch(0.97 0.014 254.604);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+
+  /* Semantic states from @cio/ui Badge variants (emerald / amber) */
+  --success: oklch(0.596 0.145 163.225); /* emerald-600 */
+  --success-foreground: #fff;
+  --success-soft: oklch(0.596 0.145 163.225 / 0.12);
+  --warning: oklch(0.666 0.179 58.318); /* amber-600 */
+  --warning-foreground: #fff;
+  --warning-soft: oklch(0.666 0.179 58.318 / 0.14);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  --shadow-2xs: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.424 0.199 265.638);
+  --primary-foreground: oklch(0.97 0.014 254.604);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+
+  --success: oklch(0.696 0.17 162.48); /* emerald-500 */
+  --success-foreground: oklch(0.262 0.051 172.552); /* emerald-950 */
+  --success-soft: oklch(0.696 0.17 162.48 / 0.16);
+  --warning: oklch(0.769 0.188 70.08); /* amber-500 */
+  --warning-foreground: oklch(0.279 0.077 45.635); /* amber-950 */
+  --warning-soft: oklch(0.769 0.188 70.08 / 0.16);
+}
+
+/* ============ base ============ */
+* {
+  box-sizing: border-box;
+  border-color: var(--border);
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+body {
+  font-family:
+    'Geist',
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+  background: var(--background);
+  color: var(--foreground);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+button {
+  font: inherit;
+}
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+.text-muted {
+  color: var(--muted-foreground);
+}
+.text-primary {
+  color: var(--primary);
+}
+
+/* ============ app shell ============ */
+.app {
+  display: grid;
+  grid-template-columns: 256px 1fr;
+  min-height: 100vh;
+}
+.main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.content {
+  padding: 28px 28px 64px;
+}
+.wrap {
+  max-width: 960px;
+  margin: 0 auto;
+}
+.wrap-narrow {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+/* sidebar (mirrors @cio/ui base/sidebar) */
+.sidebar {
+  background: var(--sidebar);
+  border-right: 1px solid var(--sidebar-border);
+  padding: 16px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px 14px;
+}
+.brand-mark {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-md);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 14px;
+}
+.brand-name {
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: -0.01em;
+}
+.nav-label {
+  font-size: 11px;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  padding: 12px 8px 4px;
+}
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px;
+  border-radius: var(--radius-md);
+  color: var(--sidebar-foreground);
+  font-weight: 400;
+  font-size: 14px;
+  transition: background 0.1s;
+}
+.nav-item svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+  color: var(--muted-foreground);
+  flex-shrink: 0;
+}
+.nav-item:hover {
+  background: var(--sidebar-accent);
+}
+.nav-item.active {
+  background: var(--sidebar-accent);
+  color: var(--sidebar-accent-foreground);
+  font-weight: 500;
+}
+.nav-item.active svg {
+  color: var(--sidebar-accent-foreground);
+}
+.nav-tail {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+.nav-badge {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+.sidebar-foot {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px;
+  border-top: 1px solid var(--sidebar-border);
+}
+.avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.who {
+  min-width: 0;
+}
+.who .nm {
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.who .rl {
+  font-size: 11.5px;
+  color: var(--muted-foreground);
+}
+
+/* path identity block (teacher path sidebar) */
+.back-link {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--muted-foreground);
+  padding: 6px 8px;
+  border-radius: var(--radius-md);
+  margin-bottom: 4px;
+}
+.back-link:hover {
+  background: var(--sidebar-accent);
+  color: var(--foreground);
+}
+.back-link svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+}
+.path-id {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 8px 14px;
+  border-bottom: 1px solid var(--sidebar-border);
+  margin-bottom: 6px;
+}
+.path-id .ico {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.path-id .ico svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+}
+.path-id .nm {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+.path-id .st {
+  font-size: 11.5px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 2px;
+}
+.path-id .st .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+}
+.st-active {
+  color: var(--success);
+}
+.st-active .dot {
+  background: var(--success);
+}
+.st-draft {
+  color: var(--warning);
+}
+.st-draft .dot {
+  background: var(--warning);
+}
+
+/* topbar */
+.topbar {
+  height: 56px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in oklab, var(--background) 90%, transparent);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 24px;
+}
+.crumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13.5px;
+  color: var(--muted-foreground);
+  min-width: 0;
+}
+.crumbs a:hover {
+  color: var(--foreground);
+}
+.crumbs .sep {
+  color: var(--border);
+}
+.crumbs .here {
+  color: var(--foreground);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.top-title {
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+.top-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ============ buttons (mirrors @cio/ui base/button) ============ */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: var(--radius-md);
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  height: 36px;
+  padding: 0 16px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    border-color 0.12s,
+    color 0.12s;
+  box-shadow: var(--shadow-2xs);
+  user-select: none;
+}
+.btn svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+  flex-shrink: 0;
+}
+.btn-primary {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+.btn-primary:hover {
+  background: color-mix(in oklab, var(--primary) 90%, transparent);
+}
+.btn-outline {
+  background: var(--background);
+  border-color: var(--input);
+  color: var(--foreground);
+}
+.btn-outline:hover {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+.btn-secondary {
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+}
+.btn-secondary:hover {
+  background: color-mix(in oklab, var(--secondary) 80%, transparent);
+}
+.btn-ghost {
+  background: transparent;
+  box-shadow: none;
+  color: var(--foreground);
+}
+.btn-ghost:hover {
+  background: var(--accent);
+}
+.btn-destructive {
+  background: var(--destructive);
+  color: #fff;
+}
+.btn-success {
+  background: var(--success);
+  color: var(--success-foreground);
+}
+.btn-sm {
+  height: 32px;
+  padding: 0 12px;
+  font-size: 13px;
+  gap: 6px;
+}
+.btn-sm svg {
+  width: 15px;
+  height: 15px;
+}
+.btn-lg {
+  height: 40px;
+  padding: 0 24px;
+}
+.btn[disabled],
+.btn.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+.btn-icon {
+  width: 36px;
+  padding: 0;
+}
+.btn-icon.btn-sm {
+  width: 32px;
+}
+
+/* ============ badges (mirrors @cio/ui base/badge) ============ */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: fit-content;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.badge svg {
+  width: 12px;
+  height: 12px;
+  stroke-width: 2.4;
+}
+.badge-default {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+.badge-secondary {
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+}
+.badge-success {
+  background: var(--success);
+  color: var(--success-foreground);
+}
+.badge-warning {
+  background: var(--warning);
+  color: var(--warning-foreground);
+}
+.badge-outline {
+  border-color: var(--border);
+  color: var(--foreground);
+  background: transparent;
+}
+.badge-success-soft {
+  background: var(--success-soft);
+  color: var(--success);
+}
+.badge-primary-soft {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+  color: var(--primary);
+}
+.badge-muted {
+  background: var(--muted);
+  color: var(--muted-foreground);
+}
+
+/* ============ cards ============ */
+.card {
+  background: var(--card);
+  color: var(--card-foreground);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-2xs);
+}
+.card-pad {
+  padding: 20px;
+}
+
+/* ============ item rows (mirrors @cio/ui base/item) ============ */
+.item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  padding: 16px;
+  font-size: 14px;
+  transition:
+    background 0.1s,
+    border-color 0.1s;
+}
+.item-muted {
+  background: color-mix(in oklab, var(--muted) 50%, transparent);
+}
+.item-outline {
+  border-color: var(--border);
+}
+.item-done {
+  opacity: 0.6;
+}
+.item-done .item-title,
+.item-done .item-desc {
+  color: var(--muted-foreground);
+  text-decoration: line-through;
+}
+.item-current {
+  background: var(--card);
+  border-color: var(--primary);
+  box-shadow: var(--shadow-sm);
+}
+.item-dashed {
+  border: 1px dashed var(--border);
+  background: transparent;
+}
+a.item:hover {
+  background: color-mix(in oklab, var(--accent) 50%, transparent);
+}
+
+.item-media-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  background: var(--muted);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin-top: 2px;
+  color: var(--muted-foreground);
+}
+.item-media-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+}
+.item-media-icon.is-done {
+  background: var(--success);
+  border-color: var(--success);
+  color: var(--success-foreground);
+}
+.item-media-icon.is-current {
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  border-color: color-mix(in oklab, var(--primary) 30%, transparent);
+  color: var(--primary);
+}
+.item-media-lg {
+  width: 40px;
+  height: 40px;
+}
+.item-media-lg svg {
+  width: 19px;
+  height: 19px;
+}
+.item-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.item-title {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+}
+.item-title-lg {
+  font-size: 15px;
+  font-weight: 600;
+}
+.item-desc {
+  font-size: 13px;
+  color: var(--muted-foreground);
+  line-height: 1.45;
+}
+.item-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.item-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+
+/* ============ progress (mirrors @cio/ui base/progress) ============ */
+.progress {
+  height: 8px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: color-mix(in oklab, var(--primary) 20%, transparent);
+  flex: 1;
+}
+.progress > span {
+  display: block;
+  height: 100%;
+  background: var(--primary);
+  border-radius: var(--radius-md);
+  transition: width 0.3s;
+}
+.progress-success > span {
+  background: var(--success);
+}
+.progress-thin {
+  height: 6px;
+}
+
+/* progress ring (mirrors @cio/ui custom/percent-ring-progress) */
+.ring {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  flex-shrink: 0;
+}
+.ring-sm {
+  width: 40px;
+  height: 40px;
+}
+.ring svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+  display: block;
+}
+.ring .track {
+  stroke: var(--border);
+}
+.ring .arc {
+  stroke: var(--success);
+  transition: stroke-dashoffset 0.7s ease-out;
+}
+.ring .lbl {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--foreground);
+}
+.ring-sm .lbl {
+  font-size: 10px;
+}
+
+/* completion dots (setup page pattern) */
+.dots {
+  display: flex;
+  gap: 4px;
+}
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--border);
+}
+.dot.on {
+  background: var(--success);
+}
+
+/* ============ forms ============ */
+.input,
+.textarea,
+.select {
+  width: 100%;
+  font: inherit;
+  font-size: 14px;
+  color: var(--foreground);
+  background: transparent;
+  border: 1px solid var(--input);
+  border-radius: var(--radius-md);
+  padding: 7px 12px;
+  outline: none;
+  box-shadow: var(--shadow-2xs);
+  transition:
+    border-color 0.12s,
+    box-shadow 0.12s;
+}
+.input:focus,
+.textarea:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 50%, transparent);
+}
+.textarea {
+  resize: vertical;
+  min-height: 76px;
+  line-height: 1.55;
+}
+.label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+.hint {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  margin-top: 5px;
+}
+.field {
+  margin-bottom: 18px;
+}
+.field:last-child {
+  margin-bottom: 0;
+}
+
+/* switch */
+.switch {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  flex-shrink: 0;
+  cursor: pointer;
+  display: inline-block;
+}
+.switch input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  margin: 0;
+  cursor: pointer;
+  z-index: 1;
+}
+.switch .track {
+  position: absolute;
+  inset: 0;
+  background: var(--input);
+  border-radius: 999px;
+  transition: background 0.15s;
+}
+.switch .knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--background);
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.15s;
+}
+.switch input:checked + .track {
+  background: var(--primary);
+}
+.switch input:checked ~ .knob {
+  transform: translateX(16px);
+}
+
+/* ============ tables ============ */
+.thead,
+.trow {
+  display: grid;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 16px;
+}
+.thead {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  border-bottom: 1px solid var(--border);
+}
+.trow {
+  border-bottom: 1px solid var(--border);
+  font-size: 14px;
+}
+.trow:last-child {
+  border-bottom: none;
+}
+a.trow:hover {
+  background: color-mix(in oklab, var(--accent) 50%, transparent);
+}
+
+/* ============ misc components ============ */
+.icon-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--input);
+  background: var(--background);
+  display: grid;
+  place-items: center;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  box-shadow: var(--shadow-2xs);
+}
+.icon-btn:hover {
+  color: var(--foreground);
+  background: var(--accent);
+}
+.icon-btn svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+}
+
+.seg-toggle {
+  display: inline-flex;
+  padding: 3px;
+  background: var(--muted);
+  border-radius: var(--radius-lg);
+  gap: 2px;
+}
+.seg-toggle a,
+.seg-toggle button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: var(--radius-md);
+  border: none;
+  background: transparent;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+.seg-toggle .on {
+  background: var(--background);
+  color: var(--foreground);
+  box-shadow: var(--shadow-2xs);
+}
+.seg-toggle svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2;
+}
+
+.stat-card {
+  padding: 16px 18px;
+}
+.stat-card .k {
+  font-size: 13px;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.stat-card .k svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
+}
+.stat-card .v {
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin-top: 4px;
+}
+.stat-card .s {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  margin-top: 2px;
+}
+
+/* page headers */
+.page-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin: 8px 0 20px;
+}
+.page-title {
+  font-size: 24px;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+  margin: 0 0 4px;
+}
+.page-sub {
+  color: var(--muted-foreground);
+  font-size: 14px;
+  margin: 0;
+}
+.sec-title {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+.sec-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 28px 0 14px;
+}
+.sec-head .count {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  background: var(--muted);
+  padding: 1px 8px;
+  border-radius: 999px;
+}
+.sec-head .more {
+  margin-left: auto;
+  font-size: 13.5px;
+  color: var(--primary);
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.sec-head .more svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2;
+}
+
+/* segmented path progress (course-count segments) */
+.segs {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+}
+.seg {
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--primary) 15%, transparent);
+  position: relative;
+  overflow: hidden;
+}
+.seg.done {
+  background: var(--success);
+}
+.seg.half::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: 45%;
+  background: var(--primary);
+  border-radius: 999px;
+}
+
+/* lock veil for thumbnails */
+.lock-veil {
+  position: absolute;
+  inset: 0;
+  background: oklch(0.145 0 0 / 0.35);
+  display: grid;
+  place-items: center;
+}
+.lock-veil svg {
+  width: 18px;
+  height: 18px;
+  color: #fff;
+  stroke-width: 2.2;
+}
+
+/* ============ journey spine (learner path detail) ============ */
+.journey {
+  position: relative;
+  margin-top: 16px;
+}
+.step {
+  position: relative;
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 16px;
+  padding-bottom: 16px;
+}
+.step:last-child {
+  padding-bottom: 0;
+}
+.rail {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+.rail::before {
+  content: '';
+  position: absolute;
+  top: 38px;
+  bottom: -16px;
+  width: 2px;
+  background: var(--border);
+  border-radius: 2px;
+}
+.step:last-child .rail::before,
+.step.no-rail .rail::before {
+  display: none;
+}
+.step.s-done .rail::before {
+  background: var(--success);
+}
+.step.s-current .rail::before {
+  background: linear-gradient(180deg, var(--success) 0%, var(--border) 70%);
+}
+.node {
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 13px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  border: 1px solid var(--border);
+}
+.node svg {
+  width: 17px;
+  height: 17px;
+  stroke-width: 2.4;
+}
+.step.s-done .node {
+  background: var(--success);
+  border-color: var(--success);
+  color: var(--success-foreground);
+}
+.step.s-current .node {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+  box-shadow: 0 0 0 4px color-mix(in oklab, var(--primary) 15%, transparent);
+}
+
+/* horizontal stepper (in-course ribbon) */
+.stepper {
+  display: flex;
+  align-items: center;
+}
+.snode {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  width: 110px;
+  text-align: center;
+}
+.sdot {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 12px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  border: 1px solid var(--border);
+}
+.sdot svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2.6;
+}
+.snode.done .sdot {
+  background: var(--success);
+  border-color: var(--success);
+  color: var(--success-foreground);
+}
+.snode.current .sdot {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--primary) 15%, transparent);
+}
+.slabel {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  line-height: 1.25;
+}
+.snode.current .slabel {
+  color: var(--foreground);
+  font-weight: 600;
+}
+.sbar {
+  flex: 1;
+  height: 2px;
+  background: var(--border);
+  min-width: 12px;
+  margin: 0 -14px 18px;
+}
+.sbar.filled {
+  background: var(--success);
+}
+
+/* ============ responsive ============ */
+@media (max-width: 860px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+  .sidebar {
+    display: none;
+  }
+  .item {
+    flex-wrap: wrap;
+  }
+  .item-actions {
+    width: 100%;
+  }
+  .item-actions .btn {
+    flex: 1;
+  }
+}

--- a/prototypes/embedded-academy/embed-category.html
+++ b/prototypes/embedded-academy/embed-category.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Category view · Embedded Academy</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&family=Instrument+Serif&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="academy.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      .url-bar { display: flex; align-items: center; gap: 8px; margin: 0 0 18px; padding: 7px 12px; border: 1px solid var(--ac-line); border-radius: 8px; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 12px; color: var(--ac-muted); background: color-mix(in oklab, var(--ac-fg) 3%, transparent); }
+      .url-bar svg { width: 13px; height: 13px; stroke-width: 2; }
+      .url-bar b { color: var(--ac-fg); font-weight: 600; }
+    </style>
+  </head>
+  <body>
+    <div class="host">
+      <aside class="host-side">
+        <div class="host-brand"><span class="mk">N</span>Northwind</div>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>Dashboard</a>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>Reports</a>
+        <div class="host-sec">Resources</div>
+        <a class="host-nav on" href="embed-learn.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Learn</a>
+        <div class="host-foot"><span class="av">RA</span><div><div class="nm">Ruth Adeyemi</div><div class="rl">Engineering</div></div></div>
+      </aside>
+
+      <main class="host-main">
+        <div class="embed-wrap" id="embed">
+          <div class="ac">
+            <div class="ac-page">
+              <a class="ac-back" href="embed-learn.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>All of Learn</a>
+
+              <div class="url-bar">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1"/><path d="M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1"/></svg>
+                app.northwind.com/learn<b>?cio=category/engineering</b>
+                <span style="margin-left: auto">router: query</span>
+              </div>
+
+              <h1 class="ac-h1">Engineering</h1>
+              <p class="ac-lead">Build, extend, and debug on the Northwind platform. 6 courses.</p>
+
+              <section class="ac-sec" style="margin-top: 34px">
+                <div class="ac-rows">
+                  <a class="ac-row" href="embed-course.html">
+                    <div class="thumb" style="background: var(--ac-tint-a)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></div>
+                    <div><div class="ac-eyebrow">Course · 8 lessons</div><h3>Building on the Northwind API</h3><p>Authentication, pagination, webhooks, and the rate limits that matter in production.</p></div>
+                    <span class="ac-arrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+                  </a>
+                  <a class="ac-row" href="embed-course.html">
+                    <div class="thumb" style="background: var(--ac-tint-c)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 7h-9M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/></svg></div>
+                    <div>
+                      <div class="ac-eyebrow">Course · 8 lessons</div><h3>Automations for Support Teams</h3><p>Route, escalate, and resolve tickets automatically.</p>
+                      <div class="ac-prog"><span style="width: 62%"></span></div><div class="ac-pmeta">5 of 8 lessons complete</div>
+                    </div>
+                    <span class="ac-arrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+                  </a>
+                  <a class="ac-row" href="embed-course.html">
+                    <div class="thumb" style="background: var(--ac-tint-d)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 2 2 7l10 5 10-5z"/><path d="m2 17 10 5 10-5M2 12l10 5 10-5"/></svg></div>
+                    <div><div class="ac-eyebrow">Course · 12 lessons · $149</div><h3>Advanced Data Modelling</h3><p>Schema design, migrations, and performance for large workspaces.</p></div>
+                    <span class="ac-arrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+                  </a>
+                </div>
+              </section>
+
+              <div class="ac-sec" style="text-align: center; font-size: 12px; color: var(--ac-muted)">Powered by ClassroomIO</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <div class="proto-bar">
+      <span class="lbl">State</span>
+      <button class="on" onclick="showState('results', this)">Results</button>
+      <button onclick="showState('empty', this)">Empty</button>
+      <span class="lbl">View</span>
+      <button onclick="document.getElementById('embed').classList.toggle('show-bounds')">Bounds</button>
+      <button onclick="toggleTheme(this)">Dark</button>
+      <a class="btn btn-sm btn-ghost" href="index.html">Map</a>
+    </div>
+    <script>
+      function toggleTheme(el) {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+        el.textContent = dark ? 'Light' : 'Dark';
+      }
+      function showState(state, el) {
+        el.parentElement.querySelectorAll('button').forEach((b) => b.classList.remove('on'));
+        el.classList.add('on');
+        const rows = document.querySelector('.ac-rows');
+        let empty = document.getElementById('empty-state');
+        if (state === 'empty') {
+          rows.style.display = 'none';
+          if (!empty) {
+            empty = document.createElement('div');
+            empty.id = 'empty-state';
+            empty.className = 'ac-empty';
+            empty.textContent = 'No published courses carry this tag yet.';
+            rows.parentElement.appendChild(empty);
+          }
+          empty.style.display = 'block';
+        } else {
+          rows.style.display = 'block';
+          if (empty) empty.style.display = 'none';
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/prototypes/embedded-academy/embed-course.html
+++ b/prototypes/embedded-academy/embed-course.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Course detail · Embedded Academy</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&family=Instrument+Serif&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="academy.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+  </head>
+  <body>
+    <div class="host">
+      <aside class="host-side">
+        <div class="host-brand"><span class="mk">N</span>Northwind</div>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>Dashboard</a>
+        <div class="host-sec">Resources</div>
+        <a class="host-nav on" href="embed-learn.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Learn</a>
+        <div class="host-foot"><span class="av">RA</span><div><div class="nm">Ruth Adeyemi</div><div class="rl">Engineering</div></div></div>
+      </aside>
+
+      <main class="host-main">
+        <div class="embed-wrap" id="embed">
+          <div class="ac">
+            <div class="ac-page">
+              <a class="ac-back" href="embed-learn.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>All of Learn</a>
+
+              <div class="ac-hero">
+                <div>
+                  <div class="ac-eyebrow">Course · Engineering</div>
+                  <h1>Automations for Support Teams</h1>
+                  <p class="ac-lead">Route, escalate, and resolve tickets automatically. You will build a working workflow, add branching conditions, and measure the hours it gives back.</p>
+                  <div class="ac-facts">
+                    <span class="f"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>8 lessons</span>
+                    <span class="f"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>2 exercises</span>
+                    <span class="f"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>About 2 hours</span>
+                  </div>
+                </div>
+
+                <aside class="ac-buy">
+                  <div id="price-line" class="price" style="display: none">$149</div>
+                  <div id="progress-block" style="display: none">
+                    <div class="ac-eyebrow">Your progress</div>
+                    <div class="ac-prog" style="margin-top: 8px"><span style="width: 62%"></span></div>
+                    <div class="ac-pmeta">5 of 8 lessons complete</div>
+                  </div>
+                  <a id="cta" class="ac-btn ac-btn-primary" href="embed-lesson.html" style="width: 100%; justify-content: center; margin-top: 14px">Enrol free</a>
+                  <p id="cta-note" style="font-size: 12px; color: var(--ac-muted); margin: 11px 0 0; line-height: 1.5">Free for everyone at Northwind. You stay on this page.</p>
+                </aside>
+              </div>
+
+              <section class="ac-sec">
+                <h2 class="ac-h2">What you will learn</h2>
+                <div class="ac-sec-body ac-prose">
+                  <ul>
+                    <li>Build a ticket-routing workflow from a blank canvas</li>
+                    <li>Branch on priority, customer tier, and business hours</li>
+                    <li>Escalate safely without creating notification storms</li>
+                    <li>Read the automation report and prove the time saved</li>
+                  </ul>
+                </div>
+              </section>
+
+              <section class="ac-sec">
+                <h2 class="ac-h2">Curriculum</h2>
+                <div class="ac-sec-body ac-curric">
+                  <div class="grp">Foundations</div>
+                  <a class="ac-item done" href="embed-lesson.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>What automations can and cannot do<span class="len">6 min</span></a>
+                  <a class="ac-item done" href="embed-lesson.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>Anatomy of a workflow<span class="len">9 min</span></a>
+                  <a class="ac-item done" href="embed-lesson.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>Your first routing rule<span class="len">12 min</span></a>
+                  <div class="grp">Conditions and branching</div>
+                  <a class="ac-item done" href="embed-lesson.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>Matching on customer tier<span class="len">8 min</span></a>
+                  <a class="ac-item done" href="embed-exercise.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>Knowledge check — conditions<span class="len">Exercise</span></a>
+                  <a class="ac-item" href="embed-lesson.html"><span class="ic"></span>Branching on ticket priority<span class="len">11 min</span></a>
+                  <a class="ac-item" href="embed-lesson.html"><span class="ic"></span>Business hours and time zones<span class="len">7 min</span></a>
+                  <div class="grp">Measuring impact</div>
+                  <a class="ac-item" href="embed-lesson.html"><span class="ic"></span>Reading the automation report<span class="len">10 min</span></a>
+                  <a class="ac-item" href="embed-exercise.html"><span class="ic"></span>Final exercise — build and measure<span class="len">Exercise</span></a>
+                </div>
+              </section>
+
+              <div class="ac-sec" style="text-align: center; font-size: 12px; color: var(--ac-muted)">Powered by ClassroomIO</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <div class="proto-bar">
+      <span class="lbl">State</span>
+      <button class="on" onclick="setState('free', this)">Free · not enrolled</button>
+      <button onclick="setState('enrolled', this)">Enrolled</button>
+      <button onclick="setState('paid', this)">Paid</button>
+      <button onclick="setState('anon', this)">Anonymous</button>
+      <span class="lbl">View</span>
+      <button onclick="document.getElementById('embed').classList.toggle('show-bounds')">Bounds</button>
+      <button onclick="toggleTheme(this)">Dark</button>
+      <a class="btn btn-sm btn-ghost" href="index.html">Map</a>
+    </div>
+
+    <script>
+      const STATES = {
+        free: { cta: 'Enrol free', href: 'embed-lesson.html', note: 'Free for everyone at Northwind. Enrolling happens here — you stay on this page.', price: false, progress: false, locked: false },
+        enrolled: { cta: 'Continue where you left off', href: 'embed-lesson.html', note: 'Next up: Branching on ticket priority.', price: false, progress: true, locked: false },
+        paid: { cta: 'Get this course ↗', href: 'embed-course.html', note: 'Checkout opens the Northwind academy in a new tab. Payment never runs inside the embed — this is the one deliberate hand-off.', price: true, progress: false, locked: true },
+        anon: { cta: 'Sign in to enrol', href: 'embed-course.html', note: 'No learner identity was supplied by the host page, so enrolling continues on the academy.', price: false, progress: false, locked: true }
+      };
+      function setState(key, el) {
+        el.parentElement.querySelectorAll('button').forEach((b) => b.classList.remove('on'));
+        el.classList.add('on');
+        const state = STATES[key];
+        const cta = document.getElementById('cta');
+        cta.textContent = state.cta;
+        cta.setAttribute('href', state.href);
+        document.getElementById('cta-note').textContent = state.note;
+        document.getElementById('price-line').style.display = state.price ? 'block' : 'none';
+        document.getElementById('progress-block').style.display = state.progress ? 'block' : 'none';
+        document.querySelectorAll('.ac-item').forEach((item, index) => {
+          item.classList.toggle('done', !state.locked && state.progress && index < 5);
+          const len = item.querySelector('.len');
+          if (state.locked && index > 0) {
+            len.innerHTML = '<span style="display:inline-flex;align-items:center;gap:4px">Locked</span>';
+          } else if (!len.dataset.original) {
+            return;
+          } else {
+            len.textContent = len.dataset.original;
+          }
+        });
+      }
+      document.querySelectorAll('.ac-item .len').forEach((len) => (len.dataset.original = len.textContent));
+      function toggleTheme(el) {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+        el.textContent = dark ? 'Light' : 'Dark';
+      }
+    </script>
+  </body>
+</html>

--- a/prototypes/embedded-academy/embed-exercise.html
+++ b/prototypes/embedded-academy/embed-exercise.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Exercise player · Embedded Academy</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&family=Instrument+Serif&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="academy.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+  </head>
+  <body>
+    <div class="host">
+      <aside class="host-side">
+        <div class="host-brand"><span class="mk">N</span>Northwind</div>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>Dashboard</a>
+        <div class="host-sec">Resources</div>
+        <a class="host-nav on" href="embed-learn.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Learn</a>
+        <div class="host-foot"><span class="av">RA</span><div><div class="nm">Ruth Adeyemi</div><div class="rl">Engineering</div></div></div>
+      </aside>
+
+      <main class="host-main">
+        <div class="embed-wrap" id="embed">
+          <div class="ac">
+            <div class="ac-page" style="max-width: 1080px; padding-top: 34px">
+              <a class="ac-back" href="embed-course.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>Automations for Support Teams</a>
+
+              <div class="ac-shell">
+                <aside class="ac-side">
+                  <div class="ac-side-head">
+                    <div class="t">Automations for Support Teams</div>
+                    <div class="ac-prog"><span style="width: 62%"></span></div>
+                    <div class="ac-pmeta">5 of 8 complete</div>
+                  </div>
+                  <a class="ac-srow done" href="embed-lesson.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>What automations can do</a>
+                  <a class="ac-srow done" href="embed-lesson.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>Anatomy of a workflow</a>
+                  <a class="ac-srow done" href="embed-lesson.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>Your first routing rule</a>
+                  <a class="ac-srow done" href="embed-lesson.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>Matching on customer tier</a>
+                  <a class="ac-srow on" href="embed-exercise.html"><span class="ic"></span>Knowledge check — conditions</a>
+                  <a class="ac-srow" href="embed-lesson.html"><span class="ic"></span>Branching on ticket priority</a>
+                  <a class="ac-srow" href="embed-lesson.html"><span class="ic"></span>Business hours and time zones</a>
+                  <a class="ac-srow" href="embed-lesson.html"><span class="ic"></span>Reading the automation report</a>
+                </aside>
+
+                <div class="ac-body">
+                  <div class="ac-eyebrow">Exercise · 3 questions · no time limit</div>
+                  <h1>Knowledge check — conditions</h1>
+                  <p id="ex-status" style="font-size: 13.5px; color: var(--ac-muted); margin: -10px 0 24px">Answer all three, then submit. You can retake this as many times as you like.</p>
+
+                  <div class="ac-q">
+                    <div class="qn">Question 1</div>
+                    <div class="qt">A ticket arrives with customer-set priority "Urgent" from a Starter-tier account. Which source should an escalation branch trust?</div>
+                    <label class="ac-opt" onclick="pick(this)"><span class="rd"></span>The customer-set priority, because the customer knows their situation</label>
+                    <label class="ac-opt sel" data-chosen="true" data-correct onclick="pick(this)"><span class="rd"></span>The tier-derived priority, because escalation paths need predictable input</label>
+                    <label class="ac-opt" onclick="pick(this)"><span class="rd"></span>Whichever value arrived most recently</label>
+                  </div>
+
+                  <div class="ac-q">
+                    <div class="qn">Question 2</div>
+                    <div class="qt">What is the risk of using a single catch-all path instead of one path per priority level?</div>
+                    <label class="ac-opt" onclick="pick(this)"><span class="rd"></span>The workflow runs more slowly</label>
+                    <label class="ac-opt" data-correct onclick="pick(this)"><span class="rd"></span>Low-priority tickets inherit escalation behaviour meant for urgent ones</label>
+                    <label class="ac-opt" onclick="pick(this)"><span class="rd"></span>Conditions stop evaluating after the first match</label>
+                  </div>
+
+                  <div class="ac-q">
+                    <div class="qn">Question 3</div>
+                    <div class="qt">In one or two sentences, describe when you would deliberately ignore triage-set priority.</div>
+                    <textarea class="textarea" rows="3" style="width: 100%; font-family: inherit" placeholder="Your answer"></textarea>
+                  </div>
+
+                  <div class="ac-footnav">
+                    <a class="ac-btn ac-btn-ghost" href="embed-lesson.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>Back to lesson</a>
+                    <button class="ac-btn ac-btn-primary" id="submit" onclick="submitExercise()">Submit exercise</button>
+                  </div>
+                  <p style="font-size: 12px; color: var(--ac-muted); text-align: right; margin: 10px 0 0" id="write-note">Signed in — this posts to the same submission record the LMS uses.</p>
+                </div>
+              </div>
+
+              <div class="ac-sec" style="text-align: center; font-size: 12px; color: var(--ac-muted)">Powered by ClassroomIO</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <div class="proto-bar">
+      <span class="lbl">State</span>
+      <button class="on" onclick="setState('progress', this)">In progress</button>
+      <button onclick="setState('graded', this)">Graded</button>
+      <button onclick="setState('anon', this)">Anonymous attempt</button>
+      <span class="lbl">View</span>
+      <button onclick="document.getElementById('embed').classList.toggle('show-bounds')">Bounds</button>
+      <button onclick="toggleTheme(this)">Dark</button>
+      <a class="btn btn-sm btn-ghost" href="index.html">Map</a>
+    </div>
+
+    <script>
+      function pick(el) {
+        el.parentElement.querySelectorAll('.ac-opt').forEach((o) => {
+          o.classList.remove('sel');
+          delete o.dataset.chosen;
+        });
+        el.classList.add('sel');
+        el.dataset.chosen = 'true';
+      }
+      function submitExercise() {
+        setGraded();
+        document.querySelector('.proto-bar button.on')?.classList.remove('on');
+        document.querySelectorAll('.proto-bar button')[1].classList.add('on');
+      }
+      function setGraded() {
+        document.querySelectorAll('.ac-q').forEach((q) => {
+          q.querySelectorAll('.ac-opt').forEach((opt) => {
+            opt.classList.remove('sel');
+            if (opt.hasAttribute('data-correct')) opt.classList.add('right');
+            else if (opt.dataset.chosen) opt.classList.add('wrong');
+          });
+        });
+        document.getElementById('ex-status').innerHTML = '<b style="color:#3f9c6d">Submitted · 2 of 3 auto-graded correct.</b> Question 3 is awaiting review by your instructor.';
+        document.getElementById('submit').textContent = 'Retake exercise';
+        document.querySelector('.ac-srow.on').classList.add('done');
+        document.querySelector('.ac-srow.on .ic').innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg>';
+      }
+      function setState(key, el) {
+        el.parentElement.querySelectorAll('button').forEach((b) => b.classList.remove('on'));
+        el.classList.add('on');
+        if (key === 'graded') return setGraded();
+        if (key === 'anon') {
+          document.getElementById('write-note').innerHTML = 'No identity supplied — this attempt is kept in the browser only, exactly as the public course page does today.';
+          document.getElementById('ex-status').textContent = 'Answer all three to check yourself. Your attempt stays in this browser until you sign in.';
+        } else {
+          document.getElementById('write-note').textContent = 'Signed in — this posts to the same submission record the LMS uses.';
+          document.getElementById('ex-status').textContent = 'Answer all three, then submit. You can retake this as many times as you like.';
+        }
+        document.querySelectorAll('.ac-opt').forEach((o) => o.classList.remove('right', 'wrong'));
+        document.getElementById('submit').textContent = 'Submit exercise';
+      }
+      function toggleTheme(el) {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+        el.textContent = dark ? 'Light' : 'Dark';
+      }
+    </script>
+  </body>
+</html>

--- a/prototypes/embedded-academy/embed-learn-anon.html
+++ b/prototypes/embedded-academy/embed-learn-anon.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Academy index (anonymous) · Embedded Academy</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&family=Instrument+Serif&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="academy.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+  </head>
+  <body>
+    <div class="host">
+      <aside class="host-side">
+        <div class="host-brand"><span class="mk">N</span>Northwind</div>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>Product tour</a>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 12V8H6a2 2 0 0 1 0-4h12v4"/><path d="M4 6v12a2 2 0 0 0 2 2h14v-4"/></svg>Pricing</a>
+        <div class="host-sec">Resources</div>
+        <a class="host-nav on" href="embed-learn-anon.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Learn</a>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>Help center</a>
+        <div class="host-foot"><span class="av" style="background: var(--host-line); color: var(--host-muted)">?</span><div><div class="nm">Not signed in</div><div class="rl">Public visitor</div></div></div>
+      </aside>
+
+      <main class="host-main">
+        <div class="embed-wrap" id="embed">
+          <div class="ac">
+            <div class="ac-page">
+              <h1 class="ac-h1">Learn</h1>
+              <p class="ac-lead">Courses, tutorials, and use cases from the Northwind Academy.</p>
+
+              <!-- continue_learning renders nothing here and collapses without leaving a gap -->
+
+              <section class="ac-sec">
+                <h2 class="ac-h2">Featured courses</h2>
+                <p class="ac-sub">Self-paced, multi-lesson courses from the Northwind Academy.</p>
+                <div class="ac-sec-body ac-rows">
+                  <a class="ac-row" href="embed-course.html">
+                    <div class="thumb" style="background: var(--ac-tint-a)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 7h-9M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/></svg></div>
+                    <div>
+                      <div class="ac-eyebrow">Course</div>
+                      <h3>Automations for Support Teams</h3>
+                      <p>Route, escalate, and resolve tickets automatically: build your first workflow, add conditions, and measure what it saved you.</p>
+                    </div>
+                    <span class="ac-arrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+                  </a>
+                  <a class="ac-row" href="embed-course.html">
+                    <div class="thumb" style="background: var(--ac-tint-b)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></div>
+                    <div>
+                      <div class="ac-eyebrow">Course</div>
+                      <h3>Northwind 101</h3>
+                      <p>Everything you need for your first week: workspaces, records, views, and the shortcuts experienced teams rely on.</p>
+                    </div>
+                    <span class="ac-arrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+                  </a>
+                </div>
+              </section>
+
+              <section class="ac-sec">
+                <h2 class="ac-h2">Getting started</h2>
+                <p class="ac-sub">Short tutorials on the basics, a few minutes each.</p>
+                <div class="ac-sec-body ac-grid">
+                  <a class="ac-card" href="embed-course.html"><div class="shot" style="background: var(--ac-tint-a)"><span class="dur">4 min</span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></div><div class="body"><div class="ac-eyebrow">Tutorial</div><h4>Set up your first workspace in three steps</h4></div></a>
+                  <a class="ac-card" href="embed-course.html"><div class="shot" style="background: var(--ac-tint-b)"><span class="dur">4 min</span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 4h16v12H5.17L4 17.17z"/></svg></div><div class="body"><div class="ac-eyebrow">Tutorial</div><h4>Delegating your first task to a teammate</h4></div></a>
+                  <a class="ac-card" href="embed-course.html"><div class="shot" style="background: var(--ac-tint-c)"><span class="dur">6 min</span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1"/><path d="M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1"/></svg></div><div class="body"><div class="ac-eyebrow">Tutorial</div><h4>Getting started with connectors</h4></div></a>
+                </div>
+              </section>
+
+              <section class="ac-sec">
+                <h2 class="ac-h2">Browse by role</h2>
+                <p class="ac-sub">Courses and use cases for the kind of work you do.</p>
+                <div class="ac-sec-body ac-cats">
+                  <a class="ac-cat" href="embed-category.html"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></span><span class="nm">Engineering</span></a>
+                  <a class="ac-cat" href="embed-category.html"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m3 11 18-5v12L3 14v-3z"/><path d="M11.6 16.8a3 3 0 1 1-5.8-1.6"/></svg></span><span class="nm">Marketing</span></a>
+                  <a class="ac-cat" href="embed-category.html"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 4h18l-7 8v6l-4 2v-8z"/></svg></span><span class="nm">Sales</span></a>
+                  <a class="ac-cat" href="embed-category.html"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10"/><polygon points="16.2 7.8 14.1 14.1 7.8 16.2 9.9 9.9"/></svg></span><span class="nm">Product</span></a>
+                </div>
+              </section>
+
+              <div class="ac-sec">
+                <div class="ac-note">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
+                  <div>No learner identity was supplied by the host page, so progress, <b>Jump back in</b>, and <b>For you</b> are hidden. Enrolling prompts sign-in on the academy. This is also the state the runtime falls back to when the overlay request fails.</div>
+                </div>
+              </div>
+
+              <div class="ac-sec" style="text-align: center; font-size: 12px; color: var(--ac-muted)">Powered by ClassroomIO</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <div class="proto-bar">
+      <span class="lbl">State</span>
+      <button class="on">Anonymous</button>
+      <a class="btn btn-sm btn-ghost" href="embed-learn.html">Signed in →</a>
+      <span class="lbl">View</span>
+      <button onclick="document.getElementById('embed').classList.toggle('show-bounds')">Bounds</button>
+      <button onclick="toggleTheme(this)">Dark</button>
+      <a class="btn btn-sm btn-ghost" href="index.html">Map</a>
+    </div>
+    <script>
+      function toggleTheme(el) {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+        el.textContent = dark ? 'Light' : 'Dark';
+      }
+    </script>
+  </body>
+</html>

--- a/prototypes/embedded-academy/embed-learn.html
+++ b/prototypes/embedded-academy/embed-learn.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Academy index (signed in) · Embedded Academy</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&family=Instrument+Serif&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="academy.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+  </head>
+  <body>
+    <div class="host">
+      <aside class="host-side">
+        <div class="host-brand"><span class="mk">N</span>Northwind</div>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>Dashboard</a>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>Reports</a>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>Customers</a>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 7h-9M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/></svg>Automations</a>
+        <div class="host-sec">Resources</div>
+        <a class="host-nav on" href="embed-learn.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Learn</a>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>Help center</a>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="3"/><path d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6 7 7M17 17l1.4 1.4M5.6 18.4 7 17M17 7l1.4-1.4"/></svg>Settings</a>
+        <div class="host-foot"><span class="av">RA</span><div><div class="nm">Ruth Adeyemi</div><div class="rl">Engineering</div></div></div>
+      </aside>
+
+      <main class="host-main">
+        <div class="embed-wrap show-bounds" id="embed">
+          <div class="ac">
+            <div class="ac-page">
+
+              <!-- section: page_header -->
+              <h1 class="ac-h1">Learn</h1>
+              <p class="ac-lead">Courses, tutorials, and use cases from the Northwind Academy.</p>
+
+              <!-- section: continue_learning — overlay-driven, signed-in only -->
+              <section class="ac-sec" data-personal>
+                <h2 class="ac-h2">Jump back in</h2>
+                <p class="ac-sub">Pick up where you stopped.</p>
+                <div class="ac-sec-body ac-continue">
+                  <a class="ac-cont-card" href="embed-lesson.html">
+                    <div class="ac-eyebrow">Course · 62% complete</div>
+                    <h4>Automations for Support Teams</h4>
+                    <div class="ac-prog"><span style="width: 62%"></span></div>
+                    <div class="nxt"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>Next: Branching on ticket priority</div>
+                  </a>
+                  <a class="ac-cont-card" href="embed-exercise.html">
+                    <div class="ac-eyebrow">Course · 40% complete</div>
+                    <h4>Reporting Fundamentals</h4>
+                    <div class="ac-prog"><span style="width: 40%"></span></div>
+                    <div class="nxt"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>Next: Knowledge check — metrics</div>
+                  </a>
+                </div>
+              </section>
+
+              <!-- section: compact_list — featured courses -->
+              <section class="ac-sec">
+                <h2 class="ac-h2">Featured courses</h2>
+                <p class="ac-sub">Self-paced, multi-lesson courses from the Northwind Academy.</p>
+                <div class="ac-sec-body ac-rows">
+                  <a class="ac-row" href="embed-course.html">
+                    <div class="thumb" style="background: var(--ac-tint-a)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 7h-9M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/></svg></div>
+                    <div>
+                      <div class="ac-eyebrow">Course</div>
+                      <h3>Automations for Support Teams</h3>
+                      <p>Route, escalate, and resolve tickets automatically: build your first workflow, add conditions, and measure what it saved you.</p>
+                      <div class="ac-prog"><span style="width: 62%"></span></div>
+                      <div class="ac-pmeta" data-personal>5 of 8 lessons complete</div>
+                    </div>
+                    <span class="ac-arrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+                  </a>
+                  <a class="ac-row" href="embed-course.html">
+                    <div class="thumb" style="background: var(--ac-tint-b)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></div>
+                    <div>
+                      <div class="ac-eyebrow">Course</div>
+                      <h3>Northwind 101</h3>
+                      <p>Everything you need for your first week: workspaces, records, views, and the shortcuts experienced teams rely on.</p>
+                    </div>
+                    <span class="ac-arrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+                  </a>
+                </div>
+              </section>
+
+              <!-- section: card_grid — short tutorials -->
+              <section class="ac-sec">
+                <h2 class="ac-h2">Getting started</h2>
+                <p class="ac-sub">Short tutorials on the basics, a few minutes each.</p>
+                <div class="ac-sec-body ac-grid">
+                  <a class="ac-card" href="embed-course.html">
+                    <div class="shot" style="background: var(--ac-tint-a)"><span class="dur">4 min</span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></div>
+                    <div class="body"><div class="ac-eyebrow">Tutorial</div><h4>Set up your first workspace in three steps</h4></div>
+                  </a>
+                  <a class="ac-card" href="embed-course.html">
+                    <div class="shot" style="background: var(--ac-tint-b)"><span class="dur">4 min</span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 4h16v12H5.17L4 17.17z"/></svg></div>
+                    <div class="body"><div class="ac-eyebrow">Tutorial</div><h4>Delegating your first task to a teammate</h4></div>
+                  </a>
+                  <a class="ac-card" href="embed-course.html">
+                    <div class="shot" style="background: var(--ac-tint-c)"><span class="dur">6 min</span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1"/><path d="M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1"/></svg></div>
+                    <div class="body"><div class="ac-eyebrow">Tutorial</div><h4>Getting started with connectors</h4></div>
+                  </a>
+                </div>
+              </section>
+
+              <!-- section: category_grid — browse by role -->
+              <section class="ac-sec">
+                <h2 class="ac-h2">Browse by role</h2>
+                <p class="ac-sub">Courses and use cases for the kind of work you do.</p>
+                <div class="ac-sec-body ac-cats">
+                  <a class="ac-cat" href="embed-category.html">
+                    <span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></span>
+                    <span><span class="nm">Engineering</span><br /><span class="ac-foryou" data-personal>For you</span></span>
+                  </a>
+                  <a class="ac-cat" href="embed-category.html"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m3 11 18-5v12L3 14v-3z"/><path d="M11.6 16.8a3 3 0 1 1-5.8-1.6"/></svg></span><span class="nm">Marketing</span></a>
+                  <a class="ac-cat" href="embed-category.html"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 4h18l-7 8v6l-4 2v-8z"/></svg></span><span class="nm">Sales</span></a>
+                  <a class="ac-cat" href="embed-category.html"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10"/><polygon points="16.2 7.8 14.1 14.1 7.8 16.2 9.9 9.9"/></svg></span><span class="nm">Product</span></a>
+                  <a class="ac-cat" href="embed-category.html"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 19l7-7 3 3-7 7-3-3z"/><path d="m18 13-1.5-7.5L2 2l3.5 14.5L13 18z"/></svg></span><span class="nm">Design</span></a>
+                  <a class="ac-cat" href="embed-category.html"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 5c-1.5 0-2.8 1.4-3 2-3.5-1.5-11-.3-11 5 0 1.8 0 3 2 4.5V20h4v-2h3v2h4v-4c1-.5 1.7-1 2-2h2v-4h-2c0-1-.5-1.5-1-2V5z"/></svg></span><span class="nm">Finance</span></a>
+                  <a class="ac-cat" href="embed-category.html"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m16 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1z"/><path d="M2 16l3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1z"/><path d="M7 21h10M12 3v18"/></svg></span><span class="nm">Legal</span></a>
+                  <a class="ac-cat" href="embed-category.html"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="3"/><path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6 7.8 7.8M16.2 16.2l2.2 2.2M5.6 18.4l2.2-2.2M16.2 7.8l2.2-2.2"/></svg></span><span class="nm">Operations</span></a>
+                </div>
+              </section>
+
+              <div class="ac-sec" style="text-align: center; font-size: 12px; color: var(--ac-muted)">Powered by ClassroomIO</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <div class="proto-bar">
+      <span class="lbl">State</span>
+      <button class="on" onclick="setState('personal', this)">Signed in</button>
+      <button onclick="setState('loading', this)">Overlay loading</button>
+      <a class="btn btn-sm btn-ghost" href="embed-learn-anon.html" style="margin-left: 4px">Anonymous →</a>
+      <span class="lbl">View</span>
+      <button onclick="document.getElementById('embed').classList.toggle('show-bounds')">Bounds</button>
+      <button onclick="document.querySelector('.ac').classList.toggle('ac-inherit')">Inherit host</button>
+      <button onclick="toggleTheme(this)">Dark</button>
+      <a class="btn btn-sm btn-ghost" href="index.html">Map</a>
+    </div>
+
+    <script>
+      function toggleTheme(el) {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+        el.textContent = dark ? 'Light' : 'Dark';
+      }
+      function setState(state, el) {
+        el.parentElement.querySelectorAll('button').forEach((b) => b.classList.remove('on'));
+        el.classList.add('on');
+        document.querySelectorAll('[data-personal]').forEach((node) => {
+          node.style.opacity = state === 'loading' ? '0.25' : '1';
+          node.style.filter = state === 'loading' ? 'grayscale(1)' : 'none';
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/prototypes/embedded-academy/embed-lesson.html
+++ b/prototypes/embedded-academy/embed-lesson.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Lesson player · Embedded Academy</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&family=Instrument+Serif&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="academy.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+  </head>
+  <body>
+    <div class="host">
+      <aside class="host-side">
+        <div class="host-brand"><span class="mk">N</span>Northwind</div>
+        <a class="host-nav" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>Dashboard</a>
+        <div class="host-sec">Resources</div>
+        <a class="host-nav on" href="embed-learn.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Learn</a>
+        <div class="host-foot"><span class="av">RA</span><div><div class="nm">Ruth Adeyemi</div><div class="rl">Engineering</div></div></div>
+      </aside>
+
+      <main class="host-main">
+        <div class="embed-wrap" id="embed">
+          <div class="ac">
+            <div class="ac-page" style="max-width: 1080px; padding-top: 34px">
+              <a class="ac-back" href="embed-course.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>Automations for Support Teams</a>
+
+              <div class="ac-shell">
+                <aside class="ac-side">
+                  <div class="ac-side-head">
+                    <div class="t">Automations for Support Teams</div>
+                    <div class="ac-prog"><span style="width: 62%"></span></div>
+                    <div class="ac-pmeta">5 of 8 complete</div>
+                  </div>
+                  <a class="ac-srow done" href="embed-lesson.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>What automations can do</a>
+                  <a class="ac-srow done" href="embed-lesson.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>Anatomy of a workflow</a>
+                  <a class="ac-srow done" href="embed-lesson.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>Your first routing rule</a>
+                  <a class="ac-srow done" href="embed-lesson.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>Matching on customer tier</a>
+                  <a class="ac-srow done" href="embed-exercise.html"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg></span>Knowledge check — conditions</a>
+                  <a class="ac-srow on" href="embed-lesson.html"><span class="ic"></span>Branching on ticket priority</a>
+                  <a class="ac-srow" href="embed-lesson.html"><span class="ic"></span>Business hours and time zones</a>
+                  <a class="ac-srow" href="embed-lesson.html"><span class="ic"></span>Reading the automation report</a>
+                  <a class="ac-srow" href="embed-exercise.html"><span class="ic"></span>Final exercise</a>
+                </aside>
+
+                <div class="ac-body">
+                  <div class="ac-eyebrow">Lesson 6 of 9 · 11 min</div>
+                  <h1>Branching on ticket priority</h1>
+
+                  <div class="ac-video" style="background: var(--ac-tint-a)"><span class="play"><svg viewBox="0 0 24 24" fill="currentColor"><polygon points="6 3 20 12 6 21 6 3"/></svg></span></div>
+
+                  <div class="ac-prose">
+                    <p>Priority is the most common branch in a support workflow, and it is also where most automations quietly go wrong. A rule that treats every urgent ticket the same way will page someone at 3am for a password reset.</p>
+                    <h2>Reading priority safely</h2>
+                    <p>Priority arrives from three places: the customer's own selection, your triage rules, and the SLA attached to the account tier. They disagree often, so decide once which one your workflow trusts and make that explicit at the top of the branch.</p>
+                    <ul>
+                      <li><b>Customer-set</b> — fast, but self-reported and frequently inflated.</li>
+                      <li><b>Triage-set</b> — accurate, but only after a human has looked.</li>
+                      <li><b>Tier-derived</b> — predictable, and the right default for escalation paths.</li>
+                    </ul>
+                    <h2>Building the branch</h2>
+                    <p>Open the workflow you built in lesson 3 and add a condition node after the routing step. Set the left-hand operand to the tier-derived priority, then add one path per level rather than a single catch-all.</p>
+                  </div>
+
+                  <div class="ac-footnav">
+                    <a class="ac-btn ac-btn-ghost" href="embed-exercise.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>Knowledge check</a>
+                    <button class="ac-btn ac-btn-primary" id="complete" onclick="markComplete(this)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg>Mark complete and continue</button>
+                  </div>
+                  <p style="font-size: 12px; color: var(--ac-muted); text-align: right; margin: 10px 0 0" id="write-note">Writes to the same completion record the LMS uses.</p>
+                </div>
+              </div>
+
+              <div class="ac-sec" style="text-align: center; font-size: 12px; color: var(--ac-muted)">Powered by ClassroomIO</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <div class="proto-bar">
+      <span class="lbl">State</span>
+      <button class="on" onclick="setState('progress', this)">In progress</button>
+      <button onclick="setState('done', this)">Complete</button>
+      <button onclick="setState('locked', this)">Not enrolled</button>
+      <span class="lbl">View</span>
+      <button onclick="document.getElementById('embed').classList.toggle('show-bounds')">Bounds</button>
+      <button onclick="toggleTheme(this)">Dark</button>
+      <a class="btn btn-sm btn-ghost" href="index.html">Map</a>
+    </div>
+
+    <script>
+      function markComplete(el) {
+        el.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg>Completed · next lesson';
+        document.querySelector('.ac-srow.on').classList.add('done');
+        document.querySelector('.ac-srow.on .ic').innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg>';
+      }
+      function setState(key, el) {
+        el.parentElement.querySelectorAll('button').forEach((b) => b.classList.remove('on'));
+        el.classList.add('on');
+        const body = document.querySelector('.ac-body');
+        const gate = document.getElementById('gate');
+        if (key === 'locked') {
+          body.style.display = 'none';
+          if (!gate) {
+            const node = document.createElement('div');
+            node.id = 'gate';
+            node.className = 'ac-body';
+            node.style.display = 'grid';
+            node.style.placeItems = 'center';
+            node.innerHTML = '<div style="text-align:center;max-width:340px"><div class="ac-eyebrow">Lesson 6 of 9</div><h1 style="margin-top:6px">Enrol to continue</h1><p style="color:var(--ac-muted);font-size:14px;line-height:1.6;margin:0 0 20px">This lesson is part of Automations for Support Teams. Enrolling is free and happens without leaving this page.</p><a class="ac-btn ac-btn-primary" href="embed-course.html">Enrol free</a></div>';
+            document.querySelector('.ac-shell').appendChild(node);
+          } else gate.style.display = 'grid';
+        } else {
+          body.style.display = 'block';
+          if (gate) gate.style.display = 'none';
+          const complete = document.getElementById('complete');
+          if (key === 'done') markComplete(complete);
+          else complete.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg>Mark complete and continue';
+        }
+      }
+      function toggleTheme(el) {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+        el.textContent = dark ? 'Light' : 'Dark';
+      }
+    </script>
+  </body>
+</html>

--- a/prototypes/embedded-academy/index.html
+++ b/prototypes/embedded-academy/index.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Embedded Academy · Prototype map</title>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300..800&family=Instrument+Serif&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="app-theme.css" />
+    <link rel="stylesheet" href="academy.css" />
+    <script>
+      if (localStorage.cioTheme === 'dark' || (!localStorage.cioTheme && matchMedia('(prefers-color-scheme: dark)').matches))
+        document.documentElement.classList.add('dark');
+    </script>
+    <style>
+      body { margin: 0; background: var(--background); color: var(--foreground); font-family: Geist, ui-sans-serif, system-ui, sans-serif; }
+      .page { max-width: 1000px; margin: 0 auto; padding: 60px 32px 100px; }
+      .hero h1 { font-family: 'Instrument Serif', Georgia, serif; font-size: 44px; font-weight: 400; letter-spacing: -0.015em; margin: 0; }
+      .hero p { font-size: 15.5px; color: var(--muted-foreground); line-height: 1.65; max-width: 620px; margin: 12px 0 0; }
+      .hero .meta { display: flex; gap: 10px; margin-top: 20px; flex-wrap: wrap; }
+      .journey { margin-top: 52px; }
+      .journey h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--muted-foreground); font-weight: 650; margin: 0 0 4px; }
+      .journey .jd { font-size: 13.5px; color: var(--muted-foreground); margin: 0 0 16px; }
+      .cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 13px; }
+      .pcard { border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--card); padding: 17px 18px 18px; text-decoration: none; color: inherit; box-shadow: var(--shadow-2xs); display: block; transition: border-color 0.13s, transform 0.13s; }
+      .pcard:hover { border-color: var(--primary); transform: translateY(-2px); }
+      .pcard .n { font-size: 10.5px; font-family: ui-monospace, monospace; color: var(--muted-foreground); }
+      .pcard .t { font-size: 15px; font-weight: 600; margin: 7px 0 5px; }
+      .pcard .d { font-size: 12.8px; color: var(--muted-foreground); line-height: 1.55; }
+      .pcard .states { margin-top: 11px; display: flex; gap: 5px; flex-wrap: wrap; }
+      .pcard .states span { font-size: 10.5px; border: 1px solid var(--border); border-radius: 5px; padding: 1px 6px; color: var(--muted-foreground); }
+      .flow { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 12.5px; color: var(--muted-foreground); margin: 14px 0 0; font-family: ui-monospace, monospace; }
+      .flow b { color: var(--foreground); font-weight: 600; }
+      .note-box { border: 1px solid var(--border); border-left: 3px solid var(--primary); border-radius: var(--radius-md); padding: 16px 18px; margin-top: 46px; font-size: 13.3px; line-height: 1.65; color: var(--muted-foreground); background: var(--card); }
+      .note-box b { color: var(--foreground); }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="hero">
+        <h1>Embedded Academy</h1>
+        <p>A ClassroomIO widget that renders a whole page instead of one block of course cards — then keeps going, all the way through course detail, lessons, and exercises, inside the customer's own product.</p>
+        <div class="meta">
+          <span class="badge badge-warning">Draft PRD</span>
+          <span class="badge badge-outline">10 screens</span>
+          <span class="badge badge-outline">Reference: the Claude app's Learn page</span>
+        </div>
+        <div class="flow"><b>Index</b> → <b>Category</b> → <b>Course</b> → <b>Lesson</b> → <b>Exercise</b> · never leaving the host app</div>
+      </div>
+
+      <section class="journey">
+        <h2>Learner — inside the customer's product</h2>
+        <p class="jd">Every screen renders in a mock host app so the embed's boundary is visible. Use the <b>Bounds</b> toggle to show where the widget starts and ends, and <b>Inherit host</b> to see the theme adopt the host's typography.</p>
+        <div class="cards">
+          <a class="pcard" href="embed-learn.html">
+            <div class="n">embed-learn.html</div>
+            <div class="t">Academy index · signed in</div>
+            <div class="d">The reference screen. Page header, continue learning, featured list, tutorial grid, and browse-by-role with the For-you badge.</div>
+            <div class="states"><span>personalized</span><span>overlay loading</span></div>
+          </a>
+          <a class="pcard" href="embed-learn-anon.html">
+            <div class="n">embed-learn-anon.html</div>
+            <div class="t">Academy index · anonymous</div>
+            <div class="d">Same page from the cached snapshot with no identity. Continue learning collapses; no progress, no For-you.</div>
+            <div class="states"><span>anonymous</span><span>overlay failed</span></div>
+          </a>
+          <a class="pcard" href="embed-category.html">
+            <div class="n">embed-category.html</div>
+            <div class="t">Category view</div>
+            <div class="d">Browse-by-role tile opens a filtered list in place. Shows the query router writing ?cio= to the host URL.</div>
+            <div class="states"><span>results</span><span>empty</span></div>
+          </a>
+          <a class="pcard" href="embed-course.html">
+            <div class="n">embed-course.html</div>
+            <div class="t">Course detail</div>
+            <div class="d">Hero, outcomes, and curriculum from the shared public-course components. The CTA carries all four enrolment states.</div>
+            <div class="states"><span>free</span><span>enrolled</span><span>paid</span><span>anonymous</span></div>
+          </a>
+          <a class="pcard" href="embed-lesson.html">
+            <div class="n">embed-lesson.html</div>
+            <div class="t">Lesson player</div>
+            <div class="d">Course sidebar, video, prose, and mark-complete — writing to the same completion record the LMS uses.</div>
+            <div class="states"><span>in progress</span><span>complete</span><span>not enrolled</span></div>
+          </a>
+          <a class="pcard" href="embed-exercise.html">
+            <div class="n">embed-exercise.html</div>
+            <div class="t">Exercise player</div>
+            <div class="d">Shipped question types inside the embed. Signed-in submissions post to the LMS; anonymous attempts stay in the browser.</div>
+            <div class="states"><span>in progress</span><span>graded</span><span>anonymous</span></div>
+          </a>
+        </div>
+      </section>
+
+      <section class="journey">
+        <h2>Admin — the ClassroomIO dashboard</h2>
+        <p class="jd">The academy is a new kind of widget, authored in the existing widget editor.</p>
+        <div class="cards">
+          <a class="pcard" href="admin-academies.html">
+            <div class="n">admin-academies.html</div>
+            <div class="t">Widgets list</div>
+            <div class="d">Blocks and Academies split into tabs, with the three starting templates.</div>
+            <div class="states"><span>has academies</span><span>empty</span><span>free plan</span></div>
+          </a>
+          <a class="pcard" href="admin-editor.html">
+            <div class="n">admin-editor.html</div>
+            <div class="t">Academy editor</div>
+            <div class="d">Section list with drag reorder and an add menu, per-section settings, and a live preview that toggles between signed-in and anonymous.</div>
+            <div class="states"><span>section list</span><span>settings open</span><span>drag</span></div>
+          </a>
+          <a class="pcard" href="admin-embed.html">
+            <div class="n">admin-embed.html</div>
+            <div class="t">Embed &amp; identity</div>
+            <div class="d">The snippet, the server-side token signing, the three router modes, and the allowed-origins guard.</div>
+            <div class="states"><span>identity active</span><span>not configured</span></div>
+          </a>
+          <a class="pcard" href="admin-analytics.html">
+            <div class="n">admin-analytics.html</div>
+            <div class="t">Analytics</div>
+            <div class="d">Per-section impressions and CTR, top courses, and the view→click→enrol→complete funnel.</div>
+            <div class="states"><span>with data</span><span>empty</span></div>
+          </a>
+        </div>
+      </section>
+
+      <div class="note-box">
+        <b>These prototypes are the UX source of truth.</b> Where the PRD at <code>prd/embedded-academy/README.md</code> and a screen here disagree on a UI detail, the screen wins. Every page has a state switcher and a light/dark toggle in the bottom-right.
+      </div>
+    </div>
+
+    <div class="proto-bar">
+      <button onclick="toggleTheme(this)">Dark</button>
+    </div>
+    <script>
+      function toggleTheme(el) {
+        const dark = document.documentElement.classList.toggle('dark');
+        localStorage.cioTheme = dark ? 'dark' : 'light';
+        el.textContent = dark ? 'Light' : 'Dark';
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What does this PR do?

Adds the PRD and clickable prototypes for **Embedded Academy** — the full-page widget ("page template") that renders an org's whole academy inside a customer's own product.

Today a widget is capped at one layout and one course list (`widget.layout_type` is a single enum column), it is anonymous, and every CTA ejects the learner to the academy on another domain. This spec makes a widget render a whole page, and then makes that page a working LMS: index → category → course detail → lesson → exercise, without the learner ever leaving the host app.

Reference experience: the Claude app's "Learn" page (featured courses, getting-started tutorials, browse-by-role with a "For you" badge).

**Docs and prototypes only — no product code, no schema migration, no dependency changes.**

### Design summary

Builds on the shipped [`prd/course-widget-embed [DONE]`](https://github.com/classroomio/classroomio/tree/main/prd/course-widget-embed%20%5BDONE%5D) rather than introducing a parallel system:

- `widget.kind` separates `block` (today, unchanged) from `page`. Sections are stored **relationally** (`widget_section` + `widget_section_course` + `widget_section_tag`) so course and tag references stay real foreign keys and `config` jsonb holds presentation only.
- Six of the seven shipped layouts become section types with no rewrite. Only `page_header`, `category_grid`, `continue_learning`, `cta_banner`, and `rich_text` are new. `path_list` is reserved in the enum for the drafted Learning Paths feature.
- **Snapshot + overlay.** The anonymous CDN-cached payload drives first paint; a separate `no-store` per-learner overlay supplies progress, resume, and "For you", merged client-side. The snapshot builder is pure and takes no learner argument, so learner data physically cannot leak into the cached payload.
- **Cookie-free auth.** Third-party cookies are blocked by default in Safari and Firefox, so the host signs a JWT with the org's existing token-auth secret and the embed exchanges it for a short-lived in-memory bearer token. `exchangeToken()` and the wildcard `publicApiCors` on `/widgets/` already exist; the missing primitive is Better Auth's `bearer()` plugin.
- **No forked player.** Course detail and the lesson/exercise player reuse `packages/ui/src/custom/public-course` — the same components the org-site route wraps today. This is a hard acceptance criterion, not a preference.
- **Per-chunk gzip budgets** (loader 3 kB / index 30 kB / course 25 kB / player 60 kB) replace the single 35 kB runtime budget, enforced by a CI gate. A learner who only browses never downloads the player.

Phases 6 and 8 of the implementation order are separable releases — index-only and anonymous is shippable on its own.

## Demo

The prototypes are the demo, and they are the UX source of truth for this feature. Clone the branch and open:

```
prototypes/embedded-academy/index.html
```

Every page has a state switcher and light/dark toggle in the bottom-right. The learner screens render inside a mock host app, with a **Bounds** toggle showing where the embed starts and ends and an **Inherit host** toggle demonstrating `theme.mode: 'inherit-host'`.

| Journey | Screens |
| --- | --- |
| Learner (in the customer's product) | `embed-learn.html`, `embed-learn-anon.html`, `embed-category.html`, `embed-course.html`, `embed-lesson.html`, `embed-exercise.html` |
| Admin (dashboard) | `admin-academies.html`, `admin-editor.html`, `admin-embed.html`, `admin-analytics.html` |

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] This change requires a documentation update

<sub>Closest fit — this is a planning document plus design prototypes, not a code change. The implementation it specifies will add a database migration, but this PR does not.</sub>

## How should this be tested?

- **A — Read the PRD**: `prd/embedded-academy/README.md`. The Confirmed Decisions and Current-State Audit sections are the parts worth arguing with; everything downstream follows from them.
- **B — Click the prototypes**: open `prototypes/embedded-academy/index.html` and walk the learner journey end to end, then the admin journey. Exercise the state switchers — anonymous vs signed in, the four course-detail CTA states, and the not-enrolled lesson gate.
- **C — Check the audit claims**: the design leans on `packages/ui/src/custom/public-course/`, `packages/db/src/auth/token-exchange.ts`, and the `/widgets/` prefix in `apps/api/src/middlewares/cors.ts` already doing what the PRD says they do.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` — n/a, no source files changed (markdown, HTML, and prototype CSS only)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch
- [x] My changes don't cause any responsiveness issues
- [x] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: n/a, it changes none of them

### Appreciated

- [x] If a UI change was made: the prototypes are the visual reference
- [ ] Updated the ClassroomIO Docs if changes were necessary — deferred to implementation (phase 9 of the PRD)

## Open calls for reviewers

Two product decisions were made without an explicit answer and are cheap to reverse now:

1. **Section-level analytics ship in v1.** It populates the `widget_analytics_event` schema the shipped widget PRD reserved, but costs roughly a phase plus a screen. Cutting it drops `admin-analytics.html`.
2. **`certificate_showcase` is deferred entirely** rather than reserved in the section-type enum, unlike `path_list`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive Embedded Academy product documentation.
  - Documented learner and administrator experiences, page composition, personalized snapshots, authentication, analytics, and navigation.
  - Included API expectations, data requirements, performance targets, implementation phases, acceptance criteria, risks, and outstanding product decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces the Embedded Academy product and technical design, covering relational page sections, anonymous snapshots with learner overlays, bearer-based identity, embedded course delivery, analytics, and route-split bundles.

- Extends existing widgets with full-page academies and reusable section renderers.
- Defines an authenticated learner journey from discovery through lessons and exercises.
- Proposes snapshot/overlay caching, host-signed identity exchange, origin restrictions, and per-chunk budgets.
- Several contracts need correction before implementation, particularly personalized-section hydration, token renewal, HLS authorization, and origin enforcement.

<h3>Confidence Score: 1/5</h3>

The PRD should not be treated as implementation-ready until its personalized rendering, authentication renewal, playback authorization, and origin-enforcement contracts are corrected.

The current design cannot hydrate or position its personalized section, cannot renew identity from the documented two-minute host token, retains a third-party-cookie dependency for HLS, and allows anonymous routes to bypass the promised origin restriction.

**Files Needing Attention:** prd/embedded-academy/README.md

<details open><summary><h3>Security Review</h3></summary>

The origin allowlist is specified only at authenticated session exchange, leaving anonymous payload and optional-auth content routes available to non-allowlisted origins. This does not enforce the PRD's leaked-key rehosting protection.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| prd/embedded-academy/README.md | Defines the complete Embedded Academy architecture, but contains blocking gaps in overlay rendering, token renewal, HLS playback, and origin enforcement. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant H as Host application
  participant E as Embedded Academy
  participant A as Widget API
  participant V as HLS delivery
  H->>E: Mount with public key and signed JWT
  E->>A: GET anonymous snapshot
  A-->>E: Ordered sections and course content
  E->>A: POST session with host JWT
  A-->>E: Short-lived bearer token
  E->>A: GET learner overlay
  A-->>E: Progress, resume, recommendations
  E->>A: Request course or learning action
  A-->>E: Course/player data
  E->>V: Request HLS manifest and segments
  Note over E,V: Design must provide a cookie-free playback credential
```

<sub>Reviews (1): Last reviewed commit: ["docs(prd): add Embedded Academy PRD and ..."](https://github.com/classroomio/classroomio/commit/3cec3b17c04f654115b451e9c3083c9d7418f03e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61052038)</sub>

> Greptile also left **5 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Embedded learning widgets](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/embedded-learning-widgets.md)
- Knowledge Base — [Authentication services](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/authentication-services.md)
- Knowledge Base — [Restore widget versions without duplicates](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/reverts/rollback_940-20260827-duplicate-widget-versions-69efb2c.md)
</details>


<!-- /greptile_comment -->