### PR TITLE
fix(dashboard): redirect new courses to lessons

### DIFF
--- a/apps/dashboard/src/lib/features/course/components/new-course-modal.svelte
+++ b/apps/dashboard/src/lib/features/course/components/new-course-modal.svelte
@@ -2,6 +2,7 @@
   import { preventDefault } from '$lib/utils/functions/svelte';
 
   import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { createCourseModal } from '../utils/store';
   import { TextareaField } from '@cio/ui/custom/textarea-field';
@@ -69,11 +70,16 @@
   }
 
   async function createCourse() {
-    await courseApi.create({
-      title: $createCourseModal.title,
-      description: $createCourseModal.description,
-      type: type
-    });
+    await courseApi.create(
+      {
+        title: $createCourseModal.title,
+        description: $createCourseModal.description,
+        type: type
+      },
+      (courseId) => {
+        goto(resolve(`/courses/${courseId}/lessons`, {}));
+      }
+    );
   }
 
   let open = $derived(new URLSearchParams(page.url.search).get('create') === 'true');


### PR DESCRIPTION
## Summary
- Redirect course creation modal success navigation to the new course's `/lessons` page.

## Verification
- `git diff --cached --check` passes.
- Full formatter/build checks are blocked because worktree dependencies, including `tailwindcss`, are not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - After creating a course, the dashboard now automatically navigates to the new course’s lessons page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes successful course creation to navigate directly to the new course's lessons page.

- Adds `$app/paths.resolve` for base-path-aware navigation.
- Supplies an `onCreated` callback that builds the lessons URL from the returned course ID.
- The destination route and callback ID contract are consistent with the existing application.

<h3>Confidence Score: 4/5</h3>

The redirect behavior is otherwise sound, but the navigation promise must be handled to satisfy the repository's asynchronous UI-handler requirement before merging.

The created course ID and destination route are correct; the sole accepted concern is that the new fire-and-forget navigation can produce an unhandled rejection.

**Files Needing Attention:** apps/dashboard/src/lib/features/course/components/new-course-modal.svelte

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/course/components/new-course-modal.svelte | Redirects newly created courses to their lessons page, but the navigation promise lacks explicit rejection handling. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): redirect new courses to ..."](https://github.com/classroomio/classroomio/commit/d0beddb57689177387e712154b5c2f1a5d029af9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61950445)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - When reviewing asynchronous UI action handlers, ve... ([source](https://app.greptile.com/classroomio/github/classroomio/classroomio/-/custom-context?memory=527a7f7a-d23b-4031-bc23-61495157650c))

<!-- /greptile_comment -->