### PR TITLE
fix(ui): render Button as an anchor when it has an href

### DIFF
--- a/apps/dashboard/src/lib/features/ui/visit-org-site-btn.svelte
+++ b/apps/dashboard/src/lib/features/ui/visit-org-site-btn.svelte
@@ -36,11 +36,12 @@
       ? subdomainOrigin || (browser ? window.location.origin : '')
       : $currentOrgDomain || (browser ? window.location.origin : '');
 
+    const target = pathname ?? (isLMS && $user.isLoggedIn ? '/home' : '/');
+
     if (!origin) {
-      return '';
+      return target;
     }
 
-    const target = pathname ?? (isLMS && $user.isLoggedIn ? '/home' : '/');
     const url = new URL(target, origin);
 
     if (browser && window.location.host.includes('localhost') && $currentOrg.siteName) {

--- a/packages/ui/src/base/button/button.svelte
+++ b/packages/ui/src/base/button/button.svelte
@@ -102,26 +102,9 @@
     'bg-shine':
       'ui:animate-shine ui:border ui:border-neutral-800 ui:bg-[linear-gradient(110deg,#000103,45%,#1e2631,55%,#000103)] ui:bg-[length:200%_100%] ui:text-white'
   };
-</script>
 
-<!-- This approach to disabled links is inspired by bits-ui see: https://github.com/huntabyte/bits-ui/pull/1055 -->
-<svelte:element
-  this={href ? 'a' : 'button'}
-  {...rest}
-  data-slot="button"
-  data-testid={testId}
-  type={href ? undefined : type}
-  href={href && !disabled ? href : undefined}
-  disabled={href ? undefined : disabled || loading}
-  aria-disabled={href ? disabled : undefined}
-  role={href && disabled ? 'link' : undefined}
-  tabindex={href && disabled ? -1 : tabindex}
-  class={cn(buttonVariants({ variant, size }), animate && animateClasses[animate], className)}
-  bind:this={ref}
-  onclick={async (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    e: any
-  ) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function handleClick(e: any) {
     onclick?.(e);
 
     if (type === undefined) return;
@@ -133,8 +116,11 @@
 
       loading = false;
     }
-  }}
->
+  }
+</script>
+
+<!-- This approach to disabled links is inspired by bits-ui see: https://github.com/huntabyte/bits-ui/pull/1055 -->
+{#snippet content()}
   {#if type !== undefined && loading}
     <div class="ui:absolute ui:flex ui:size-full ui:place-items-center ui:justify-center ui:bg-inherit">
       <div class="ui:flex ui:place-items-center ui:justify-center">
@@ -149,4 +135,35 @@
   {:else}
     {@render children?.()}
   {/if}
-</svelte:element>
+{/snippet}
+
+{#if href}
+  <a
+    {...rest}
+    data-slot="button"
+    data-testid={testId}
+    href={disabled ? undefined : href}
+    aria-disabled={disabled}
+    role={disabled ? 'link' : undefined}
+    tabindex={disabled ? -1 : tabindex}
+    class={cn(buttonVariants({ variant, size }), animate && animateClasses[animate], className)}
+    bind:this={ref}
+    onclick={handleClick}
+  >
+    {@render content()}
+  </a>
+{:else}
+  <button
+    {...rest}
+    data-slot="button"
+    data-testid={testId}
+    {type}
+    disabled={disabled || loading}
+    {tabindex}
+    class={cn(buttonVariants({ variant, size }), animate && animateClasses[animate], className)}
+    bind:this={ref}
+    onclick={handleClick}
+  >
+    {@render content()}
+  </button>
+{/if}


### PR DESCRIPTION
## Problem

The **Open Academy** button in the dashboard header did nothing when clicked, even though it had the right URL. The rendered DOM explains why:

```html
<button target="_blank" data-slot="button" href="https://dblocked.myclassroomio.com/" aria-disabled="false">
  <span>Open Academy</span> …
</button>
```

It's a `<button>` carrying `href` and `target="_blank"`. Both are inert on a `<button>` — no navigation, no new tab.

## Root cause

`packages/ui/src/base/button/button.svelte` chose its tag with:

```svelte
<svelte:element this={href ? 'a' : 'button'} …>
```

Svelte 5's `<svelte:element>` **reuses the server-rendered node during hydration and never swaps its tag** — from `svelte/src/internal/client/dom/blocks/svelte-element.js`:

```js
element = hydrating ? element : create_element(next_tag, ns);
```

So for any `Button` whose `href` is empty during SSR and only resolves on the client, the server renders a `<button>`, and hydration applies the anchor attributes to that same node while leaving the tag alone.

`VisitOrgSiteBtn` is exactly that case: server-side there is no `window.location.origin` and `$currentOrg` isn't populated yet, so `href` was `''` → `<button>`. On the client the URL resolved, but the element stayed a button.

## Fix

**`packages/ui/src/base/button/button.svelte`**
- Pick the element with `{#if href}` / `{:else}` instead of `<svelte:element>`. If-blocks *do* detect a hydration mismatch and re-render the branch — `internal/client/dom/blocks/if.js` handles it explicitly (*"Hydration mismatch: remove everything inside the anchor and start fresh. This could happen with `{#if browser}…{/if}`"*).
- Shared body moved into a `{#snippet content()}`; the inline click handler became a named `handleClick`.
- Per-branch attributes are now written directly instead of ternaries on `href`, so the anchor and button branches each carry only what applies to them.

This fixes every `Button` in the app that receives a dynamic or async `href`, not just this one.

**`apps/dashboard/src/lib/features/ui/visit-org-site-btn.svelte`**
- When there's no origin yet, return the relative target (`/` or `/home`) instead of `''`. The button then renders as an anchor on the server too, so hydration doesn't need to swap branches at all — only the target changes once the org domain resolves.

## Verification

- `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build` — pass
- `pnpm format:check` — pass
- `pnpm --filter @cio/ui prefix:check` — pass (no class changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cEMvo57kcaXWyDeE3TpZq


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects link rendering for buttons whose destination becomes available after server rendering.
- Replaces the dynamic `<svelte:element>` with explicit anchor and button branches while retaining shared content and click behavior.
- Gives `VisitOrgSiteBtn` a truthy relative server-side destination so it initially renders as an anchor.
- Preserves disabled, loading, styling, testing, and forwarded-attribute behavior across both branches.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable regression established in the changed behavior.

The explicit branches preserve existing Button contracts and ensure a truthy dynamic destination renders as an anchor without leaving a stale server-rendered button.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/ui/visit-org-site-btn.svelte | Returns a relative destination when no server-side origin is available, ensuring link semantics in SSR output. |
| packages/ui/src/base/button/button.svelte | Splits anchor and button rendering into explicit branches with shared content and click handling. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[VisitOrgSiteBtn computes destination] --> B{Origin available?}
  B -->|Yes| C[Build absolute organization URL]
  B -->|No during SSR| D[Use relative target]
  C --> E{href truthy?}
  D --> E
  E -->|Yes| F[Render anchor]
  E -->|No| G[Render button]
  F --> H[Hydration updates href as organization state resolves]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ui): render Button as an anchor when..."](https://github.com/classroomio/classroomio/commit/134bcd3f7551c22ed75241210cd956385db13dc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61197527)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Organization site buttons now continue to navigate to the intended destination when an origin is unavailable, instead of leading to an empty link.
  - Buttons and links now preserve their expected loading, disabled, accessibility, and click behavior across supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->