### PR TITLE
fix(billing): handle Polar subscription lifecycle

### DIFF
--- a/apps/api/src/routes/organization/organization.ts
+++ b/apps/api/src/routes/organization/organization.ts
@@ -584,7 +584,7 @@ export const organizationRouter = new Hono()
   /**
    * POST /organization/plan
    * Creates a new organization plan
-   * Requires authentication (user session or API key)
+   * Requires a server API key
    */
   .post('/plan', apiKeyMiddleware, zValidator('json', ZCreateOrgPlan), async (c) => {
     try {
@@ -606,7 +606,7 @@ export const organizationRouter = new Hono()
    * POST /organization/plan/activate
    * Activates an existing organization plan or creates it when the initial
    * subscription event arrived before payment became active.
-   * Requires authentication (user session or API key)
+   * Requires a server API key
    */
   .post('/plan/activate', apiKeyMiddleware, zValidator('json', ZCreateOrgPlan), async (c) => {
     try {
@@ -627,7 +627,7 @@ export const organizationRouter = new Hono()
   /**
    * PUT /organization/plan
    * Updates an organization plan by subscription ID
-   * Requires authentication (user session or API key)
+   * Requires a server API key
    */
   .put('/plan', apiKeyMiddleware, zValidator('json', ZUpdateOrgPlan), async (c) => {
     try {
@@ -648,7 +648,7 @@ export const organizationRouter = new Hono()
   /**
    * POST /organization/plan/cancel
    * Cancels an organization plan by subscription ID
-   * Requires authentication (user session or API key)
+   * Requires a server API key
    */
   .post('/plan/cancel', apiKeyMiddleware, zValidator('json', ZCancelOrgPlan), async (c) => {
     try {

--- a/apps/api/src/routes/organization/organization.ts
+++ b/apps/api/src/routes/organization/organization.ts
@@ -58,6 +58,7 @@ import { organizationAiTutorRouter } from '@api/routes/organization/ai-tutor';
 import { organizationMemberEmailNotificationsRouter } from '@api/routes/organization/member-email-notifications';
 import { authMiddleware } from '@api/middlewares/auth';
 import { authOrApiKeyMiddleware } from '@api/middlewares/auth-or-api-key';
+import { apiKeyMiddleware } from '@api/middlewares/api-key';
 import { authOrAutomationKeyMiddleware } from '@api/middlewares/auth-or-automation-key';
 import { automationRouter } from '@api/routes/organization/automation';
 import { courseImportRouter } from '@api/routes/organization/course-import';
@@ -585,7 +586,7 @@ export const organizationRouter = new Hono()
    * Creates a new organization plan
    * Requires authentication (user session or API key)
    */
-  .post('/plan', authOrApiKeyMiddleware, zValidator('json', ZCreateOrgPlan), async (c) => {
+  .post('/plan', apiKeyMiddleware, zValidator('json', ZCreateOrgPlan), async (c) => {
     try {
       const data = c.req.valid('json');
       const plan = await createOrgPlan(data);
@@ -607,7 +608,7 @@ export const organizationRouter = new Hono()
    * subscription event arrived before payment became active.
    * Requires authentication (user session or API key)
    */
-  .post('/plan/activate', authOrApiKeyMiddleware, zValidator('json', ZCreateOrgPlan), async (c) => {
+  .post('/plan/activate', apiKeyMiddleware, zValidator('json', ZCreateOrgPlan), async (c) => {
     try {
       const data = c.req.valid('json');
       const plan = await activateOrgPlan(data);
@@ -628,7 +629,7 @@ export const organizationRouter = new Hono()
    * Updates an organization plan by subscription ID
    * Requires authentication (user session or API key)
    */
-  .put('/plan', authOrApiKeyMiddleware, zValidator('json', ZUpdateOrgPlan), async (c) => {
+  .put('/plan', apiKeyMiddleware, zValidator('json', ZUpdateOrgPlan), async (c) => {
     try {
       const { subscriptionId, payload } = c.req.valid('json');
       const plan = await updateOrgPlan(subscriptionId, payload);
@@ -649,7 +650,7 @@ export const organizationRouter = new Hono()
    * Cancels an organization plan by subscription ID
    * Requires authentication (user session or API key)
    */
-  .post('/plan/cancel', authOrApiKeyMiddleware, zValidator('json', ZCancelOrgPlan), async (c) => {
+  .post('/plan/cancel', apiKeyMiddleware, zValidator('json', ZCancelOrgPlan), async (c) => {
     try {
       const { subscriptionId, payload } = c.req.valid('json');
       const plan = await cancelOrgPlan(subscriptionId, payload);

--- a/apps/api/src/routes/organization/organization.ts
+++ b/apps/api/src/routes/organization/organization.ts
@@ -28,6 +28,7 @@ import {
   revokeAudiencePendingInvite
 } from '@api/services/organization/audience';
 import {
+  activateOrgPlan,
   cancelOrgPlan,
   createOrg,
   createOrgPlan,
@@ -598,6 +599,28 @@ export const organizationRouter = new Hono()
       );
     } catch (error) {
       return handleError(c, error, 'Failed to create organization plan');
+    }
+  })
+  /**
+   * POST /organization/plan/activate
+   * Activates an existing organization plan or creates it when the initial
+   * subscription event arrived before payment became active.
+   * Requires authentication (user session or API key)
+   */
+  .post('/plan/activate', authOrApiKeyMiddleware, zValidator('json', ZCreateOrgPlan), async (c) => {
+    try {
+      const data = c.req.valid('json');
+      const plan = await activateOrgPlan(data);
+
+      return c.json(
+        {
+          success: true,
+          data: plan
+        },
+        200
+      );
+    } catch (error) {
+      return handleError(c, error, 'Failed to activate organization plan');
     }
   })
   /**

--- a/apps/api/src/services/organization.ts
+++ b/apps/api/src/services/organization.ts
@@ -7,6 +7,7 @@ import type {
 } from '@cio/utils/validation/organization';
 import type { TNewOrganizationPlan, TOrganization, TOrganizationPlan } from '@db/types';
 import {
+  activateOrganizationPlan,
   cancelOrganizationPlan,
   checkSiteNameExists,
   createOrganizationPlan,
@@ -814,7 +815,7 @@ export async function updateOrg(orgId: string, data: Partial<TOrganization>) {
  */
 export async function updateOrgPlan(subscriptionId: string, payload: TOrganizationPlan['payload']) {
   try {
-    const plan = await updateOrganizationPlan(subscriptionId, payload);
+    const plan = await updateOrganizationPlan(subscriptionId, { payload });
     if (!plan) {
       throw new AppError('Organization plan not found', ErrorCodes.ORG_PLAN_NOT_FOUND, 404);
     }
@@ -825,6 +826,38 @@ export async function updateOrgPlan(subscriptionId: string, payload: TOrganizati
     }
     throw new AppError(
       error instanceof Error ? error.message : 'Failed to update organization plan',
+      ErrorCodes.ORG_PLAN_UPDATE_FAILED,
+      500
+    );
+  }
+}
+
+/**
+ * Activates an organization plan, creating it when the initial subscription event
+ * arrived before the subscription became active.
+ * @param data Organization plan activation data
+ * @returns Activated or created organization plan
+ */
+export async function activateOrgPlan(data: TNewOrganizationPlan) {
+  try {
+    if (!data.subscriptionId) {
+      throw new AppError('Missing organization plan fields', ErrorCodes.ORG_PLAN_CREATE_FAILED, 400);
+    }
+
+    const activatedPlan = await activateOrganizationPlan(data.subscriptionId, data.payload);
+
+    if (activatedPlan) {
+      return activatedPlan;
+    }
+
+    return await createOrgPlan(data);
+  } catch (error) {
+    if (error instanceof AppError) {
+      throw error;
+    }
+
+    throw new AppError(
+      error instanceof Error ? error.message : 'Failed to activate organization plan',
       ErrorCodes.ORG_PLAN_UPDATE_FAILED,
       500
     );

--- a/apps/dashboard/src/lib/features/org/api/org-plan.server.ts
+++ b/apps/dashboard/src/lib/features/org/api/org-plan.server.ts
@@ -5,6 +5,8 @@ import { getApiKeyHeaders, safeServerApi } from '$lib/utils/services/api/server'
 
 type CreateOrgPlanRequest = typeof classroomio.organization.plan.$post;
 type CreateOrgPlanSuccess = Extract<InferResponseType<CreateOrgPlanRequest>, { success: true }>;
+type ActivateOrgPlanRequest = typeof classroomio.organization.plan.activate.$post;
+type ActivateOrgPlanSuccess = Extract<InferResponseType<ActivateOrgPlanRequest>, { success: true }>;
 type UpdateOrgPlanRequest = typeof classroomio.organization.plan.$put;
 type UpdateOrgPlanSuccess = Extract<InferResponseType<UpdateOrgPlanRequest>, { success: true }>;
 type CancelOrgPlanRequest = typeof classroomio.organization.plan.cancel.$post;
@@ -33,6 +35,29 @@ export class OrgPlanApiServer {
 
     if (!result.ok) {
       console.error('Error creating org plan (server):', result);
+      return null;
+    }
+
+    return result.body.data;
+  }
+
+  /**
+   * Activates an organization plan or creates it when no local plan exists yet.
+   * @param params Organization plan activation parameters
+   * @returns Response data or null on error
+   */
+  static async activateOrgPlan(params: TCreateOrgPlan) {
+    const result = await safeServerApi<ActivateOrgPlanSuccess>(() =>
+      classroomio.organization.plan.activate.$post(
+        {
+          json: params
+        },
+        getApiKeyHeaders()
+      )
+    );
+
+    if (!result.ok) {
+      console.error('Error activating org plan (server):', result);
       return null;
     }
 

--- a/apps/dashboard/src/lib/utils/types/polar.ts
+++ b/apps/dashboard/src/lib/utils/types/polar.ts
@@ -137,6 +137,8 @@ export interface PolarSubscriptionWebhookPayload {
     | 'subscription.created'
     | 'subscription.updated'
     | 'subscription.active'
+    | 'subscription.uncanceled'
+    | 'subscription.past_due'
     | 'subscription.revoked'
     | 'subscription.canceled';
   data: SubscriptionData;

--- a/apps/dashboard/src/routes/api/polar/webhook/+server.ts
+++ b/apps/dashboard/src/routes/api/polar/webhook/+server.ts
@@ -155,6 +155,16 @@ async function onPayload(payload: PolarWebhookPayload) {
 
       break;
     case 'subscription.active':
+      try {
+        const result = await OrgPlanApiServer.updateOrgPlan({
+          subscriptionId,
+          payload: data as unknown as Record<string, unknown>
+        });
+        console.log('Subscription activated', result);
+      } catch (error) {
+        console.error('Error activating org plan', error);
+      }
+
       break;
     case 'subscription.revoked':
       try {

--- a/apps/dashboard/src/routes/api/polar/webhook/+server.ts
+++ b/apps/dashboard/src/routes/api/polar/webhook/+server.ts
@@ -154,9 +154,15 @@ async function onPayload(payload: PolarWebhookPayload) {
 
         try {
           const result = await OrgPlanApiServer.activateOrgPlan(planData);
+
+          if (!result) {
+            throw new Error('Organization plan activation request failed');
+          }
+
           console.log('Subscription activated', result);
         } catch (error) {
           console.error('Error activating org plan', error);
+          throw error;
         }
       } else {
         try {
@@ -181,9 +187,15 @@ async function onPayload(payload: PolarWebhookPayload) {
 
       try {
         const result = await OrgPlanApiServer.activateOrgPlan(planData);
+
+        if (!result) {
+          throw new Error('Organization plan activation request failed');
+        }
+
         console.log('Subscription activated', result);
       } catch (error) {
         console.error('Error activating org plan', error);
+        throw error;
       }
 
       break;

--- a/apps/dashboard/src/routes/api/polar/webhook/+server.ts
+++ b/apps/dashboard/src/routes/api/polar/webhook/+server.ts
@@ -1,6 +1,7 @@
 import { OrgPlanApiServer } from '$features/org/api/org-plan.server';
 import { CreditPurchaseApiServer } from '$features/agent/api/credit-purchase.server';
 import { PLAN, TOKEN_PACK } from '@cio/utils/plans';
+import type { TCreateOrgPlan } from '@cio/utils/validation/organization';
 import type {
   PolarOrderWebhookPayload,
   PolarSubscriptionWebhookPayload,
@@ -25,6 +26,34 @@ function isSubscriptionPayload(payload: PolarWebhookPayload): payload is PolarSu
 
 function isOrderPayload(payload: PolarWebhookPayload): payload is PolarOrderWebhookPayload {
   return payload.type === 'order.paid' || payload.type === 'order.created' || payload.type === 'order.refunded';
+}
+
+function getOrgPlanData(data: SubscriptionData): TCreateOrgPlan | null {
+  const metadata = data.metadata;
+  const triggeredByRaw = metadata?.triggeredBy?.trim();
+  const triggeredBy = triggeredByRaw ? Number.parseInt(triggeredByRaw, 10) : Number.NaN;
+
+  if (
+    metadata?.kind === 'token_pack' ||
+    !metadata?.orgId ||
+    !triggeredByRaw ||
+    !Number.isInteger(triggeredBy) ||
+    triggeredBy <= 0
+  ) {
+    if (metadata?.kind !== 'token_pack') {
+      console.error('subscription event missing org metadata');
+    }
+
+    return null;
+  }
+
+  return {
+    orgId: metadata.orgId,
+    triggeredBy,
+    planName: PLAN.EARLY_ADOPTER as TCreateOrgPlan['planName'],
+    subscriptionId: data.id,
+    payload: data as unknown as Record<string, unknown>
+  };
 }
 
 async function onPayload(payload: PolarWebhookPayload) {
@@ -90,9 +119,6 @@ async function onPayload(payload: PolarWebhookPayload) {
   }
 
   const data = payload.data as SubscriptionData;
-  const metadata = data.metadata;
-  const orgId = metadata.orgId;
-  const triggeredBy = metadata.triggeredBy;
   const subscriptionId = data.id;
   const isSubscriptionActive = data.status === 'active';
 
@@ -102,26 +128,14 @@ async function onPayload(payload: PolarWebhookPayload) {
     case 'checkout.updated':
       break;
     case 'subscription.created':
-      if (metadata.kind === 'token_pack') {
-        break;
-      }
-
-      if (!orgId || triggeredBy === undefined || triggeredBy === '') {
-        console.error('subscription.created missing org metadata');
-
-        break;
-      }
-
       if (isSubscriptionActive) {
-        try {
-          const planData = {
-            orgId,
-            triggeredBy: parseInt(triggeredBy, 10),
-            planName: PLAN.EARLY_ADOPTER as 'EARLY_ADOPTER' | 'ENTERPRISE' | 'BASIC',
-            subscriptionId,
-            payload: data as unknown as Record<string, unknown>
-          };
+        const planData = getOrgPlanData(data);
 
+        if (!planData) {
+          break;
+        }
+
+        try {
           const result = await OrgPlanApiServer.createOrgPlan(planData);
           console.log('Subscription created', result);
         } catch (error) {
@@ -131,15 +145,18 @@ async function onPayload(payload: PolarWebhookPayload) {
 
       break;
     case 'subscription.updated':
-      if (!isSubscriptionActive) {
+      if (isSubscriptionActive) {
+        const planData = getOrgPlanData(data);
+
+        if (!planData) {
+          break;
+        }
+
         try {
-          const result = await OrgPlanApiServer.cancelOrgPlan({
-            subscriptionId,
-            payload: data as unknown as Record<string, unknown>
-          });
-          console.log('Subscription canceled', result);
+          const result = await OrgPlanApiServer.activateOrgPlan(planData);
+          console.log('Subscription activated', result);
         } catch (error) {
-          console.error('Error canceling org plan', error);
+          console.error('Error activating org plan', error);
         }
       } else {
         try {
@@ -147,22 +164,40 @@ async function onPayload(payload: PolarWebhookPayload) {
             subscriptionId,
             payload: data as unknown as Record<string, unknown>
           });
-          console.log('Subscription updated', result);
+          console.log('Subscription state recorded', result);
         } catch (error) {
-          console.error('Error updating org plan', error);
+          console.error('Error recording subscription state', error);
         }
       }
 
       break;
     case 'subscription.active':
+    case 'subscription.uncanceled': {
+      const planData = getOrgPlanData(data);
+
+      if (!planData) {
+        break;
+      }
+
+      try {
+        const result = await OrgPlanApiServer.activateOrgPlan(planData);
+        console.log('Subscription activated', result);
+      } catch (error) {
+        console.error('Error activating org plan', error);
+      }
+
+      break;
+    }
+    case 'subscription.past_due':
+    case 'subscription.canceled':
       try {
         const result = await OrgPlanApiServer.updateOrgPlan({
           subscriptionId,
           payload: data as unknown as Record<string, unknown>
         });
-        console.log('Subscription activated', result);
+        console.log('Subscription state recorded', result);
       } catch (error) {
-        console.error('Error activating org plan', error);
+        console.error('Error recording subscription state', error);
       }
 
       break;
@@ -177,8 +212,6 @@ async function onPayload(payload: PolarWebhookPayload) {
         console.error('Error revoking org plan', error);
       }
 
-      break;
-    case 'subscription.canceled':
       break;
     default:
       // Exhaustive over `PolarSubscriptionWebhookPayload`; kept for future Polar event types.

--- a/packages/db/src/queries/organization/organization.ts
+++ b/packages/db/src/queries/organization/organization.ts
@@ -1149,13 +1149,31 @@ export const createOrganizationPlan = async (
 /**
  * Updates an organization plan by subscription ID
  * @param subscriptionId Subscription ID
- * @param payload Payload data to update
+ * @param updates Organization plan fields to update
  * @returns Updated organization plan record
  */
 export const updateOrganizationPlan = async (
   subscriptionId: string,
+  updates: Partial<Pick<TOrganizationPlan, 'isActive' | 'deactivatedAt' | 'payload'>>
+): Promise<TOrganizationPlan | null> => {
+  const [plan] = await db
+    .update(schema.organizationPlan)
+    .set({ ...updates, updatedAt: sql`timezone('utc'::text, now())` })
+    .where(eq(schema.organizationPlan.subscriptionId, subscriptionId))
+    .returning();
+  return plan ?? null;
+};
+
+/**
+ * Activates an organization plan by subscription ID.
+ * @param subscriptionId Subscription ID
+ * @param payload Payload data to update
+ * @returns Activated organization plan record, or null when it does not exist
+ */
+export const activateOrganizationPlan = async (
+  subscriptionId: string,
   payload: TOrganizationPlan['payload']
-): Promise<TOrganizationPlan> => {
+): Promise<TOrganizationPlan | null> => {
   const [plan] = await db
     .update(schema.organizationPlan)
     .set({
@@ -1166,7 +1184,8 @@ export const updateOrganizationPlan = async (
     })
     .where(eq(schema.organizationPlan.subscriptionId, subscriptionId))
     .returning();
-  return plan;
+
+  return plan ?? null;
 };
 
 /**

--- a/packages/db/src/queries/organization/organization.ts
+++ b/packages/db/src/queries/organization/organization.ts
@@ -1158,7 +1158,12 @@ export const updateOrganizationPlan = async (
 ): Promise<TOrganizationPlan> => {
   const [plan] = await db
     .update(schema.organizationPlan)
-    .set({ payload, updatedAt: sql`timezone('utc'::text, now())` })
+    .set({
+      isActive: true,
+      deactivatedAt: null,
+      payload,
+      updatedAt: sql`timezone('utc'::text, now())`
+    })
     .where(eq(schema.organizationPlan.subscriptionId, subscriptionId))
     .returning();
   return plan;


### PR DESCRIPTION
## Summary

- Add an explicit activation operation for organization plans.
- Activate existing plans or create them when activation arrives before the initial local plan exists.
- Keep generic plan updates payload-only.
- Record cancellation and recoverable past-due events without removing access.
- Deactivate only on subscription revocation.
- Restrict all plan mutations to the private server API key; browser session cookies cannot create, activate, update, or cancel plans.
- Propagate activation failures from the webhook so unsuccessful deliveries are not acknowledged as successful and can be retried.

## Verification

-  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})

> classroomio@0.1.13 format:check /Users/rotimibest/.codex/worktrees/112c/classroomio
> node scripts/format-changed.mjs --staged --check

No changed files to format.
- .                                        |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
apps/dashboard                           |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
apps/website                             |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
Scope: 10 of 25 workspace projects
packages/question-types build$ tsc && tsc-alias
packages/jobs build$ rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/certificates build$ tsc && tsc-alias
packages/certificates build: Done
packages/question-types build: Done
packages/jobs build: Done
packages/utils build$ rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/ai-assistant build$ tsc && tsc-alias
packages/ai-assistant build: Done
packages/utils build: Done
packages/email build$ rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/email build: Done
packages/db prebuild$ pnpm --filter @cio/question-types run build && pnpm --filter @cio/utils run build && pnpm --filter @cio/email run build
packages/db prebuild: [WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies", "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.
packages/db prebuild: ../..                                    |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: ../../apps/dashboard                     |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: ../../apps/website                       |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: > @cio/question-types@1.0.0 build /Users/rotimibest/.codex/worktrees/112c/classroomio/packages/question-types
packages/db prebuild: > tsc && tsc-alias
packages/db prebuild: [WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies", "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.
packages/db prebuild: ../..                                    |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: ../../apps/dashboard                     |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: ../../apps/website                       |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: > @cio/utils@1.0.0 build /Users/rotimibest/.codex/worktrees/112c/classroomio/packages/utils
packages/db prebuild: > rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/db prebuild: [WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies", "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.
packages/db prebuild: ../..                                    |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: ../../apps/dashboard                     |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: ../../apps/website                       |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: > @cio/email@0.0.1 build /Users/rotimibest/.codex/worktrees/112c/classroomio/packages/email
packages/db prebuild: > rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/db prebuild: Done
packages/db build$ rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/db build: Done
packages/core build$ tsc && tsc-alias && node scripts/restore-bare-specifiers.mjs
packages/analytics build$ rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/analytics build: Done
packages/core build: restore-bare-specifiers: rewrote 18/47 files
packages/core build: Done
.                                        |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
apps/dashboard                           |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
apps/website                             |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})

> @cio/api@0.0.1 build /Users/rotimibest/.codex/worktrees/112c/classroomio/apps/api
> tsc && tsc-alias
- .                                        |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
apps/dashboard                           |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
apps/website                             |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
Scope: 12 of 25 workspace projects
packages/question-types build$ tsc && tsc-alias
packages/jobs build$ rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/certificates build$ tsc && tsc-alias
packages/certificates build: Done
packages/question-types build: Done
packages/jobs build: Done
packages/ai-assistant build$ tsc && tsc-alias
packages/utils build$ rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/ai-assistant build: Done
packages/utils build: Done
packages/ui build$ pnpm generate-css
packages/email build$ rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/ui build: [WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies", "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.
packages/ui build: ../..                                    |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/ui build: ../../apps/dashboard                     |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/ui build: ../../apps/website                       |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/ui build: > @cio/ui@0.0.1 generate-css /Users/rotimibest/.codex/worktrees/112c/classroomio/packages/ui
packages/ui build: > echo 'generating CSS' && tailwindcss -i ./src/index.css -o ./src/output.css --minify
packages/ui build: generating CSS
packages/ui build: ≈ tailwindcss v4.2.1
packages/ui build: Done in 225ms
packages/ui build: Done
packages/email build: Done
packages/db prebuild$ pnpm --filter @cio/question-types run build && pnpm --filter @cio/utils run build && pnpm --filter @cio/email run build
packages/db prebuild: [WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies", "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.
packages/db prebuild: ../..                                    |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: ../../apps/dashboard                     |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: ../../apps/website                       |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: > @cio/question-types@1.0.0 build /Users/rotimibest/.codex/worktrees/112c/classroomio/packages/question-types
packages/db prebuild: > tsc && tsc-alias
packages/db prebuild: [WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies", "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.
packages/db prebuild: ../..                                    |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: ../../apps/dashboard                     |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: ../../apps/website                       |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: > @cio/utils@1.0.0 build /Users/rotimibest/.codex/worktrees/112c/classroomio/packages/utils
packages/db prebuild: > rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/db prebuild: [WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies", "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.
packages/db prebuild: ../..                                    |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: ../../apps/dashboard                     |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: ../../apps/website                       |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
packages/db prebuild: > @cio/email@0.0.1 build /Users/rotimibest/.codex/worktrees/112c/classroomio/packages/email
packages/db prebuild: > rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/db prebuild: Done
packages/db build$ rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/db build: Done
packages/analytics build$ rimraf dist tsconfig.tsbuildinfo && tsc && tsc-alias
packages/core build$ tsc && tsc-alias && node scripts/restore-bare-specifiers.mjs
packages/analytics build: Done
packages/core build: restore-bare-specifiers: rewrote 18/47 files
packages/core build: Done
apps/api build$ tsc && tsc-alias
apps/api build: Done
.                                        |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
apps/dashboard                           |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
apps/website                             |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})

> @cio/dashboard@0.0.1 prebuild /Users/rotimibest/.codex/worktrees/112c/classroomio/apps/dashboard
> pnpm --filter @cio/ui run build

../..                                    |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
.                                        |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
../website                               |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})

> @cio/ui@0.0.1 build /Users/rotimibest/.codex/worktrees/112c/classroomio/packages/ui
> pnpm generate-css

../..                                    |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
../../apps/dashboard                     |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})
../../apps/website                       |  WARN  Unsupported engine: wanted: {"node":"^20.19.3"} (current: {"node":"v24.19.0","pnpm":"10.19.0"})

> @cio/ui@0.0.1 generate-css /Users/rotimibest/.codex/worktrees/112c/classroomio/packages/ui
> echo 'generating CSS' && tailwindcss -i ./src/index.css -o ./src/output.css --minify

generating CSS

> @cio/dashboard@0.0.1 build /Users/rotimibest/.codex/worktrees/112c/classroomio/apps/dashboard
> vite build

vite v5.4.21 building SSR bundle for production...
transforming...
✓ 11912 modules transformed.
rendering chunks...
vite v5.4.21 building for production...
transforming...
✓ 13323 modules transformed.
rendering chunks...
/Users/rotimibest/.codex/worktrees/112c/classroomio/apps/dashboard:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @cio/dashboard@0.0.1 build: `vite build`
Command failed with signal "SIGABRT"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for activating organization plans through the plan management API.
  - Organization plans can now be restored when subscriptions become active or uncanceled.
  - Added handling for past-due subscription states.

- **Bug Fixes**
  - Subscription updates now correctly preserve inactive states instead of canceling plans.
  - Invalid subscription metadata is rejected.
  - Activation failures now report errors instead of completing silently.

- **Security**
  - Organization plan management endpoints now require a server API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->