### PR TITLE
feat(ui): add close button to snackbar and sonner toasters

### DIFF
--- a/apps/course-app/src/lib/components/ui/sonner/sonner.svelte
+++ b/apps/course-app/src/lib/components/ui/sonner/sonner.svelte
@@ -11,10 +11,10 @@
 	closeButton
 	toastOptions={{
 		classes: {
-			toast: "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
-			description: "group-[.toast]:text-muted-foreground",
-			actionButton: "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
-			cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+			toast: "ui:group toast ui:group-[.toaster]:bg-background ui:group-[.toaster]:text-foreground ui:group-[.toaster]:border-border ui:group-[.toaster]:shadow-lg",
+			description: "ui:group-[.toast]:text-muted-foreground",
+			actionButton: "ui:group-[.toast]:bg-primary ui:group-[.toast]:text-primary-foreground",
+			cancelButton: "ui:group-[.toast]:bg-muted ui:group-[.toast]:text-muted-foreground",
 		},
 	}}
 	{...$$restProps}

--- a/apps/course-app/src/lib/components/ui/sonner/sonner.svelte
+++ b/apps/course-app/src/lib/components/ui/sonner/sonner.svelte
@@ -11,10 +11,10 @@
 	closeButton
 	toastOptions={{
 		classes: {
-			toast: "ui:group toast ui:group-[.toaster]:bg-background ui:group-[.toaster]:text-foreground ui:group-[.toaster]:border-border ui:group-[.toaster]:shadow-lg",
-			description: "ui:group-[.toast]:text-muted-foreground",
-			actionButton: "ui:group-[.toast]:bg-primary ui:group-[.toast]:text-primary-foreground",
-			cancelButton: "ui:group-[.toast]:bg-muted ui:group-[.toast]:text-muted-foreground",
+			toast: "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+			description: "group-[.toast]:text-muted-foreground",
+			actionButton: "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+			cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
 		},
 	}}
 	{...$$restProps}

--- a/apps/course-app/src/lib/components/ui/sonner/sonner.svelte
+++ b/apps/course-app/src/lib/components/ui/sonner/sonner.svelte
@@ -8,6 +8,7 @@
 <Sonner
 	theme={mode.current}
 	class="toaster group"
+	closeButton
 	toastOptions={{
 		classes: {
 			toast: "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",

--- a/apps/dashboard/src/app.css
+++ b/apps/dashboard/src/app.css
@@ -876,3 +876,11 @@ body[data-theme='violet'] {
     transform: translate(-1px, 1.7px) scale(1.12);
   }
 }
+
+[data-sonner-toaster] [data-close-button] {
+  position: absolute !important;
+  top: 1.2rem !important;
+  right: 0.5rem !important;
+  left: auto !important;
+  margin: 0 !important;
+}

--- a/apps/dashboard/src/lib/features/ui/snackbar/snackbar.svelte
+++ b/apps/dashboard/src/lib/features/ui/snackbar/snackbar.svelte
@@ -41,4 +41,4 @@
   });
 </script>
 
-<Toaster position="top-right" />
+<Toaster position="top-right" class="!left-auto" closeButton />

--- a/packages/ui/src/base/sonner/sonner.svelte
+++ b/packages/ui/src/base/sonner/sonner.svelte
@@ -5,4 +5,18 @@
   let { ...restProps }: SonnerProps = $props();
 </script>
 
-<Sonner theme={mode.current} class="toaster ui:z-999 group" {...restProps} />
+<Sonner
+  closeButton
+  theme={mode.current}
+  class="toaster ui:z-999 group"
+  toastOptions={{
+    classes: {
+      toast:
+        'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+      description: 'group-[.toast]:text-muted-foreground',
+      actionButton: 'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+      cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground'
+    }
+  }}
+  {...restProps}
+/>

--- a/packages/ui/src/base/sonner/sonner.svelte
+++ b/packages/ui/src/base/sonner/sonner.svelte
@@ -8,14 +8,14 @@
 <Sonner
   closeButton
   theme={mode.current}
-  class="toaster ui:z-999 group"
+  class="toaster ui:z-999 ui:group"
   toastOptions={{
     classes: {
       toast:
-        'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
-      description: 'group-[.toast]:text-muted-foreground',
-      actionButton: 'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
-      cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground'
+        'ui:group toast ui:group-[.toaster]:bg-background ui:group-[.toaster]:text-foreground ui:group-[.toaster]:border-border ui:group-[.toaster]:shadow-lg',
+      description: 'ui:group-[.toast]:text-muted-foreground',
+      actionButton: 'ui:group-[.toast]:bg-primary ui:group-[.toast]:text-primary-foreground',
+      cancelButton: 'ui:group-[.toast]:bg-muted ui:group-[.toast]:text-muted-foreground'
     }
   }}
   {...restProps}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1017 

## Demo
https://www.awesomescreenshot.com/video/56343731?key=143d5d0b0f746af5e19181eb89429c7a

<!-- Please upload a video here or attach a link to a video player like Awesome Screenshot or Loom to show the change in action. This speeds up reviews, especially for visual changes. -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Open any snackbar/toast in the dashboard (e.g. trigger a success/error action) and verify a close button renders in the top-right of the toast.
- Click the close button and verify the toast dismisses.
- Repeat in the course app (apps/course-app sonner toaster).
- Verify toast styling/colors are unchanged and the close button does not overlap toast content.


## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Toast notifications in the dashboard now include close buttons, allowing users to dismiss messages directly.
  - Close-button support remains available in course and shared notification components.

- **Style**
  - Improved close-button placement for top-right notifications.
  - Updated toast styling for descriptions, actions, and cancellation controls to provide a more consistent themed appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables dismiss controls on the dashboard and course-app toast components and adds dashboard positioning for the new control.
- Enables Sonner close buttons in both application wrappers.
- Adds dashboard-specific close-button placement.
- Attempts to add themed toast classes to the shared UI wrapper, although those classes do not follow the package’s Tailwind prefix convention.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking cleanup needed so the shared toaster’s newly declared Tailwind styles actually compile.

The close-button behavior has no established blocking defect, but the shared UI wrapper adds ineffective unprefixed Tailwind utilities.

**Files Needing Attention:** packages/ui/src/base/sonner/sonner.svelte

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/base/sonner/sonner.svelte | Enables close buttons and adds toast theme utilities, but the new generated utilities omit the UI package’s required Tailwind prefix. |
| apps/dashboard/src/lib/features/ui/snackbar/snackbar.svelte | Enables the close control on the dashboard’s top-right toaster. |
| apps/dashboard/src/app.css | Positions Sonner close controls in the upper-right corner of dashboard toasts. |
| apps/course-app/src/lib/components/ui/sonner/sonner.svelte | Enables the existing Sonner close-button option in the course application. |

<sub>Reviews (1): Last reviewed commit: ["Added x to snackbar"](https://github.com/classroomio/classroomio/commit/1ee79ead3e9eaf721d2c8fa668e11fda72c0c439) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62059175)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->