### PR TITLE
fix(landing-page): quartz course images, callout links, courses selection

### DIFF
--- a/apps/dashboard/src/lib/features/org/utils/landing-page.ts
+++ b/apps/dashboard/src/lib/features/org/utils/landing-page.ts
@@ -161,12 +161,36 @@ function normalizeText(value: unknown, fallback = '') {
 
 import { isAllowedHref } from '@cio/utils/validation/shared';
 
+/**
+ * Repairs an absolute URL that was accidentally saved behind a leading '#' — the
+ * shape you get when a URL is pasted into a link field pre-filled with '#'.
+ * Left as a fragment, the browser resolves it against the current org page
+ * (`https://org.example.com/#https://somewhere.com`) instead of navigating away.
+ */
+function stripAccidentalFragmentPrefix(href: string): string {
+  const withoutHash = href.replace(/^#+/, '');
+  const isAbsolute = /^(https?:\/\/|mailto:|tel:|\/\/)/i.test(withoutHash);
+
+  return isAbsolute ? withoutHash : href;
+}
+
 function normalizeHref(value: unknown, fallback = '#') {
-  if (typeof value !== 'string') return fallback;
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
   const trimmed = value.trim();
-  if (trimmed.length === 0) return fallback;
-  if (!isAllowedHref(trimmed)) return fallback;
-  return trimmed;
+  if (trimmed.length === 0) {
+    return fallback;
+  }
+
+  // Repair before validating, so the allowlist judges the URL the user meant.
+  const repaired = stripAccidentalFragmentPrefix(trimmed);
+  if (!isAllowedHref(repaired)) {
+    return fallback;
+  }
+
+  return repaired;
 }
 
 function isLegacyFooterSocialBlock(value: Record<string, unknown>): boolean {

--- a/apps/dashboard/src/lib/features/org/utils/landing-page.ts
+++ b/apps/dashboard/src/lib/features/org/utils/landing-page.ts
@@ -18,6 +18,7 @@ import {
   labelMatchesSocialPlatform,
   resolveFooterSocialPlatform
 } from '@cio/ui/custom/org-landing-page/footer-social-platform';
+import { isAllowedHref } from '@cio/utils/validation/shared';
 import { t } from '$lib/utils/functions/translations';
 
 export const landingPageThemes = [
@@ -159,14 +160,6 @@ function normalizeText(value: unknown, fallback = '') {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallback;
 }
 
-import { isAllowedHref } from '@cio/utils/validation/shared';
-
-/**
- * Repairs an absolute URL that was accidentally saved behind a leading '#' — the
- * shape you get when a URL is pasted into a link field pre-filled with '#'.
- * Left as a fragment, the browser resolves it against the current org page
- * (`https://org.example.com/#https://somewhere.com`) instead of navigating away.
- */
 function stripAccidentalFragmentPrefix(href: string): string {
   const withoutHash = href.replace(/^#+/, '');
   const isAbsolute = /^(https?:\/\/|mailto:|tel:|\/\/)/i.test(withoutHash);
@@ -184,7 +177,6 @@ function normalizeHref(value: unknown, fallback = '#') {
     return fallback;
   }
 
-  // Repair before validating, so the allowlist judges the URL the user meant.
   const repaired = stripAccidentalFragmentPrefix(trimmed);
   if (!isAllowedHref(repaired)) {
     return fallback;

--- a/apps/dashboard/src/lib/features/settings/pages/landingpage-editor/callout-section.svelte
+++ b/apps/dashboard/src/lib/features/settings/pages/landingpage-editor/callout-section.svelte
@@ -38,9 +38,6 @@
       description: '',
       action: {
         label: t.get('settings.landing_page.editor.callout.action_label_default'),
-        // Left empty so the field shows its `https://...` placeholder. Pre-filling
-        // '#' made pasted URLs land as '#https://example.com', which the browser
-        // then resolves as a fragment on the current page.
         href: ''
       }
     };

--- a/apps/dashboard/src/lib/features/settings/pages/landingpage-editor/callout-section.svelte
+++ b/apps/dashboard/src/lib/features/settings/pages/landingpage-editor/callout-section.svelte
@@ -38,7 +38,10 @@
       description: '',
       action: {
         label: t.get('settings.landing_page.editor.callout.action_label_default'),
-        href: '#'
+        // Left empty so the field shows its `https://...` placeholder. Pre-filling
+        // '#' made pasted URLs land as '#https://example.com', which the browser
+        // then resolves as a fragment on the current page.
+        href: ''
       }
     };
 

--- a/packages/ui/src/custom/org-landing-page/classic/org.svelte
+++ b/packages/ui/src/custom/org-landing-page/classic/org.svelte
@@ -8,6 +8,7 @@
   import ClassicHero from './hero.svelte';
   import ClassicCourseCard from './course-card.svelte';
   import OrgLandingPageCoursesEmpty from '../courses-empty.svelte';
+  import EditableLandingSection from '../editable-section.svelte';
   import { Button } from '../../../base/button';
   import LandingThemeScope from '../landing-theme-scope.svelte';
 
@@ -35,38 +36,40 @@
   <main>
     <ClassicHero {hero} />
 
-    <section class="ui:py-10 ui:px-6 ui:lg:px-8 ui:max-w-7xl ui:mx-auto">
-      <div class="ui:text-center ui:mb-8">
-        <h2 class="ui:text-3xl ui:font-bold ui:text-[var(--landing-fg)]">
-          {labels?.catalogHeading ?? 'Featured Courses'}
-        </h2>
-        <div class="ui:mt-6 ui:h-px ui:w-24 ui:bg-[var(--landing-border)] ui:mx-auto"></div>
-      </div>
-
-      {#if coursesLoaded && courses.length === 0}
-        <OrgLandingPageCoursesEmpty {labels} />
-      {:else}
-        <div class="ui:grid ui:grid-cols-1 ui:sm:grid-cols-2 ui:lg:grid-cols-3 ui:gap-8 ui:justify-items-center">
-          {#each courses as course, index (course.id)}
-            <ClassicCourseCard {course} {disableCourseLinks} {labels} />
-          {/each}
+    <EditableLandingSection sectionKey="courses">
+      <section class="ui:py-10 ui:px-6 ui:lg:px-8 ui:max-w-7xl ui:mx-auto">
+        <div class="ui:text-center ui:mb-8">
+          <h2 class="ui:text-3xl ui:font-bold ui:text-[var(--landing-fg)]">
+            {labels?.catalogHeading ?? 'Featured Courses'}
+          </h2>
+          <div class="ui:mt-6 ui:h-px ui:w-24 ui:bg-[var(--landing-border)] ui:mx-auto"></div>
         </div>
 
-        {#if hasMoreCourses}
-          <div class="ui:mt-12 ui:flex ui:justify-center">
-            <Button
-              href={disableCourseLinks ? undefined : '/courses'}
-              variant="outline"
-              size="lg"
-              class="ui:px-8"
-              disabled={disableCourseLinks}
-            >
-              {labels?.browseCoursesLabel ?? 'View more courses'}
-            </Button>
+        {#if coursesLoaded && courses.length === 0}
+          <OrgLandingPageCoursesEmpty {labels} />
+        {:else}
+          <div class="ui:grid ui:grid-cols-1 ui:sm:grid-cols-2 ui:lg:grid-cols-3 ui:gap-8 ui:justify-items-center">
+            {#each courses as course, index (course.id)}
+              <ClassicCourseCard {course} {disableCourseLinks} {labels} />
+            {/each}
           </div>
+
+          {#if hasMoreCourses}
+            <div class="ui:mt-12 ui:flex ui:justify-center">
+              <Button
+                href={disableCourseLinks ? undefined : '/courses'}
+                variant="outline"
+                size="lg"
+                class="ui:px-8"
+                disabled={disableCourseLinks}
+              >
+                {labels?.browseCoursesLabel ?? 'View more courses'}
+              </Button>
+            </div>
+          {/if}
         {/if}
-      {/if}
-    </section>
+      </section>
+    </EditableLandingSection>
   </main>
 
   <OrgLandingPageLinks {links} {labels} variant="classic" />

--- a/packages/ui/src/custom/org-landing-page/corporate/org.svelte
+++ b/packages/ui/src/custom/org-landing-page/corporate/org.svelte
@@ -8,6 +8,7 @@
   import CorporateHero from './hero.svelte';
   import CorporateCourseCard from './course-card.svelte';
   import OrgLandingPageCoursesEmpty from '../courses-empty.svelte';
+  import EditableLandingSection from '../editable-section.svelte';
   import { Button } from '../../../base/button';
   import LandingThemeScope from '../landing-theme-scope.svelte';
 
@@ -37,42 +38,46 @@
       {/snippet}
     </CorporateHero>
 
-    <section class="ui:py-24 ui:px-6 ui:border-t ui:border-[var(--landing-border)]">
-      <div class="ui:max-w-[1120px] ui:mx-auto">
-        <div class="ui:flex ui:items-end ui:justify-between ui:flex-wrap ui:gap-4 ui:mb-10">
-          <div>
-            <p class="ui:text-xs ui:font-semibold ui:tracking-widest ui:uppercase ui:text-[var(--landing-fg)] ui:mb-3">
-              {labels?.catalogEyebrow ?? 'Catalog'}
-            </p>
-            <h2 class="ui:text-3xl ui:lg:text-4xl ui:font-semibold ui:tracking-tight ui:m-0 ui:max-w-xl">
-              {labels?.catalogHeading ?? 'Courses your teams are taking'}
-            </h2>
+    <EditableLandingSection sectionKey="courses">
+      <section class="ui:py-24 ui:px-6 ui:border-t ui:border-[var(--landing-border)]">
+        <div class="ui:max-w-[1120px] ui:mx-auto">
+          <div class="ui:flex ui:items-end ui:justify-between ui:flex-wrap ui:gap-4 ui:mb-10">
+            <div>
+              <p
+                class="ui:text-xs ui:font-semibold ui:tracking-widest ui:uppercase ui:text-[var(--landing-fg)] ui:mb-3"
+              >
+                {labels?.catalogEyebrow ?? 'Catalog'}
+              </p>
+              <h2 class="ui:text-3xl ui:lg:text-4xl ui:font-semibold ui:tracking-tight ui:m-0 ui:max-w-xl">
+                {labels?.catalogHeading ?? 'Courses your teams are taking'}
+              </h2>
+            </div>
+            {#if hasMoreCourses && courses.length > 0}
+              <Button
+                href={disableCourseLinks ? undefined : '/courses'}
+                variant="outline"
+                class="ui:rounded-none ui:font-medium"
+                disabled={disableCourseLinks}
+              >
+                {labels?.browseCoursesLabel ?? 'Browse catalog →'}
+              </Button>
+            {/if}
           </div>
-          {#if hasMoreCourses && courses.length > 0}
-            <Button
-              href={disableCourseLinks ? undefined : '/courses'}
-              variant="outline"
-              class="ui:rounded-none ui:font-medium"
-              disabled={disableCourseLinks}
+
+          {#if coursesLoaded && courses.length === 0}
+            <OrgLandingPageCoursesEmpty {labels} />
+          {:else}
+            <div
+              class="ui:grid ui:grid-cols-1 ui:md:grid-cols-2 ui:lg:grid-cols-3 ui:border-t ui:border-l ui:border-[var(--landing-border)]"
             >
-              {labels?.browseCoursesLabel ?? 'Browse catalog →'}
-            </Button>
+              {#each courses as course, index (course.id)}
+                <CorporateCourseCard {course} {disableCourseLinks} {labels} />
+              {/each}
+            </div>
           {/if}
         </div>
-
-        {#if coursesLoaded && courses.length === 0}
-          <OrgLandingPageCoursesEmpty {labels} />
-        {:else}
-          <div
-            class="ui:grid ui:grid-cols-1 ui:md:grid-cols-2 ui:lg:grid-cols-3 ui:border-t ui:border-l ui:border-[var(--landing-border)]"
-          >
-            {#each courses as course, index (course.id)}
-              <CorporateCourseCard {course} {disableCourseLinks} {labels} />
-            {/each}
-          </div>
-        {/if}
-      </div>
-    </section>
+      </section>
+    </EditableLandingSection>
   </main>
 
   <OrgLandingPageLinks {links} {labels} variant="corporate" />

--- a/packages/ui/src/custom/org-landing-page/editorial/org.svelte
+++ b/packages/ui/src/custom/org-landing-page/editorial/org.svelte
@@ -8,6 +8,7 @@
   import EditorialHero from './hero.svelte';
   import EditorialCourseCard from './course-card.svelte';
   import OrgLandingPageCoursesEmpty from '../courses-empty.svelte';
+  import EditableLandingSection from '../editable-section.svelte';
   import LandingThemeScope from '../landing-theme-scope.svelte';
   import { Button } from '../../../base/button';
   import { getCourseTypeLandingMeta } from '../landing-page-utils';
@@ -95,84 +96,86 @@
       {/snippet}
     </EditorialHero>
 
-    <section id="courses" class="ui:py-10 ui:px-6 ui:md:px-8 ui:bg-[var(--landing-bg)]">
-      <div class="ui:max-w-[1240px] ui:mx-auto">
-        <div class="ui:flex ui:flex-col ui:md:flex-row ui:md:items-end ui:justify-between ui:gap-6 ui:mb-8">
-          <div>
-            <p class="ui:text-[13px] ui:m-0 ui:mb-2 ui:text-[var(--landing-fg-muted)]">
-              {labels?.catalogEyebrow ?? 'Catalog'}
-            </p>
-            <h2
-              class="ui:text-3xl ui:md:text-[40px] ui:font-medium ui:tracking-tight ui:m-0 ui:leading-[1.1] ui:text-[var(--landing-fg)]"
-              style="letter-spacing: -0.025em;"
-            >
-              {labels?.catalogHeading ?? 'Courses starting this season.'}
-            </h2>
-            <p class="ui:text-base ui:mt-3 ui:max-w-xl ui:m-0 ui:text-[var(--landing-fg-muted)]">
-              {labels?.catalogDescription ??
-                'Cohort-based and self-paced — every course ends with a reviewed project and a certificate of completion.'}
-            </p>
-          </div>
-          {#if hasMoreCourses && courses.length > 0}
-            <Button
-              href={disableCourseLinks ? undefined : '/courses'}
-              variant="outline"
-              class="ui:rounded-full ui:px-5 ui:font-medium ui:bg-transparent ui:border-[var(--landing-border)] ui:text-[var(--landing-fg)] ui:hover:bg-[var(--landing-bg-section)]"
-              disabled={disableCourseLinks}
-            >
-              {labels?.browseCoursesLabel ?? 'Browse all courses →'}
-            </Button>
-          {/if}
-        </div>
-
-        {#if coursesLoaded && courses.length === 0}
-          <OrgLandingPageCoursesEmpty {labels} />
-        {:else}
-          {#if visibleFilterDefs.length > 1}
-            <div class="ui:flex ui:flex-wrap ui:items-center ui:gap-1.5 ui:mb-8">
-              {#each visibleFilterDefs as def (def.key)}
-                {@const isActive = activeFilter === def.key}
-                <button
-                  type="button"
-                  class="ui:inline-flex ui:items-center ui:gap-1.5 ui:px-3.5 ui:py-1.5 ui:rounded-full ui:text-[13.5px] ui:transition-colors ui:border ui:cursor-pointer"
-                  style={isActive
-                    ? 'background: var(--landing-fg); color: var(--landing-bg); border-color: var(--landing-fg);'
-                    : 'background: transparent; color: var(--landing-fg); border-color: var(--landing-border);'}
-                  onclick={() => (activeFilter = def.key)}
-                >
-                  {def.label}
-                  <span
-                    class="ui:text-[11.5px] ui:tabular-nums"
-                    style={isActive ? 'opacity: 0.6;' : 'color: var(--landing-fg-faint);'}
-                  >
-                    {filterCounts[def.key]}
-                  </span>
-                </button>
-              {/each}
+    <EditableLandingSection sectionKey="courses">
+      <section id="courses" class="ui:py-10 ui:px-6 ui:md:px-8 ui:bg-[var(--landing-bg)]">
+        <div class="ui:max-w-[1240px] ui:mx-auto">
+          <div class="ui:flex ui:flex-col ui:md:flex-row ui:md:items-end ui:justify-between ui:gap-6 ui:mb-8">
+            <div>
+              <p class="ui:text-[13px] ui:m-0 ui:mb-2 ui:text-[var(--landing-fg-muted)]">
+                {labels?.catalogEyebrow ?? 'Catalog'}
+              </p>
+              <h2
+                class="ui:text-3xl ui:md:text-[40px] ui:font-medium ui:tracking-tight ui:m-0 ui:leading-[1.1] ui:text-[var(--landing-fg)]"
+                style="letter-spacing: -0.025em;"
+              >
+                {labels?.catalogHeading ?? 'Courses starting this season.'}
+              </h2>
+              <p class="ui:text-base ui:mt-3 ui:max-w-xl ui:m-0 ui:text-[var(--landing-fg-muted)]">
+                {labels?.catalogDescription ??
+                  'Cohort-based and self-paced — every course ends with a reviewed project and a certificate of completion.'}
+              </p>
             </div>
-          {/if}
-
-          <div class="ui:grid ui:grid-cols-1 ui:md:grid-cols-2 ui:lg:grid-cols-3 ui:gap-4">
-            {#each filteredCourses as course, index (course.id)}
-              <EditorialCourseCard {course} {index} {disableCourseLinks} {labels} />
-            {/each}
-          </div>
-
-          {#if hasMoreCourses}
-            <div class="ui:text-center ui:mt-10">
+            {#if hasMoreCourses && courses.length > 0}
               <Button
                 href={disableCourseLinks ? undefined : '/courses'}
-                size="lg"
-                class="ui:rounded-full ui:px-6 ui:font-medium ui:bg-[var(--landing-fg)] ui:text-[var(--landing-bg)] ui:hover:opacity-90"
+                variant="outline"
+                class="ui:rounded-full ui:px-5 ui:font-medium ui:bg-transparent ui:border-[var(--landing-border)] ui:text-[var(--landing-fg)] ui:hover:bg-[var(--landing-bg-section)]"
                 disabled={disableCourseLinks}
               >
-                {labels?.browseCoursesLabel ?? 'View all courses'}
+                {labels?.browseCoursesLabel ?? 'Browse all courses →'}
               </Button>
+            {/if}
+          </div>
+
+          {#if coursesLoaded && courses.length === 0}
+            <OrgLandingPageCoursesEmpty {labels} />
+          {:else}
+            {#if visibleFilterDefs.length > 1}
+              <div class="ui:flex ui:flex-wrap ui:items-center ui:gap-1.5 ui:mb-8">
+                {#each visibleFilterDefs as def (def.key)}
+                  {@const isActive = activeFilter === def.key}
+                  <button
+                    type="button"
+                    class="ui:inline-flex ui:items-center ui:gap-1.5 ui:px-3.5 ui:py-1.5 ui:rounded-full ui:text-[13.5px] ui:transition-colors ui:border ui:cursor-pointer"
+                    style={isActive
+                      ? 'background: var(--landing-fg); color: var(--landing-bg); border-color: var(--landing-fg);'
+                      : 'background: transparent; color: var(--landing-fg); border-color: var(--landing-border);'}
+                    onclick={() => (activeFilter = def.key)}
+                  >
+                    {def.label}
+                    <span
+                      class="ui:text-[11.5px] ui:tabular-nums"
+                      style={isActive ? 'opacity: 0.6;' : 'color: var(--landing-fg-faint);'}
+                    >
+                      {filterCounts[def.key]}
+                    </span>
+                  </button>
+                {/each}
+              </div>
+            {/if}
+
+            <div class="ui:grid ui:grid-cols-1 ui:md:grid-cols-2 ui:lg:grid-cols-3 ui:gap-4">
+              {#each filteredCourses as course, index (course.id)}
+                <EditorialCourseCard {course} {index} {disableCourseLinks} {labels} />
+              {/each}
             </div>
+
+            {#if hasMoreCourses}
+              <div class="ui:text-center ui:mt-10">
+                <Button
+                  href={disableCourseLinks ? undefined : '/courses'}
+                  size="lg"
+                  class="ui:rounded-full ui:px-6 ui:font-medium ui:bg-[var(--landing-fg)] ui:text-[var(--landing-bg)] ui:hover:opacity-90"
+                  disabled={disableCourseLinks}
+                >
+                  {labels?.browseCoursesLabel ?? 'View all courses'}
+                </Button>
+              </div>
+            {/if}
           {/if}
-        {/if}
-      </div>
-    </section>
+        </div>
+      </section>
+    </EditableLandingSection>
   </main>
 
   <OrgLandingPageLinks {links} {labels} variant="editorial" />

--- a/packages/ui/src/custom/org-landing-page/landing-page-utils.ts
+++ b/packages/ui/src/custom/org-landing-page/landing-page-utils.ts
@@ -5,7 +5,26 @@ import GraduationCapIcon from '@lucide/svelte/icons/graduation-cap';
 import ShieldCheckIcon from '@lucide/svelte/icons/shield-check';
 import UserIcon from '@lucide/svelte/icons/user';
 
+import { DEFAULT_COURSE_BANNER_IMAGE } from '../course-card/constants';
 import type { CourseItem } from './types';
+
+/**
+ * Cover art for a course card. Falls back to the shared ClassroomIO banner so
+ * catalogs never render a hole where a course has no uploaded image.
+ */
+export function getCourseCoverImage(course: CourseItem): string {
+  const logo = course.logo?.trim();
+  if (logo) {
+    return logo;
+  }
+
+  const image = course.image?.trim();
+  if (image) {
+    return image;
+  }
+
+  return DEFAULT_COURSE_BANNER_IMAGE;
+}
 
 export function getPrimaryCourseTag(course: CourseItem) {
   return course.tags?.[0];

--- a/packages/ui/src/custom/org-landing-page/landing-page-utils.ts
+++ b/packages/ui/src/custom/org-landing-page/landing-page-utils.ts
@@ -8,10 +8,6 @@ import UserIcon from '@lucide/svelte/icons/user';
 import { DEFAULT_COURSE_BANNER_IMAGE } from '../course-card/constants';
 import type { CourseItem } from './types';
 
-/**
- * Cover art for a course card. Falls back to the shared ClassroomIO banner so
- * catalogs never render a hole where a course has no uploaded image.
- */
 export function getCourseCoverImage(course: CourseItem): string {
   const logo = course.logo?.trim();
   if (logo) {

--- a/packages/ui/src/custom/org-landing-page/quartz/course-card.svelte
+++ b/packages/ui/src/custom/org-landing-page/quartz/course-card.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { CourseItem, OrgLandingPageLabels } from '../types';
-  import { getCourseTypeLandingMeta, getPrimaryCourseTag } from '../landing-page-utils';
+  import { getCourseCoverImage, getCourseTypeLandingMeta, getPrimaryCourseTag } from '../landing-page-utils';
 
   interface Props {
     course: CourseItem;
@@ -12,6 +12,7 @@
 
   const courseTypeMeta = $derived(getCourseTypeLandingMeta(course));
   const primaryTag = $derived(getPrimaryCourseTag(course));
+  const cover = $derived(getCourseCoverImage(course));
 
   const href = $derived.by(() => {
     if (disableCourseLinks) return undefined;
@@ -41,37 +42,51 @@
 <svelte:element
   this={href ? 'a' : 'div'}
   {href}
-  class="ui:flex ui:flex-col ui:min-h-[260px] ui:p-6 ui:no-underline ui:border-r ui:border-b ui:border-[var(--landing-border)] ui:bg-[var(--landing-card)] ui:transition-colors {disableCourseLinks
+  class="ui:group ui:flex ui:flex-col ui:min-h-[260px] ui:no-underline ui:border-r ui:border-b ui:border-[var(--landing-border)] ui:bg-[var(--landing-card)] ui:transition-colors {disableCourseLinks
     ? 'ui:cursor-default'
     : 'ui:cursor-pointer ui:hover:bg-[var(--landing-card-soft)]'}"
   aria-disabled={disableCourseLinks}
 >
-  {#if primaryTag}
-    <span
-      class="ui:inline-flex ui:items-center ui:gap-1.5 ui:self-start ui:mb-3 ui:px-2.5 ui:py-0.5 ui:rounded-[var(--landing-radius-pill)] ui:border ui:border-[var(--landing-border)] ui:text-xs ui:text-[var(--landing-fg-muted)]"
-    >
-      {#if primaryTag.color}
-        <span class="ui:h-1.5 ui:w-1.5 ui:rounded-full" style={`background-color: ${primaryTag.color}`}></span>
-      {/if}
-      {primaryTag.name}
-    </span>
-  {/if}
-
-  <h3
-    class="ui:m-0 ui:mb-2.5 ui:text-lg ui:leading-snug ui:text-[var(--landing-fg)] ui:[font-weight:var(--landing-heading-weight)] ui:[letter-spacing:var(--landing-heading-tracking)]"
+  <div
+    class="ui:aspect-[16/9] ui:w-full ui:overflow-hidden ui:bg-[var(--landing-card-soft)] ui:border-b ui:border-[var(--landing-border)]"
   >
-    {course.title}
-  </h3>
-  <p class="ui:m-0 ui:text-sm ui:leading-relaxed ui:text-[var(--landing-fg-muted)] ui:line-clamp-3">
-    {course.description}
-  </p>
+    <img
+      src={cover}
+      alt=""
+      class="ui:h-full ui:w-full ui:object-cover ui:transition-transform ui:duration-300 ui:group-hover:scale-[1.03]"
+    />
+  </div>
 
-  <div class="ui:mt-auto ui:pt-6 ui:flex ui:items-center ui:justify-between ui:gap-4">
-    <span class="ui:flex ui:flex-wrap ui:gap-x-3 ui:gap-y-1 ui:text-[13px] ui:text-[var(--landing-fg-faint)]">
-      {#if lessonsLabel}<span>{lessonsLabel}</span>{/if}
-      {#if courseTypeMeta}<span>{courseTypeMeta.label}</span>{/if}
-      {#if course.duration}<span>{course.duration}</span>{/if}
-    </span>
-    <span class="ui:text-[13.5px] ui:font-semibold ui:text-[var(--landing-fg)] ui:whitespace-nowrap">{priceLabel}</span>
+  <div class="ui:flex ui:flex-1 ui:flex-col ui:p-6">
+    {#if primaryTag}
+      <span
+        class="ui:inline-flex ui:items-center ui:gap-1.5 ui:self-start ui:mb-3 ui:px-2.5 ui:py-0.5 ui:rounded-[var(--landing-radius-pill)] ui:border ui:border-[var(--landing-border)] ui:text-xs ui:text-[var(--landing-fg-muted)]"
+      >
+        {#if primaryTag.color}
+          <span class="ui:h-1.5 ui:w-1.5 ui:rounded-full" style={`background-color: ${primaryTag.color}`}></span>
+        {/if}
+        {primaryTag.name}
+      </span>
+    {/if}
+
+    <h3
+      class="ui:m-0 ui:mb-2.5 ui:text-lg ui:leading-snug ui:text-[var(--landing-fg)] ui:[font-weight:var(--landing-heading-weight)] ui:[letter-spacing:var(--landing-heading-tracking)]"
+    >
+      {course.title}
+    </h3>
+    <p class="ui:m-0 ui:text-sm ui:leading-relaxed ui:text-[var(--landing-fg-muted)] ui:line-clamp-3">
+      {course.description}
+    </p>
+
+    <div class="ui:mt-auto ui:pt-6 ui:flex ui:items-center ui:justify-between ui:gap-4">
+      <span class="ui:flex ui:flex-wrap ui:gap-x-3 ui:gap-y-1 ui:text-[13px] ui:text-[var(--landing-fg-faint)]">
+        {#if lessonsLabel}<span>{lessonsLabel}</span>{/if}
+        {#if courseTypeMeta}<span>{courseTypeMeta.label}</span>{/if}
+        {#if course.duration}<span>{course.duration}</span>{/if}
+      </span>
+      <span class="ui:text-[13.5px] ui:font-semibold ui:text-[var(--landing-fg)] ui:whitespace-nowrap"
+        >{priceLabel}</span
+      >
+    </div>
   </div>
 </svelte:element>

--- a/packages/ui/src/custom/org-landing-page/quartz/course-row.svelte
+++ b/packages/ui/src/custom/org-landing-page/quartz/course-row.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import type { CourseItem, OrgLandingPageLabels } from '../types';
-  import { getCourseTypeLandingMeta, getPrimaryCourseTag } from '../landing-page-utils';
+  import { getCourseCoverImage, getCourseTypeLandingMeta, getPrimaryCourseTag } from '../landing-page-utils';
   import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
-  import ImageIcon from '@lucide/svelte/icons/image';
 
   interface Props {
     course: CourseItem;
@@ -14,7 +13,7 @@
 
   const courseTypeMeta = $derived(getCourseTypeLandingMeta(course));
   const primaryTag = $derived(getPrimaryCourseTag(course));
-  const cover = $derived(course.logo || course.image);
+  const cover = $derived(getCourseCoverImage(course));
 
   const href = $derived.by(() => {
     if (disableCourseLinks) return undefined;
@@ -59,13 +58,7 @@
   <div
     class="ui:grid ui:place-items-center ui:aspect-[4/3] ui:@2xl:aspect-auto ui:overflow-hidden ui:bg-[var(--landing-card-soft)] ui:border-b ui:@2xl:border-b-0 ui:@2xl:border-r ui:border-[var(--landing-border)]"
   >
-    {#if cover}
-      <img src={cover} alt="" class="ui:h-full ui:w-full ui:object-cover" />
-    {:else}
-      <span class="ui:flex ui:flex-col ui:items-center ui:gap-2 ui:text-[var(--landing-fg-faint)]">
-        <ImageIcon class="ui:size-6" aria-hidden="true" />
-      </span>
-    {/if}
+    <img src={cover} alt="" class="ui:h-full ui:w-full ui:object-cover" />
   </div>
 
   <div class="ui:flex ui:flex-col ui:p-7 ui:@2xl:px-8">

--- a/packages/ui/src/custom/org-landing-page/quartz/org.svelte
+++ b/packages/ui/src/custom/org-landing-page/quartz/org.svelte
@@ -5,6 +5,7 @@
   import OrgLandingPageCallout from '../callout.svelte';
   import QuartzFooter from './footer.svelte';
   import OrgLandingPageCoursesEmpty from '../courses-empty.svelte';
+  import EditableLandingSection from '../editable-section.svelte';
   import LandingThemeScope from '../landing-theme-scope.svelte';
   import LandingButton from '../landing-button.svelte';
   import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
@@ -36,49 +37,51 @@
   <main class="ui:@container ui:max-w-[1200px] ui:mx-auto ui:border-x ui:border-[var(--landing-border)]">
     <QuartzHero {hero} />
 
-    <section id="courses" class="ui:border-t ui:border-[var(--landing-border)]">
-      <p
-        class="ui:m-0 ui:px-5 ui:md:px-8 ui:py-3 ui:bg-[var(--landing-card)] ui:text-xs ui:text-[var(--landing-fg-faint)] ui:[letter-spacing:var(--landing-eyebrow-tracking)] ui:[text-transform:var(--landing-eyebrow-case)]"
-      >
-        {labels?.catalogEyebrow ?? 'Selected courses'}
-      </p>
+    <EditableLandingSection sectionKey="courses">
+      <section id="courses" class="ui:border-t ui:border-[var(--landing-border)]">
+        <p
+          class="ui:m-0 ui:px-5 ui:md:px-8 ui:py-3 ui:bg-[var(--landing-card)] ui:text-xs ui:text-[var(--landing-fg-faint)] ui:[letter-spacing:var(--landing-eyebrow-tracking)] ui:[text-transform:var(--landing-eyebrow-case)]"
+        >
+          {labels?.catalogEyebrow ?? 'Selected courses'}
+        </p>
 
-      {#if coursesLoaded && courses.length === 0}
-        <OrgLandingPageCoursesEmpty {labels} />
-      {:else}
-        {#each courses as course (course.id)}
-          <QuartzCourseRow {course} {disableCourseLinks} {labels} />
-        {/each}
+        {#if coursesLoaded && courses.length === 0}
+          <OrgLandingPageCoursesEmpty {labels} />
+        {:else}
+          {#each courses as course (course.id)}
+            <QuartzCourseRow {course} {disableCourseLinks} {labels} />
+          {/each}
 
-        {#if hasMoreCourses}
-          <div
-            class="ui:flex ui:flex-wrap ui:items-center ui:justify-between ui:gap-6 ui:px-5 ui:md:px-8 ui:py-8 ui:bg-[var(--landing-card)] ui:border-y ui:border-[var(--landing-border)]"
-          >
-            <div>
-              <p
-                class="ui:m-0 ui:text-lg ui:text-[var(--landing-fg)] ui:[font-weight:var(--landing-heading-weight)] ui:[letter-spacing:var(--landing-heading-tracking)]"
-              >
-                {labels?.catalogHeading ?? 'The full catalogue'}
-              </p>
-              {#if labels?.catalogDescription}
-                <p class="ui:m-0 ui:mt-1.5 ui:text-sm ui:text-[var(--landing-fg-muted)]">
-                  {labels.catalogDescription}
-                </p>
-              {/if}
-            </div>
-            <LandingButton
-              variant="secondary"
-              size="lg"
-              href={disableCourseLinks ? undefined : '/courses'}
-              disabled={disableCourseLinks}
+          {#if hasMoreCourses}
+            <div
+              class="ui:flex ui:flex-wrap ui:items-center ui:justify-between ui:gap-6 ui:px-5 ui:md:px-8 ui:py-8 ui:bg-[var(--landing-card)] ui:border-y ui:border-[var(--landing-border)]"
             >
-              {labels?.browseCoursesLabel ?? 'View more courses'}
-              <ArrowRightIcon class="ui:size-3.5" aria-hidden="true" />
-            </LandingButton>
-          </div>
+              <div>
+                <p
+                  class="ui:m-0 ui:text-lg ui:text-[var(--landing-fg)] ui:[font-weight:var(--landing-heading-weight)] ui:[letter-spacing:var(--landing-heading-tracking)]"
+                >
+                  {labels?.catalogHeading ?? 'The full catalogue'}
+                </p>
+                {#if labels?.catalogDescription}
+                  <p class="ui:m-0 ui:mt-1.5 ui:text-sm ui:text-[var(--landing-fg-muted)]">
+                    {labels.catalogDescription}
+                  </p>
+                {/if}
+              </div>
+              <LandingButton
+                variant="secondary"
+                size="lg"
+                href={disableCourseLinks ? undefined : '/courses'}
+                disabled={disableCourseLinks}
+              >
+                {labels?.browseCoursesLabel ?? 'View more courses'}
+                <ArrowRightIcon class="ui:size-3.5" aria-hidden="true" />
+              </LandingButton>
+            </div>
+          {/if}
         {/if}
-      {/if}
-    </section>
+      </section>
+    </EditableLandingSection>
 
     <OrgLandingPageLinks {links} {labels} variant="quartz" />
 

--- a/packages/ui/src/custom/org-landing-page/studio/org.svelte
+++ b/packages/ui/src/custom/org-landing-page/studio/org.svelte
@@ -8,6 +8,7 @@
   import StudioHero from './hero.svelte';
   import StudioCourseCard from './course-card.svelte';
   import OrgLandingPageCoursesEmpty from '../courses-empty.svelte';
+  import EditableLandingSection from '../editable-section.svelte';
   import { Button } from '../../../base/button';
   import LandingThemeScope from '../landing-theme-scope.svelte';
 
@@ -37,43 +38,45 @@
       {/snippet}
     </StudioHero>
 
-    <section class="ui:py-24 ui:px-6 ui:border-t ui:border-[var(--landing-border)]">
-      <div class="ui:max-w-[1080px] ui:mx-auto">
-        <div class="ui:grid ui:grid-cols-1 ui:md:grid-cols-2 ui:gap-12 ui:items-end ui:mb-12">
-          <div>
-            <p class="ui:text-sm ui:text-[var(--landing-fg-muted)] ui:mb-1.5 ui:inline-flex ui:items-center ui:gap-2">
-              <span class="ui:size-1.5 ui:rounded-full ui:bg-[var(--landing-accent)]"></span>
-              {labels?.catalogEyebrow ?? 'Catalog'}
-            </p>
-            <h2 class="ui:text-3xl ui:lg:text-4xl ui:font-semibold ui:tracking-tight ui:m-0">
-              {labels?.catalogHeading ?? 'Courses your team can actually finish.'}
-            </h2>
+    <EditableLandingSection sectionKey="courses">
+      <section class="ui:py-24 ui:px-6 ui:border-t ui:border-[var(--landing-border)]">
+        <div class="ui:max-w-[1080px] ui:mx-auto">
+          <div class="ui:grid ui:grid-cols-1 ui:md:grid-cols-2 ui:gap-12 ui:items-end ui:mb-12">
+            <div>
+              <p class="ui:text-sm ui:text-[var(--landing-fg-muted)] ui:mb-1.5 ui:inline-flex ui:items-center ui:gap-2">
+                <span class="ui:size-1.5 ui:rounded-full ui:bg-[var(--landing-accent)]"></span>
+                {labels?.catalogEyebrow ?? 'Catalog'}
+              </p>
+              <h2 class="ui:text-3xl ui:lg:text-4xl ui:font-semibold ui:tracking-tight ui:m-0">
+                {labels?.catalogHeading ?? 'Courses your team can actually finish.'}
+              </h2>
+            </div>
+            {#if hasMoreCourses && courses.length > 0}
+              <div class="ui:flex ui:justify-start ui:md:justify-end">
+                <Button
+                  href={disableCourseLinks ? undefined : '/courses'}
+                  variant="outline"
+                  class="ui:rounded-md"
+                  disabled={disableCourseLinks}
+                >
+                  {labels?.browseCoursesLabel ?? 'Browse all →'}
+                </Button>
+              </div>
+            {/if}
           </div>
-          {#if hasMoreCourses && courses.length > 0}
-            <div class="ui:flex ui:justify-start ui:md:justify-end">
-              <Button
-                href={disableCourseLinks ? undefined : '/courses'}
-                variant="outline"
-                class="ui:rounded-md"
-                disabled={disableCourseLinks}
-              >
-                {labels?.browseCoursesLabel ?? 'Browse all →'}
-              </Button>
+
+          {#if coursesLoaded && courses.length === 0}
+            <OrgLandingPageCoursesEmpty {labels} />
+          {:else}
+            <div class="ui:grid ui:grid-cols-1 ui:md:grid-cols-2 ui:lg:grid-cols-3 ui:gap-3">
+              {#each courses as course, index (course.id)}
+                <StudioCourseCard {course} {disableCourseLinks} {labels} />
+              {/each}
             </div>
           {/if}
         </div>
-
-        {#if coursesLoaded && courses.length === 0}
-          <OrgLandingPageCoursesEmpty {labels} />
-        {:else}
-          <div class="ui:grid ui:grid-cols-1 ui:md:grid-cols-2 ui:lg:grid-cols-3 ui:gap-3">
-            {#each courses as course, index (course.id)}
-              <StudioCourseCard {course} {disableCourseLinks} {labels} />
-            {/each}
-          </div>
-        {/if}
-      </div>
-    </section>
+      </section>
+    </EditableLandingSection>
   </main>
 
   <OrgLandingPageLinks {links} {labels} variant="studio" />

--- a/packages/ui/src/custom/org-landing-page/terminal/org.svelte
+++ b/packages/ui/src/custom/org-landing-page/terminal/org.svelte
@@ -8,6 +8,7 @@
   import TerminalHero from './hero.svelte';
   import TerminalCourseCard from './course-card.svelte';
   import OrgLandingPageCoursesEmpty from '../courses-empty.svelte';
+  import EditableLandingSection from '../editable-section.svelte';
   import { Button } from '../../../base/button';
   import LandingThemeScope from '../landing-theme-scope.svelte';
   import { getCourseTypeLandingMeta } from '../landing-page-utils';
@@ -80,81 +81,83 @@
       {/snippet}
     </TerminalHero>
 
-    <section
-      class="ui:py-24 ui:px-6 ui:bg-[var(--landing-bg)]"
-      style="border-top: 1px solid var(--landing-border-soft);"
-    >
-      <div class="ui:max-w-[1120px] ui:mx-auto">
-        <p
-          class="ui:font-mono ui:text-[11px] ui:tracking-[0.12em] ui:uppercase ui:mb-3 ui:inline-flex ui:items-center ui:gap-2"
-          style="color: var(--landing-accent);"
-        >
-          <span
-            class="ui:size-1.5 ui:rounded-full"
-            style="background: var(--landing-accent); box-shadow: 0 0 12px var(--landing-accent);"
-          ></span>
-          {labels?.catalogEyebrow ?? 'Catalog'}
-        </p>
+    <EditableLandingSection sectionKey="courses">
+      <section
+        class="ui:py-24 ui:px-6 ui:bg-[var(--landing-bg)]"
+        style="border-top: 1px solid var(--landing-border-soft);"
+      >
+        <div class="ui:max-w-[1120px] ui:mx-auto">
+          <p
+            class="ui:font-mono ui:text-[11px] ui:tracking-[0.12em] ui:uppercase ui:mb-3 ui:inline-flex ui:items-center ui:gap-2"
+            style="color: var(--landing-accent);"
+          >
+            <span
+              class="ui:size-1.5 ui:rounded-full"
+              style="background: var(--landing-accent); box-shadow: 0 0 12px var(--landing-accent);"
+            ></span>
+            {labels?.catalogEyebrow ?? 'Catalog'}
+          </p>
 
-        <h2
-          class="ui:text-4xl ui:lg:text-[40px] ui:font-semibold ui:tracking-tight ui:leading-[1.08] ui:m-0 ui:mb-3 ui:max-w-[700px] ui:text-[var(--landing-fg)]"
-        >
-          {labels?.catalogHeading ?? 'Courses your team can actually finish.'}
-        </h2>
+          <h2
+            class="ui:text-4xl ui:lg:text-[40px] ui:font-semibold ui:tracking-tight ui:leading-[1.08] ui:m-0 ui:mb-3 ui:max-w-[700px] ui:text-[var(--landing-fg)]"
+          >
+            {labels?.catalogHeading ?? 'Courses your team can actually finish.'}
+          </h2>
 
-        <p class="ui:text-[15px] ui:max-w-xl ui:m-0 ui:mb-8 ui:text-[var(--landing-fg-muted)]">
-          {labels?.catalogDescription ??
-            'Tracks built around real-world artifacts — pull requests, postmortems, and runbooks. No filler.'}
-        </p>
+          <p class="ui:text-[15px] ui:max-w-xl ui:m-0 ui:mb-8 ui:text-[var(--landing-fg-muted)]">
+            {labels?.catalogDescription ??
+              'Tracks built around real-world artifacts — pull requests, postmortems, and runbooks. No filler.'}
+          </p>
 
-        {#if coursesLoaded && courses.length === 0}
-          <OrgLandingPageCoursesEmpty {labels} />
-        {:else}
-          {#if tabs.length > 1}
-            <div
-              class="ui:inline-flex ui:items-center ui:gap-0.5 ui:p-1 ui:rounded-full ui:mb-8 ui:bg-[var(--landing-card)]"
-              style="border: 1px solid var(--landing-border);"
-              role="tablist"
-            >
-              {#each tabs as tab (tab.key)}
-                {@const isActive = activeTab === tab.key}
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={isActive}
-                  onclick={() => (activeTab = tab.key)}
-                  class="ui:px-3.5 ui:py-1.5 ui:text-[13px] ui:font-medium ui:rounded-full ui:transition-colors ui:cursor-pointer"
-                  style={isActive
-                    ? 'background: var(--landing-fg); color: var(--landing-bg);'
-                    : 'background: transparent; color: var(--landing-fg-muted);'}
-                >
-                  {tab.label}
-                </button>
+          {#if coursesLoaded && courses.length === 0}
+            <OrgLandingPageCoursesEmpty {labels} />
+          {:else}
+            {#if tabs.length > 1}
+              <div
+                class="ui:inline-flex ui:items-center ui:gap-0.5 ui:p-1 ui:rounded-full ui:mb-8 ui:bg-[var(--landing-card)]"
+                style="border: 1px solid var(--landing-border);"
+                role="tablist"
+              >
+                {#each tabs as tab (tab.key)}
+                  {@const isActive = activeTab === tab.key}
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    onclick={() => (activeTab = tab.key)}
+                    class="ui:px-3.5 ui:py-1.5 ui:text-[13px] ui:font-medium ui:rounded-full ui:transition-colors ui:cursor-pointer"
+                    style={isActive
+                      ? 'background: var(--landing-fg); color: var(--landing-bg);'
+                      : 'background: transparent; color: var(--landing-fg-muted);'}
+                  >
+                    {tab.label}
+                  </button>
+                {/each}
+              </div>
+            {/if}
+
+            <div class="ui:grid ui:grid-cols-1 ui:md:grid-cols-2 ui:lg:grid-cols-3 ui:gap-[14px]">
+              {#each visibleCourses as course, index (course.id)}
+                <TerminalCourseCard {course} {disableCourseLinks} {labels} />
               {/each}
             </div>
-          {/if}
 
-          <div class="ui:grid ui:grid-cols-1 ui:md:grid-cols-2 ui:lg:grid-cols-3 ui:gap-[14px]">
-            {#each visibleCourses as course, index (course.id)}
-              <TerminalCourseCard {course} {disableCourseLinks} {labels} />
-            {/each}
-          </div>
-
-          {#if hasMoreCourses}
-            <div class="ui:mt-7 ui:flex ui:justify-center">
-              <Button
-                href={disableCourseLinks ? undefined : '/courses'}
-                variant="outline"
-                disabled={disableCourseLinks}
-                class="ui:rounded-full ui:px-5 ui:bg-transparent ui:border-[var(--landing-border)] ui:text-[var(--landing-fg)] ui:hover:bg-white/5"
-              >
-                {labels?.browseCoursesLabel ?? 'View all courses →'}
-              </Button>
-            </div>
+            {#if hasMoreCourses}
+              <div class="ui:mt-7 ui:flex ui:justify-center">
+                <Button
+                  href={disableCourseLinks ? undefined : '/courses'}
+                  variant="outline"
+                  disabled={disableCourseLinks}
+                  class="ui:rounded-full ui:px-5 ui:bg-transparent ui:border-[var(--landing-border)] ui:text-[var(--landing-fg)] ui:hover:bg-white/5"
+                >
+                  {labels?.browseCoursesLabel ?? 'View all courses →'}
+                </Button>
+              </div>
+            {/if}
           {/if}
-        {/if}
-      </div>
-    </section>
+        </div>
+      </section>
+    </EditableLandingSection>
   </main>
 
   <OrgLandingPageLinks {links} {labels} variant="terminal" />

--- a/packages/ui/src/custom/org-landing-page/vibrant/org.svelte
+++ b/packages/ui/src/custom/org-landing-page/vibrant/org.svelte
@@ -8,6 +8,7 @@
   import VibrantHero from './hero.svelte';
   import VibrantCourseCard from './course-card.svelte';
   import OrgLandingPageCoursesEmpty from '../courses-empty.svelte';
+  import EditableLandingSection from '../editable-section.svelte';
   import LandingThemeScope from '../landing-theme-scope.svelte';
   import { Button } from '../../../base/button';
   import { getCourseTypeLandingMeta, defaultLessonsLabel, defaultExercisesLabel } from '../landing-page-utils';
@@ -55,162 +56,164 @@
       {/snippet}
     </VibrantHero>
 
-    {#if coursesLoaded && courses.length === 0}
-      <section id="courses" class="ui:px-6 ui:md:px-8 ui:py-24 ui:md:py-28 ui:bg-[var(--landing-bg)]">
-        <div class="ui:max-w-[1320px] ui:mx-auto">
-          <OrgLandingPageCoursesEmpty {labels} />
-        </div>
-      </section>
-    {:else}
-      {#if featured}
-        <section
-          class="ui:bg-[var(--landing-accent)] ui:text-[var(--landing-accent-fg)] ui:px-6 ui:md:px-8 ui:py-24 ui:md:py-32"
-        >
+    <EditableLandingSection sectionKey="courses">
+      {#if coursesLoaded && courses.length === 0}
+        <section id="courses" class="ui:px-6 ui:md:px-8 ui:py-24 ui:md:py-28 ui:bg-[var(--landing-bg)]">
           <div class="ui:max-w-[1320px] ui:mx-auto">
-            <div class="ui:grid ui:grid-cols-1 ui:lg:grid-cols-[1.15fr_1fr] ui:gap-12 ui:lg:gap-20 ui:items-center">
-              <div>
-                {#if featuredTypeMeta}
-                  <span
-                    class="ui:inline-flex ui:items-center ui:gap-1.5 ui:rounded-full ui:px-3 ui:py-1 ui:text-[13px] ui:font-medium ui:mb-6 ui:text-[var(--landing-accent-fg)]"
-                    style="background: rgba(255,255,255,0.18);"
+            <OrgLandingPageCoursesEmpty {labels} />
+          </div>
+        </section>
+      {:else}
+        {#if featured}
+          <section
+            class="ui:bg-[var(--landing-accent)] ui:text-[var(--landing-accent-fg)] ui:px-6 ui:md:px-8 ui:py-24 ui:md:py-32"
+          >
+            <div class="ui:max-w-[1320px] ui:mx-auto">
+              <div class="ui:grid ui:grid-cols-1 ui:lg:grid-cols-[1.15fr_1fr] ui:gap-12 ui:lg:gap-20 ui:items-center">
+                <div>
+                  {#if featuredTypeMeta}
+                    <span
+                      class="ui:inline-flex ui:items-center ui:gap-1.5 ui:rounded-full ui:px-3 ui:py-1 ui:text-[13px] ui:font-medium ui:mb-6 ui:text-[var(--landing-accent-fg)]"
+                      style="background: rgba(255,255,255,0.18);"
+                    >
+                      {labels?.featuredLabel ?? 'Featured'} · {featuredTypeMeta.label}
+                    </span>
+                  {/if}
+                  <h2
+                    class="ui:text-4xl ui:md:text-5xl ui:lg:text-[56px] ui:font-medium ui:tracking-tight ui:m-0 ui:mb-6 ui:max-w-[520px]"
+                    style="line-height: 1.05; letter-spacing: -0.025em;"
                   >
-                    {labels?.featuredLabel ?? 'Featured'} · {featuredTypeMeta.label}
-                  </span>
-                {/if}
-                <h2
-                  class="ui:text-4xl ui:md:text-5xl ui:lg:text-[56px] ui:font-medium ui:tracking-tight ui:m-0 ui:mb-6 ui:max-w-[520px]"
-                  style="line-height: 1.05; letter-spacing: -0.025em;"
-                >
-                  {featured.title}
-                </h2>
-                <p class="ui:text-lg ui:m-0 ui:mb-4 ui:max-w-[480px] ui:opacity-90" style="line-height: 1.5;">
-                  {featured.description}
-                </p>
-                <div
-                  class="ui:flex ui:flex-wrap ui:items-center ui:gap-x-5 ui:gap-y-2 ui:text-[14.5px] ui:mb-8 ui:opacity-85"
-                >
-                  {#if featured.lessonCount}
-                    <span>{resolvedLessonsLabel(featured.lessonCount)}</span>
-                  {/if}
-                  {#if featured.exerciseCount}
-                    <span aria-hidden="true">·</span>
-                    <span>{resolvedExercisesLabel(featured.exerciseCount)}</span>
-                  {/if}
-                  {#if featured.duration}
-                    <span aria-hidden="true">·</span>
-                    <span>{featured.duration}</span>
-                  {/if}
-                </div>
-                <div class="ui:flex ui:flex-wrap ui:items-center ui:gap-3">
-                  <Button
-                    href={courseHref(featured)}
-                    disabled={disableCourseLinks}
-                    class="ui:rounded-md ui:px-6 ui:py-3 ui:text-base ui:font-medium ui:bg-[var(--landing-bg)] ui:text-[var(--landing-fg)] ui:hover:opacity-90"
+                    {featured.title}
+                  </h2>
+                  <p class="ui:text-lg ui:m-0 ui:mb-4 ui:max-w-[480px] ui:opacity-90" style="line-height: 1.5;">
+                    {featured.description}
+                  </p>
+                  <div
+                    class="ui:flex ui:flex-wrap ui:items-center ui:gap-x-5 ui:gap-y-2 ui:text-[14.5px] ui:mb-8 ui:opacity-85"
                   >
-                    {labels?.startCourseLabel ?? 'Start this course'}
-                  </Button>
-                  <span class="ui:text-base ui:font-medium ui:opacity-95">
-                    {featured.price || formatCost(featured.cost, featured.currency)}
-                  </span>
+                    {#if featured.lessonCount}
+                      <span>{resolvedLessonsLabel(featured.lessonCount)}</span>
+                    {/if}
+                    {#if featured.exerciseCount}
+                      <span aria-hidden="true">·</span>
+                      <span>{resolvedExercisesLabel(featured.exerciseCount)}</span>
+                    {/if}
+                    {#if featured.duration}
+                      <span aria-hidden="true">·</span>
+                      <span>{featured.duration}</span>
+                    {/if}
+                  </div>
+                  <div class="ui:flex ui:flex-wrap ui:items-center ui:gap-3">
+                    <Button
+                      href={courseHref(featured)}
+                      disabled={disableCourseLinks}
+                      class="ui:rounded-md ui:px-6 ui:py-3 ui:text-base ui:font-medium ui:bg-[var(--landing-bg)] ui:text-[var(--landing-fg)] ui:hover:opacity-90"
+                    >
+                      {labels?.startCourseLabel ?? 'Start this course'}
+                    </Button>
+                    <span class="ui:text-base ui:font-medium ui:opacity-95">
+                      {featured.price || formatCost(featured.cost, featured.currency)}
+                    </span>
+                  </div>
                 </div>
-              </div>
 
-              <div
-                class="ui:relative ui:overflow-hidden ui:rounded-3xl ui:h-[440px] ui:md:h-[480px]"
-                style="
-                background:
-                  radial-gradient(50% 60% at 40% 40%, rgba(255,255,255,0.55) 0%, transparent 70%),
-                  radial-gradient(60% 70% at 70% 65%, rgba(255,255,255,0.32) 0%, transparent 70%),
-                  radial-gradient(40% 50% at 25% 75%, rgba(255,235,210,0.5) 0%, transparent 70%),
-                  linear-gradient(135deg, #b0a8a0 0%, #d4cabd 50%, #c8c0b5 100%);
-              "
-              >
                 <div
-                  class="ui:absolute ui:left-1/2 ui:top-1/2 ui:w-[80%] ui:overflow-hidden ui:rounded-2xl ui:p-6"
+                  class="ui:relative ui:overflow-hidden ui:rounded-3xl ui:h-[440px] ui:md:h-[480px]"
                   style="
-                  transform: translate(-50%, -50%);
-                  background: #0c1320;
-                  color: #fff;
-                  box-shadow: 0 30px 60px -20px rgba(0,0,0,0.35);
+                  background:
+                    radial-gradient(50% 60% at 40% 40%, rgba(255,255,255,0.55) 0%, transparent 70%),
+                    radial-gradient(60% 70% at 70% 65%, rgba(255,255,255,0.32) 0%, transparent 70%),
+                    radial-gradient(40% 50% at 25% 75%, rgba(255,235,210,0.5) 0%, transparent 70%),
+                    linear-gradient(135deg, #b0a8a0 0%, #d4cabd 50%, #c8c0b5 100%);
                 "
                 >
-                  <p class="ui:m-0 ui:mb-1 ui:text-[16px] ui:font-semibold">Course outline</p>
-                  <p class="ui:m-0 ui:mb-5 ui:text-[13px]" style="color: #8a93a0;">
-                    Pick up where you left off — anytime.
-                  </p>
-                  <div class="ui:flex ui:flex-col ui:gap-2">
-                    {#each Array.from({ length: Math.min(featured.lessonCount ?? 4, 4) }) as _, idx (idx)}
-                      <div
-                        class="ui:flex ui:items-center ui:gap-3 ui:rounded-lg ui:px-3.5 ui:py-3"
-                        style="background: #131c2c;"
-                      >
-                        <span
-                          class="ui:inline-flex ui:items-center ui:justify-center ui:size-6 ui:rounded ui:text-[11px] ui:font-semibold ui:tabular-nums"
-                          style="background: #2a3548; color: #fff;"
+                  <div
+                    class="ui:absolute ui:left-1/2 ui:top-1/2 ui:w-[80%] ui:overflow-hidden ui:rounded-2xl ui:p-6"
+                    style="
+                    transform: translate(-50%, -50%);
+                    background: #0c1320;
+                    color: #fff;
+                    box-shadow: 0 30px 60px -20px rgba(0,0,0,0.35);
+                  "
+                  >
+                    <p class="ui:m-0 ui:mb-1 ui:text-[16px] ui:font-semibold">Course outline</p>
+                    <p class="ui:m-0 ui:mb-5 ui:text-[13px]" style="color: #8a93a0;">
+                      Pick up where you left off — anytime.
+                    </p>
+                    <div class="ui:flex ui:flex-col ui:gap-2">
+                      {#each Array.from({ length: Math.min(featured.lessonCount ?? 4, 4) }) as _, idx (idx)}
+                        <div
+                          class="ui:flex ui:items-center ui:gap-3 ui:rounded-lg ui:px-3.5 ui:py-3"
+                          style="background: #131c2c;"
                         >
-                          {String(idx + 1).padStart(2, '0')}
-                        </span>
-                        <span class="ui:flex-1 ui:text-[13.5px] ui:font-medium" style="color: #fff;">
-                          {idx === 0
-                            ? 'Foundations & setup'
-                            : idx === 1
-                              ? 'Core concepts'
-                              : idx === 2
-                                ? 'Hands-on practice'
-                                : 'Capstone project'}
-                        </span>
-                        <span class="ui:text-[11.5px] ui:tabular-nums" style="color: #6c7585;">
-                          {idx === 0 ? '42 min' : idx === 1 ? '1h 12m' : idx === 2 ? '58 min' : '2h 30m'}
-                        </span>
-                      </div>
-                    {/each}
+                          <span
+                            class="ui:inline-flex ui:items-center ui:justify-center ui:size-6 ui:rounded ui:text-[11px] ui:font-semibold ui:tabular-nums"
+                            style="background: #2a3548; color: #fff;"
+                          >
+                            {String(idx + 1).padStart(2, '0')}
+                          </span>
+                          <span class="ui:flex-1 ui:text-[13.5px] ui:font-medium" style="color: #fff;">
+                            {idx === 0
+                              ? 'Foundations & setup'
+                              : idx === 1
+                                ? 'Core concepts'
+                                : idx === 2
+                                  ? 'Hands-on practice'
+                                  : 'Capstone project'}
+                          </span>
+                          <span class="ui:text-[11.5px] ui:tabular-nums" style="color: #6c7585;">
+                            {idx === 0 ? '42 min' : idx === 1 ? '1h 12m' : idx === 2 ? '58 min' : '2h 30m'}
+                          </span>
+                        </div>
+                      {/each}
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </section>
-      {/if}
+          </section>
+        {/if}
 
-      {#if remainingCourses.length > 0 || (!featured && courses.length > 0)}
-        {@const catalogCourses = featured ? remainingCourses : courses}
-        <section id="courses" class="ui:px-6 ui:md:px-8 ui:py-24 ui:md:py-28 ui:bg-[var(--landing-bg)]">
-          <div class="ui:max-w-[1320px] ui:mx-auto">
-            <div class="ui:flex ui:flex-col ui:md:flex-row ui:md:items-end ui:justify-between ui:gap-6 ui:mb-12">
-              <div>
-                <p
-                  class="ui:text-[13px] ui:font-medium ui:tracking-[0.08em] ui:uppercase ui:text-[var(--landing-fg-muted)] ui:m-0 ui:mb-3"
-                >
-                  {labels?.catalogEyebrow ?? 'Catalog'}
-                </p>
-                <h2
-                  class="ui:text-4xl ui:md:text-5xl ui:font-medium ui:tracking-tight ui:m-0 ui:text-[var(--landing-fg)] ui:max-w-2xl"
-                  style="line-height: 1.05; letter-spacing: -0.025em;"
-                >
-                  {labels?.catalogHeading ?? 'More courses to take next.'}
-                </h2>
+        {#if remainingCourses.length > 0 || (!featured && courses.length > 0)}
+          {@const catalogCourses = featured ? remainingCourses : courses}
+          <section id="courses" class="ui:px-6 ui:md:px-8 ui:py-24 ui:md:py-28 ui:bg-[var(--landing-bg)]">
+            <div class="ui:max-w-[1320px] ui:mx-auto">
+              <div class="ui:flex ui:flex-col ui:md:flex-row ui:md:items-end ui:justify-between ui:gap-6 ui:mb-12">
+                <div>
+                  <p
+                    class="ui:text-[13px] ui:font-medium ui:tracking-[0.08em] ui:uppercase ui:text-[var(--landing-fg-muted)] ui:m-0 ui:mb-3"
+                  >
+                    {labels?.catalogEyebrow ?? 'Catalog'}
+                  </p>
+                  <h2
+                    class="ui:text-4xl ui:md:text-5xl ui:font-medium ui:tracking-tight ui:m-0 ui:text-[var(--landing-fg)] ui:max-w-2xl"
+                    style="line-height: 1.05; letter-spacing: -0.025em;"
+                  >
+                    {labels?.catalogHeading ?? 'More courses to take next.'}
+                  </h2>
+                </div>
+                {#if hasMoreCourses}
+                  <Button
+                    href={disableCourseLinks ? undefined : '/courses'}
+                    variant="outline"
+                    class="ui:rounded-md ui:px-5 ui:py-2.5 ui:font-medium ui:border-[var(--landing-border)] ui:text-[var(--landing-fg)] ui:hover:bg-[var(--landing-card-soft)]"
+                    disabled={disableCourseLinks}
+                  >
+                    {labels?.browseCoursesLabel ?? 'Browse all →'}
+                  </Button>
+                {/if}
               </div>
-              {#if hasMoreCourses}
-                <Button
-                  href={disableCourseLinks ? undefined : '/courses'}
-                  variant="outline"
-                  class="ui:rounded-md ui:px-5 ui:py-2.5 ui:font-medium ui:border-[var(--landing-border)] ui:text-[var(--landing-fg)] ui:hover:bg-[var(--landing-card-soft)]"
-                  disabled={disableCourseLinks}
-                >
-                  {labels?.browseCoursesLabel ?? 'Browse all →'}
-                </Button>
-              {/if}
-            </div>
 
-            <div class="ui:grid ui:grid-cols-1 ui:md:grid-cols-2 ui:lg:grid-cols-3 ui:gap-5">
-              {#each catalogCourses as course, index (course.id)}
-                <VibrantCourseCard {course} {disableCourseLinks} {labels} />
-              {/each}
+              <div class="ui:grid ui:grid-cols-1 ui:md:grid-cols-2 ui:lg:grid-cols-3 ui:gap-5">
+                {#each catalogCourses as course, index (course.id)}
+                  <VibrantCourseCard {course} {disableCourseLinks} {labels} />
+                {/each}
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
+        {/if}
       {/if}
-    {/if}
+    </EditableLandingSection>
   </main>
 
   <OrgLandingPageLinks {links} {labels} variant="vibrant" />


### PR DESCRIPTION
Four fixes to the org landing page — two specific to the **quartz** template that is now the default, one across all 11 themes.

## 1. Callout button link resolved as a page fragment

Reported as the link "concatenating with the current page domain" — `https://org.example.com/#https://somedomain.com`. Nothing concatenates a domain; the stored value is literally `#https://somedomain.com`, and the browser resolves that as a fragment on the current page.

The cause is at the write site. `callout-section.svelte` seeded a new callout with `href: '#'`, and that field renders as `value={settings.callout.action.href}` — so the "Button link" input arrives pre-filled with `#`. Paste a URL without clearing it first and you get `#https://somedomain.com`. The label field beside it defaults to real copy, so the `#` reads as a prefix you're meant to keep.

- New callouts now start with an empty `href`, so the field shows its `https://...` placeholder.
- `normalizeHref()` strips a leading `#` when what follows is absolute (`http(s)://`, `mailto:`, `tel:`, `//`), repairing configs already saved that way.

Real anchors are left untouched:

| stored | rendered |
|---|---|
| `#https://somedomain.com` | `https://somedomain.com` |
| `#mailto:a@b.com` | `mailto:a@b.com` |
| `#courses` | `#courses` |
| `#` | `#` |
| `/courses` | `/courses` |

**Interaction with #1069.** This rebases onto the `isAllowedHref` allowlist that landed in #1069. The repair runs *before* validation, so the allowlist judges the URL the user meant. No new hole: `isAllowedHref` treats any `#…` as an inert fragment, and the repair only unwraps `http(s)://`, `mailto:`, `tel:` and `//` — so `#javascript:alert(1)` stays a fragment and never becomes a live scheme. The commit also lifts #1069's mid-file `import` up into the import block.

## 2. Courses with no image showed no banner

New `getCourseCoverImage()` in `landing-page-utils.ts` resolves `logo` → `image` → `DEFAULT_COURSE_BANNER_IMAGE`. The quartz course row previously rendered a grey placeholder icon instead.

## 3. No image cards on `/courses` for quartz

`quartz/course-card.svelte` — the component `/courses` actually renders, via `bundle.courseCard` in `+page.ts` — had no image region at all. It now renders a 16/9 cover above the body with a subtle hover scale, keeping quartz's bordered-cell rhythm (hairline `border-b`, no gap), with the body in a `flex-1` padded column.

Verified against local data — `/courses` for `udemy-test`:

```html
<img src="https://images.unsplash.com/photo-1565843708714-...">   <!-- has a logo -->
<img src="/images/classroomio-course-img-template.jpg">           <!-- no logo, falls back -->
<img src="https://images.unsplash.com/photo-1518186285589-...">
```

## 4. Courses section was not click-to-edit — in 6 of 11 themes

In the landing page editor, clicking a section opens its form in the sidebar. The courses section was only wrapped in `EditableLandingSection` on bold, minimal, saas and tech — everywhere else the click was dead.

Now wired on all 11: **classic, corporate, editorial, quartz, studio, terminal, vibrant** added. On vibrant the wrapper covers the whole empty/featured/catalog branch, so the entire courses area is one clickable region rather than three.

The `courses` key and its form were already registered in `landingpage-editor.svelte`; only the preview wrappers were missing.

## Verification

- All 11 `org.svelte` files compile (`svelte/compiler`, SSR target).
- `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`
- `pnpm format:check`, `pnpm --filter @cio/ui prefix:check`
- Fixes 2 and 3 confirmed live against local Postgres with the API and dashboard running from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cEMvo57kcaXWyDeE3TpZq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added editing support for the courses section across organization landing page designs.
  - Course cards now display cover images with consistent fallback handling and updated layouts.

- **Bug Fixes**
  - Improved landing-page link handling by correcting malformed absolute URLs while preserving fragment links.
  - Prevented invalid or empty links from being used by applying a safe fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->