### PR TITLE
fix(assets): make Vimeo backfills non-blocking

### DIFF
--- a/packages/core/src/services/assets/assets.ts
+++ b/packages/core/src/services/assets/assets.ts
@@ -20,6 +20,7 @@ import type {
 import type { TTranscriptResponse, TUpdateTranscript } from '@cio/utils/validation/media';
 import {
   assetUsageExistsForTarget,
+  AssetUsageAlreadyExistsError,
   createAssetAndUsage,
   createAssetUsage,
   createHlsAssetPlaceholder,
@@ -482,6 +483,10 @@ export async function createAndAttachAssetService(orgId: string, profileId: stri
 
     return result;
   } catch (error) {
+    if (error instanceof AssetUsageAlreadyExistsError) {
+      throw new AppError('Asset is already attached to this target', ErrorCodes.ASSET_ALREADY_ATTACHED, 409);
+    }
+
     if (error instanceof AppError) {
       throw error;
     }

--- a/packages/core/src/services/assets/assets.ts
+++ b/packages/core/src/services/assets/assets.ts
@@ -20,6 +20,7 @@ import type {
 import type { TTranscriptResponse, TUpdateTranscript } from '@cio/utils/validation/media';
 import {
   assetUsageExistsForTarget,
+  createAssetAndUsage,
   createAssetUsage,
   createHlsAssetPlaceholder,
   createOrGetAssetByStorageKey,
@@ -409,44 +410,50 @@ export async function listOrganizationAssetsService(orgId: string, query: TAsset
   }
 }
 
+function buildAssetValues(orgId: string, profileId: string, data: TAssetCreateUpload) {
+  return {
+    organizationId: orgId,
+    kind: data.kind,
+    provider: data.provider,
+    storageProvider: data.storageProvider,
+    storageKey: data.storageKey ?? null,
+    sourceUrl: data.sourceUrl ?? null,
+    mimeType: data.mimeType ?? null,
+    byteSize: data.byteSize ?? null,
+    checksum: data.checksum ?? null,
+    title: data.title ?? null,
+    description: data.description ?? null,
+    thumbnailUrl: data.thumbnailUrl ?? null,
+    durationSeconds: data.durationSeconds ?? null,
+    aspectRatio: data.aspectRatio ?? null,
+    isExternal: data.isExternal,
+    status: 'active' as const,
+    metadata: data.metadata ?? {},
+    createdByProfileId: profileId
+  };
+}
+
+function scheduleAssetBackgroundWork(orgId: string, profileId: string, asset: TAsset): void {
+  // Fire-and-forget: enqueue lesson-video post-processing for new uploads.
+  // Errors are logged but never block the asset response.
+  if (asset.kind === 'video' && asset.provider === 'upload' && asset.storageKey) {
+    void enqueueMediaPostProcessingForAsset({
+      organizationId: orgId,
+      assetId: asset.id,
+      storageKey: asset.storageKey,
+      triggeredByProfileId: profileId
+    });
+  }
+
+  // Vimeo oEmbed is slow and third-party controlled. Reads and writes return
+  // the persisted asset immediately while the bounded queue repairs metadata.
+  queueVimeoBackfill(asset);
+}
+
 export async function createAssetFromUploadService(orgId: string, profileId: string, data: TAssetCreateUpload) {
   try {
-    const asset = await createOrGetAssetByStorageKey({
-      organizationId: orgId,
-      kind: data.kind,
-      provider: data.provider,
-      storageProvider: data.storageProvider,
-      storageKey: data.storageKey ?? null,
-      sourceUrl: data.sourceUrl ?? null,
-      mimeType: data.mimeType ?? null,
-      byteSize: data.byteSize ?? null,
-      checksum: data.checksum ?? null,
-      title: data.title ?? null,
-      description: data.description ?? null,
-      thumbnailUrl: data.thumbnailUrl ?? null,
-      durationSeconds: data.durationSeconds ?? null,
-      aspectRatio: data.aspectRatio ?? null,
-      isExternal: data.isExternal,
-      status: 'active',
-      metadata: data.metadata ?? {},
-      createdByProfileId: profileId
-    });
-
-    // Fire-and-forget: enqueue lesson-video post-processing for new uploads.
-    // Errors are logged but never block the asset create response.
-    if (asset.kind === 'video' && asset.provider === 'upload' && asset.storageKey) {
-      void enqueueMediaPostProcessingForAsset({
-        organizationId: orgId,
-        assetId: asset.id,
-        storageKey: asset.storageKey,
-        triggeredByProfileId: profileId
-      });
-    }
-
-    if (shouldBackfillVimeoAsset(asset)) {
-      const backfilledAsset = await backfillVimeoAsset(asset);
-      return backfilledAsset;
-    }
+    const asset = await createOrGetAssetByStorageKey(buildAssetValues(orgId, profileId, data));
+    scheduleAssetBackgroundWork(orgId, profileId, asset);
 
     return asset;
   } catch (error) {
@@ -459,22 +466,22 @@ export async function createAssetFromUploadService(orgId: string, profileId: str
 }
 
 export async function createAndAttachAssetService(orgId: string, profileId: string, input: TAssetCreateAndAttach) {
-  const asset = await createAssetFromUploadService(orgId, profileId, input.asset);
-
   try {
-    const usage = await attachAssetService(orgId, asset.id, profileId, input.attach);
+    const assetValues = buildAssetValues(orgId, profileId, input.asset);
+    const usageValues = {
+      organizationId: orgId,
+      targetType: input.attach.targetType,
+      targetId: input.attach.targetId,
+      slotType: input.attach.slotType,
+      slotKey: input.attach.slotKey ?? null,
+      position: input.attach.position ?? null,
+      createdByProfileId: profileId
+    };
+    const result = await createAssetAndUsage(assetValues, usageValues);
+    scheduleAssetBackgroundWork(orgId, profileId, result.asset);
 
-    return { asset, usage };
+    return result;
   } catch (error) {
-    try {
-      await deleteAsset(asset.id, orgId);
-    } catch (cleanupError) {
-      console.error('createAndAttachAssetService: failed to cleanup asset on attach failure', {
-        assetId: asset.id,
-        error: cleanupError
-      });
-    }
-
     if (error instanceof AppError) {
       throw error;
     }
@@ -509,10 +516,7 @@ export async function getAssetService(orgId: string, assetId: string) {
     const asset = await getAssetById(assetId, orgId);
     const existingAsset = assertAssetExists(asset);
 
-    if (shouldBackfillVimeoAsset(existingAsset)) {
-      const backfilledAsset = await backfillVimeoAsset(existingAsset);
-      return backfilledAsset;
-    }
+    queueVimeoBackfill(existingAsset);
 
     return existingAsset;
   } catch (error) {

--- a/packages/db/src/queries/assets/assets.ts
+++ b/packages/db/src/queries/assets/assets.ts
@@ -423,6 +423,22 @@ export async function createAssetUsage(values: TNewAssetUsage, dbClient: DbOrTxC
   }
 }
 
+/**
+ * Create an asset and its first usage in one transaction. This keeps the
+ * asset table and polymorphic usage table consistent when attachment fails.
+ */
+export async function createAssetAndUsage(
+  assetValues: TNewAsset,
+  usageValues: Omit<TNewAssetUsage, 'assetId'>
+): Promise<{ asset: TAsset; usage: TAssetUsage }> {
+  return db.transaction(async (tx) => {
+    const asset = await createOrGetAssetByStorageKey(assetValues, tx);
+    const usage = await createAssetUsage({ ...usageValues, assetId: asset.id }, tx);
+
+    return { asset, usage };
+  });
+}
+
 export async function deleteAssetUsage(
   orgId: string,
   assetId: string,

--- a/packages/db/src/queries/assets/assets.ts
+++ b/packages/db/src/queries/assets/assets.ts
@@ -28,6 +28,13 @@ export interface AssetStorageSummary {
   bytesByKind: Record<string, number>;
 }
 
+export class AssetUsageAlreadyExistsError extends Error {
+  constructor() {
+    super('Asset is already attached to this target');
+    this.name = 'AssetUsageAlreadyExistsError';
+  }
+}
+
 export interface AssetDetachInput {
   usageId?: string;
   targetType?: string;
@@ -433,6 +440,18 @@ export async function createAssetAndUsage(
 ): Promise<{ asset: TAsset; usage: TAssetUsage }> {
   return db.transaction(async (tx) => {
     const asset = await createOrGetAssetByStorageKey(assetValues, tx);
+    const alreadyAttached = await assetUsageExistsForTarget(
+      asset.id,
+      assetValues.organizationId,
+      usageValues.targetType,
+      usageValues.targetId,
+      tx
+    );
+
+    if (alreadyAttached) {
+      throw new AssetUsageAlreadyExistsError();
+    }
+
     const usage = await createAssetUsage({ ...usageValues, assetId: asset.id }, tx);
 
     return { asset, usage };
@@ -528,10 +547,11 @@ export async function assetUsageExistsForTarget(
   assetId: string,
   orgId: string,
   targetType: string,
-  targetId: string
+  targetId: string,
+  dbClient: DbOrTxClient = db
 ): Promise<boolean> {
   try {
-    const [existing] = await db
+    const [existing] = await dbClient
       .select({ id: schema.assetUsage.id })
       .from(schema.assetUsage)
       .where(


### PR DESCRIPTION
## Summary

Follow-up fixes for [#1077](https://github.com/classroomio/classroomio/pull/1077):

- Return asset reads and creates immediately while Vimeo metadata repair runs through the existing bounded, deduplicated background queue.
- Create assets and their first lesson usage in one database transaction so failed attachment rolls back the asset automatically.

## Verification

- `pnpm --filter @cio/api^... build && pnpm --filter @cio/api build`
- `pnpm --filter @cio/utils test`
- `node --test packages/core/test/vimeo-embed.test.mjs packages/core/test/vimeo-backfill.test.mjs`
- `pnpm format:check`

This is a stacked follow-up PR targeting the feature branch from #1077.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves Vimeo metadata repair off asset read/create response paths and makes initial asset attachment transactional.

- Centralizes construction of new asset values and scheduling of background processing.
- Returns persisted Vimeo assets immediately while metadata repair runs asynchronously.
- Creates an asset and its first usage in one database transaction.
- Changes duplicate create-and-attach requests from an explicit conflict to silent success.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until transactional create-and-attach preserves the existing duplicate-attachment conflict behavior.

The transaction and background scheduling are otherwise coherent, but an asset reused by storage key can already have the requested usage; the new path silently returns that usage instead of producing the established 409 response.

**Files Needing Attention:** packages/core/src/services/assets/assets.ts; packages/db/src/queries/assets/assets.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/services/assets/assets.ts | Makes Vimeo repair non-blocking and switches create-and-attach to the transactional query, but bypasses the existing duplicate-attachment conflict contract. |
| packages/db/src/queries/assets/assets.ts | Adds an atomic asset-and-usage transaction whose conflict handling can return an existing usage. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant API
  participant Core as Asset service
  participant DB
  participant Queue as Vimeo backfill queue

  API->>Core: create-and-attach request
  Core->>DB: begin transaction
  DB->>DB: create or reuse asset
  DB->>DB: create asset usage
  DB-->>Core: "commit {asset, usage}"
  Core->>Queue: schedule metadata repair
  Core-->>API: return immediately
```

<sub>Reviews (1): Last reviewed commit: ["fix(assets): make Vimeo backfills non-bl..."](https://github.com/classroomio/classroomio/commit/41deb5365efed3837d24dfb41036e23bd55e05aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62223883)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->