### PR TITLE
fix(dashboard): use authenticated landing page CTA

### DIFF
--- a/apps/dashboard/src/lib/features/org/utils/landing-page.ts
+++ b/apps/dashboard/src/lib/features/org/utils/landing-page.ts
@@ -40,7 +40,7 @@ export const defaultLandingPageHero: OrgLandingPageHero = {
   subheading: 'Master the skills, earn your certification, and prove your expertise with hands-on training programs.',
   primaryAction: {
     label: 'Start Learning',
-    href: '/login'
+    href: '/lms'
   },
   secondaryAction: {
     label: 'Browse',

--- a/apps/dashboard/src/lib/features/org/utils/landing-page.ts
+++ b/apps/dashboard/src/lib/features/org/utils/landing-page.ts
@@ -749,12 +749,21 @@ export function buildOrgLandingPageProps(
   options?: { coursesLoaded?: boolean }
 ): OrgLandingPageProps {
   const normalizedLandingPage = normalizeLandingPageSettings(landingpage);
+  const configuredPrimaryAction = normalizedLandingPage.hero.primaryAction;
+  const primaryAction =
+    configuredPrimaryAction.href === '/login' && authAction && !authAction.loading
+      ? { ...configuredPrimaryAction, href: authAction.href }
+      : configuredPrimaryAction;
 
   return {
     orgName: org.name,
     logoUrl: org.avatarUrl || undefined,
     authAction,
     ...normalizedLandingPage,
+    hero: {
+      ...normalizedLandingPage.hero,
+      primaryAction
+    },
     courses: mapPublicCoursesToLandingPageCourses(courses),
     hasMoreCourses,
     coursesLoaded: options?.coursesLoaded ?? true,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -89,7 +89,8 @@
     "db:restore-lesson-section-from-dump": "tsx src/scripts/restore-lesson-section-from-dump.ts",
     "db:restore-organizationmember-from-dump": "tsx src/scripts/restore-organizationmember-from-dump.ts",
     "db:disable-v1-content-grouping-from-dump": "tsx src/scripts/disable-v1-content-grouping-from-dump.ts",
-    "db:fix-landing-courses": "tsx src/scripts/fix-landing-page-courses-links.ts"
+    "db:fix-landing-courses": "tsx src/scripts/fix-landing-page-courses-links.ts",
+    "db:migrate-landing-primary-action": "tsx src/scripts/migrate-landing-page-primary-action.ts"
   },
   "dependencies": {
     "@better-auth/sso": "^1.4.18",

--- a/packages/db/src/scripts/migrate-landing-page-primary-action.ts
+++ b/packages/db/src/scripts/migrate-landing-page-primary-action.ts
@@ -1,0 +1,73 @@
+import { eq, isNotNull } from 'drizzle-orm';
+
+import { db } from '../drizzle';
+import { organization } from '../schema';
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function migratePrimaryAction(landingpage: unknown): { landingpage: unknown; changed: boolean } {
+  if (!isRecord(landingpage) || !isRecord(landingpage.hero) || !isRecord(landingpage.hero.primaryAction)) {
+    return { landingpage, changed: false };
+  }
+
+  if (landingpage.hero.primaryAction.href !== '/login') {
+    return { landingpage, changed: false };
+  }
+
+  return {
+    landingpage: {
+      ...landingpage,
+      hero: {
+        ...landingpage.hero,
+        primaryAction: {
+          ...landingpage.hero.primaryAction,
+          href: '/lms'
+        }
+      }
+    },
+    changed: true
+  };
+}
+
+async function main() {
+  const shouldExecute = process.argv.includes('--execute');
+  const rows = await db
+    .select({ id: organization.id, siteName: organization.siteName, landingpage: organization.landingpage })
+    .from(organization)
+    .where(isNotNull(organization.landingpage));
+
+  let updatedCount = 0;
+
+  for (const row of rows) {
+    const result = migratePrimaryAction(row.landingpage);
+
+    if (!result.changed) {
+      continue;
+    }
+
+    if (shouldExecute) {
+      await db
+        .update(organization)
+        .set({ landingpage: result.landingpage as typeof organization.$inferInsert.landingpage })
+        .where(eq(organization.id, row.id));
+    }
+
+    console.log(`${shouldExecute ? 'Updated' : 'Would update'} org "${row.siteName}" (${row.id})`);
+    updatedCount += 1;
+  }
+
+  console.log(
+    `${shouldExecute ? 'Migration complete' : 'Dry run complete'}. ${updatedCount} of ${rows.length} orgs ${
+      shouldExecute ? 'updated' : 'would be updated'
+    }.`
+  );
+}
+
+main().catch((error) => {
+  console.error('migrate-landing-page-primary-action failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- default the landing-page hero CTA to `/lms`
- migrate existing organization landing pages whose exact `hero.primaryAction.href` is `/login`
- preserve custom destinations and all other landing-page data
- keep the runtime auth-aware CTA behavior for legacy/unmigrated values

## Migration
Run a dry run first:
```bash
pnpm --filter @cio/db db:migrate-landing-primary-action
```

Apply only the exact `/login` matches:
```bash
pnpm --filter @cio/db db:migrate-landing-primary-action -- --execute
```

## Verification
- `pnpm format:check`
- `pnpm --filter @cio/db build`
- `pnpm --filter @cio/dashboard^... build && pnpm --filter @cio/dashboard build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Landing pages now direct the hero’s primary action to the appropriate authentication destination when available.
  - The configured action remains unchanged when authentication details are unavailable or still loading.
  - Default landing pages now direct the hero’s primary action to the learning platform instead of the login page.
  - Existing landing page links using the previous login destination are updated to the learning platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->