### PR TITLE
feat: redirect classroomio.com/changelog to feedback.classroomio.com/updates

### DIFF
--- a/apps/website/src/routes/(redirects)/changelog/+page.server.ts
+++ b/apps/website/src/routes/(redirects)/changelog/+page.server.ts
@@ -1,0 +1,13 @@
+import { redirect } from '@sveltejs/kit';
+import { client } from '$lib/utils/posthog';
+
+export const prerender = false;
+
+export const load = ({ request }) => {
+  client.capture({
+    distinctId: request.headers.get('x-forwarded-for') || new Date().getTime().toString(),
+    event: 'changelog page visited'
+  });
+
+  redirect(307, 'https://feedback.classroomio.com/updates');
+};


### PR DESCRIPTION
Adds a 307 redirect from `classroomio.com/changelog` to `https://feedback.classroomio.com/updates`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a request-time `/changelog` route that records a visit and redirects visitors to the external ClassroomIO updates page.

- Adds a fixed 307 redirect to `https://feedback.classroomio.com/updates`.
- Disables prerendering so the redirect and analytics capture execute per request.
- The new analytics capture depends on a shared PostHog client that has already been shut down during module initialization.

<h3>Confidence Score: 4/5</h3>

The redirect itself appears safe to merge, but its non-blocking visit analytics should be corrected so the newly added event is reliably recorded.

The fixed HTTPS target, request-time route, and 307 behavior match established redirect routes; the only accepted concern is that the analytics call uses a client shut down during import, which affects tracking rather than redirect delivery.

**Files Needing Attention:** apps/website/src/routes/(redirects)/changelog/+page.server.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/website/src/routes/(redirects)/changelog/+page.server.ts | Adds the intended external redirect, but attempts to record its visit through a PostHog client that is shut down before route execution. |

<sub>Reviews (1): Last reviewed commit: ["feat: redirect classroomio.com/changelog..."](https://github.com/classroomio/classroomio/commit/151b46de3256e31a55a4454e6f47ed88647f6a75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61155868)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Marketing website](https://app.greptile.com/classroomio/-/custom-context/knowledge-base/classroomio/classroomio/-/docs/marketing-website.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `/changelog` route that redirects visitors to the external feedback page.
  - The redirect is handled dynamically when the page is requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->