### PR TITLE
fix(security): protect public organization landing data

### DIFF
--- a/apps/dashboard/src/lib/features/app/layout-setup.ts
+++ b/apps/dashboard/src/lib/features/app/layout-setup.ts
@@ -1,6 +1,7 @@
 import { getFirstOrg, getOrgBySiteName, getOrgsByCustomDomain } from '$features/org/api/org.server';
 
-import type { AccountOrg } from '$features/app/types';
+import type { AccountOrg, PublicOrg } from '$features/app/types';
+import { toPublicOrg } from '$features/app/public-org';
 import type { Cookies } from '@sveltejs/kit';
 import { PUBLIC_IS_SELFHOSTED } from '$env/static/public';
 import { blockedSubdomain } from '$lib/utils/constants/app';
@@ -11,7 +12,7 @@ import { isLocalOrPrivateHost } from '@cio/utils/functions';
 
 export interface OrgSiteInfo {
   isOrgSite: boolean;
-  org: AccountOrg | null;
+  org: PublicOrg | null;
   subdomain: string;
   orgSiteName: string;
 }
@@ -29,7 +30,7 @@ export async function getOrgSiteInfo(url: URL, cookies: Cookies): Promise<OrgSit
     const apiKeyHeaders = getApiKeyHeaders();
     const firstOrg = await getFirstOrg(apiKeyHeaders);
     if (firstOrg) {
-      response.org = firstOrg as AccountOrg;
+      response.org = toPublicOrg(firstOrg as AccountOrg);
       response.isOrgSite = true;
       response.orgSiteName = firstOrg.siteName || '';
       response.subdomain = '';
@@ -63,7 +64,7 @@ export async function getOrgSiteInfo(url: URL, cookies: Cookies): Promise<OrgSit
     }
 
     const org = orgs[0];
-    response.org = org as AccountOrg;
+    response.org = toPublicOrg(org as AccountOrg);
     response.isOrgSite = true;
     response.orgSiteName = response.org?.siteName || '';
     response.subdomain = subdomain;
@@ -85,7 +86,7 @@ export async function getOrgSiteInfo(url: URL, cookies: Cookies): Promise<OrgSit
     if (response.orgSiteName) {
       const apiKeyHeaders = getApiKeyHeaders();
       const org = await getOrgBySiteName(response.orgSiteName, apiKeyHeaders);
-      response.org = org ?? null;
+      response.org = org ? toPublicOrg(org as AccountOrg) : null;
     }
 
     const shouldDeleteCookie = !response.org && _orgSiteName;

--- a/apps/dashboard/src/lib/features/app/public-org.test.ts
+++ b/apps/dashboard/src/lib/features/app/public-org.test.ts
@@ -1,0 +1,65 @@
+import { toPublicOrg } from './public-org';
+
+import type { AccountOrg } from './types';
+
+describe('toPublicOrg', () => {
+  it('keeps only fields required by public organization pages', () => {
+    const accountOrg = {
+      id: 'org-1',
+      name: 'Acme Academy',
+      siteName: 'acme',
+      avatarUrl: 'https://example.com/avatar.png',
+      favicon: 'https://example.com/favicon.png',
+      theme: 'blue',
+      isRestricted: false,
+      landingpage: { theme: 'bold' },
+      customDomain: 'learn.acme.test',
+      isCustomDomainVerified: true,
+      disableSignup: false,
+      disableSignupMessage: null,
+      disableEmailPassword: false,
+      disableGoogleAuth: false,
+      settings: {
+        signup: { inviteOnly: true },
+        emailNotifications: { newStudent: true }
+      },
+      customization: {
+        auth: { backgroundImage: 'https://example.com/auth.png' },
+        dashboard: { bannerText: 'Private dashboard setting' }
+      },
+      plans: [
+        {
+          planName: 'ENTERPRISE',
+          isActive: true,
+          provider: 'polar',
+          subscriptionId: 'subscription-secret',
+          customerId: 'customer-secret'
+        }
+      ],
+      aiTutorSettings: { escalation: { email: 'owner@example.com' } },
+      createdAt: '2026-09-10T00:00:00.000Z',
+      customCode: '<script>private()</script>',
+      readOnlyUntil: null
+    } as unknown as AccountOrg;
+
+    expect(toPublicOrg(accountOrg)).toEqual({
+      id: 'org-1',
+      name: 'Acme Academy',
+      siteName: 'acme',
+      avatarUrl: 'https://example.com/avatar.png',
+      favicon: 'https://example.com/favicon.png',
+      theme: 'blue',
+      isRestricted: false,
+      landingpage: { theme: 'bold' },
+      customDomain: 'learn.acme.test',
+      isCustomDomainVerified: true,
+      disableSignup: false,
+      disableSignupMessage: null,
+      disableEmailPassword: false,
+      disableGoogleAuth: false,
+      settings: { signup: { inviteOnly: true } },
+      customization: { auth: { backgroundImage: 'https://example.com/auth.png' } },
+      plans: [{ planName: 'ENTERPRISE', isActive: true }]
+    });
+  });
+});

--- a/apps/dashboard/src/lib/features/app/public-org.ts
+++ b/apps/dashboard/src/lib/features/app/public-org.ts
@@ -1,0 +1,53 @@
+import type { AccountOrg, PublicOrg } from './types';
+
+type OrganizationCustomization = AccountOrg['customization'] & {
+  auth?: {
+    backgroundImage?: string;
+  };
+};
+
+/**
+ * Keep the organization data serialized into public page loads intentionally small.
+ * Account-only configuration, billing identifiers, and internal timestamps must not
+ * cross the server-to-browser boundary for an organization site.
+ */
+export function toPublicOrg(org: AccountOrg): PublicOrg {
+  const customization = org.customization as OrganizationCustomization;
+  const signupSettings = org.settings?.signup;
+  const authBackgroundImage = customization.auth?.backgroundImage;
+
+  return {
+    id: org.id,
+    name: org.name,
+    siteName: org.siteName,
+    avatarUrl: org.avatarUrl,
+    favicon: org.favicon,
+    theme: org.theme,
+    isRestricted: org.isRestricted,
+    landingpage: org.landingpage,
+    customDomain: org.customDomain,
+    isCustomDomainVerified: org.isCustomDomainVerified,
+    disableSignup: org.disableSignup,
+    disableSignupMessage: org.disableSignupMessage,
+    disableEmailPassword: org.disableEmailPassword,
+    disableGoogleAuth: org.disableGoogleAuth,
+    settings: signupSettings
+      ? {
+          signup: {
+            inviteOnly: signupSettings.inviteOnly
+          }
+        }
+      : {},
+    customization: authBackgroundImage
+      ? {
+          auth: {
+            backgroundImage: authBackgroundImage
+          }
+        }
+      : {},
+    plans: org.plans.map((plan) => ({
+      planName: plan.planName,
+      isActive: plan.isActive
+    }))
+  };
+}

--- a/apps/dashboard/src/lib/features/app/types.ts
+++ b/apps/dashboard/src/lib/features/app/types.ts
@@ -5,3 +5,33 @@ export type AccountResponse = InferResponseType<typeof classroomio.account.$get>
 export type AccountSuccess = Extract<InferResponseType<typeof classroomio.account.$get>, { success: true }>;
 
 export type AccountOrg = AccountSuccess['organizations'][number];
+
+export type PublicOrg = Pick<
+  AccountOrg,
+  | 'id'
+  | 'name'
+  | 'siteName'
+  | 'avatarUrl'
+  | 'favicon'
+  | 'theme'
+  | 'isRestricted'
+  | 'landingpage'
+  | 'customDomain'
+  | 'isCustomDomainVerified'
+  | 'disableSignup'
+  | 'disableSignupMessage'
+  | 'disableEmailPassword'
+  | 'disableGoogleAuth'
+> & {
+  settings: {
+    signup?: {
+      inviteOnly?: boolean;
+    };
+  };
+  customization: {
+    auth?: {
+      backgroundImage?: string;
+    };
+  };
+  plans: Array<Pick<AccountOrg['plans'][number], 'planName' | 'isActive'>>;
+};

--- a/apps/dashboard/src/lib/features/org/utils/landing-page.ts
+++ b/apps/dashboard/src/lib/features/org/utils/landing-page.ts
@@ -1,4 +1,4 @@
-import type { AccountOrg } from '$features/app/types';
+import type { AccountOrg, PublicOrg } from '$features/app/types';
 import type {
   FooterColumn,
   FooterColumnLink,
@@ -741,7 +741,7 @@ export function buildOrgLandingPageLabels(): OrgLandingPageProps['labels'] {
 }
 
 export function buildOrgLandingPageProps(
-  org: AccountOrg,
+  org: AccountOrg | PublicOrg,
   landingpage: unknown,
   courses: OrgPublicCourses,
   hasMoreCourses = false,

--- a/apps/dashboard/src/lib/features/org/utils/org-landing-auth-action.ts
+++ b/apps/dashboard/src/lib/features/org/utils/org-landing-auth-action.ts
@@ -1,4 +1,4 @@
-import type { AccountOrg } from '$features/app/types';
+import type { PublicOrg } from '$features/app/types';
 import { t } from '$lib/utils/functions/translations';
 import { PUBLIC_IS_SELFHOSTED } from '$env/static/public';
 import { ROLE } from '@cio/utils/constants';
@@ -12,7 +12,7 @@ type OrganizationMembership = {
 interface OrgLandingAuthActionOptions {
   isLoggedIn: boolean;
   isInitialized: boolean;
-  org: AccountOrg;
+  org: PublicOrg;
   organizations?: OrganizationMembership[];
   hasPendingInvite?: boolean;
 }

--- a/apps/dashboard/src/lib/features/ui/course-landing-page/course-landing-page.svelte
+++ b/apps/dashboard/src/lib/features/ui/course-landing-page/course-landing-page.svelte
@@ -10,7 +10,7 @@
   import { isSelfEnrollmentAllowed } from '@cio/utils/functions';
   import { importCourseLandingPageTheme, normalizeLandingPageSettings } from '$features/org/utils/landing-page';
   import type { Course } from '$features/course/utils/types';
-  import type { AccountOrg } from '$features/app/types';
+  import type { AccountOrg, PublicOrg } from '$features/app/types';
   import UploadWidget from '$features/ui/upload-widget/upload-widget.svelte';
   import PaymentModal from './components/payment-modal.svelte';
   import { buildCourseLandingPageProps } from './utils';
@@ -23,7 +23,7 @@
   interface Props {
     editMode?: boolean;
     courseData: Course;
-    org?: AccountOrg | null;
+    org?: AccountOrg | PublicOrg | null;
     /** Pre-resolved theme component from the route's load function (eliminates the flash on SSR pages). */
     themeComponent?: Component | null;
   }

--- a/apps/dashboard/src/lib/features/ui/course-landing-page/utils.ts
+++ b/apps/dashboard/src/lib/features/ui/course-landing-page/utils.ts
@@ -4,7 +4,7 @@ import { NAV_ITEMS, NAV_ITEM_KEY } from './constants';
 import { ContentType } from '@cio/utils/constants/content';
 import type { Review } from '$features/course/utils/types';
 import get from 'lodash/get';
-import type { AccountOrg } from '$features/app/types';
+import type { AccountOrg, PublicOrg } from '$features/app/types';
 import { normalizeLandingPageSettings } from '$features/org/utils/landing-page';
 import type { CourseLandingPageProps, OrgLandingPageTheme } from '@cio/ui/custom/org-landing-page';
 import { calcCourseCost, isCourseFree } from '$lib/utils/functions/course';
@@ -113,7 +113,7 @@ export function filterNavItems(course: Course, reviews: Review[]) {
 
 export function buildCourseLandingPageProps(
   course: Course,
-  org: AccountOrg,
+  org: AccountOrg | PublicOrg,
   options: {
     enrollHref: string;
     enrollDisabled: boolean;

--- a/apps/dashboard/src/lib/utils/store/org.ts
+++ b/apps/dashboard/src/lib/utils/store/org.ts
@@ -2,7 +2,7 @@ import { browser, dev } from '$app/environment';
 import { derived, writable } from 'svelte/store';
 import merge from 'lodash/merge';
 
-import type { AccountOrg } from '$features/app/types';
+import type { AccountOrg, PublicOrg } from '$features/app/types';
 import type { OrgTeamMember } from '../types/org';
 import {
   canUseBasicAuthSettings,
@@ -27,11 +27,19 @@ export const DEFAULT_ORG_CUSTOMIZATION = {
   auth: { backgroundImage: '' }
 } as NonNullable<AccountOrg['customization']>;
 
-export function mergeAccountOrgFromServer(org: AccountOrg): AccountOrg {
+export function mergeAccountOrgFromServer(org: AccountOrg | PublicOrg): AccountOrg {
+  const plans = org.plans.map((plan) => ({
+    provider: null,
+    subscriptionId: null,
+    customerId: null,
+    ...plan
+  }));
+
   return {
     ...org,
+    plans,
     customization: merge({}, DEFAULT_ORG_CUSTOMIZATION, org.customization ?? {}) as AccountOrg['customization']
-  };
+  } as AccountOrg;
 }
 
 export const orgs = writable<AccountOrg[]>([]);

--- a/apps/dashboard/src/routes/(org-site)/+layout.svelte
+++ b/apps/dashboard/src/routes/(org-site)/+layout.svelte
@@ -6,13 +6,13 @@
   import { analytics } from '@cio/analytics/client';
   import { getRequestBaseUrl } from '$lib/utils/services/api';
   import type { Snippet } from 'svelte';
-  import type { AccountOrg } from '$features/app/types';
+  import type { PublicOrg } from '$features/app/types';
 
   interface Props {
     children?: Snippet;
     data: {
       isOrgSite: boolean;
-      org: AccountOrg | null;
+      org: PublicOrg | null;
     };
   }
 

--- a/apps/dashboard/src/routes/(org-site)/course/[slug]/+page.server.ts
+++ b/apps/dashboard/src/routes/(org-site)/course/[slug]/+page.server.ts
@@ -1,6 +1,8 @@
 import type { MetaTagsProps } from 'svelte-meta-tags';
 import type { CourseBySlugWithOrg, GetCourseBySlugRequest } from '$features/course/utils/types';
 import type { GetOrganizationRequest } from '$features/org/utils/types';
+import type { AccountOrg } from '$features/app/types';
+import { toPublicOrg } from '$features/app/public-org';
 import { classroomio, type InferResponseType } from '$lib/utils/services/api';
 import { getApiKeyHeaders, safeServerApi } from '$lib/utils/services/api/server';
 import { error, redirect } from '@sveltejs/kit';
@@ -56,7 +58,8 @@ export const load = async ({ params = { slug: '' }, parent, url }) => {
     );
 
     if (organizationResult.ok) {
-      org = organizationResult.body.data[0] ?? null;
+      const organization = organizationResult.body.data[0];
+      org = organization ? toPublicOrg(organization as AccountOrg) : null;
     } else {
       console.error('Failed to fetch course organization:', organizationResult);
     }

--- a/apps/dashboard/src/routes/(org-site)/courses/+page.server.ts
+++ b/apps/dashboard/src/routes/(org-site)/courses/+page.server.ts
@@ -2,6 +2,7 @@ import type { MetaTagsProps } from 'svelte-meta-tags';
 import { classroomio, type InferResponseType } from '$lib/utils/services/api';
 import { safeServerApi } from '$lib/utils/services/api/server';
 import { redirect } from '@sveltejs/kit';
+import { mapPublicCoursesToLandingPageCourses } from '$features/org/utils/landing-page';
 
 type GetPublicCoursesRequest = typeof classroomio.organization.courses.public.$get;
 type GetPublicCoursesSuccess = Extract<InferResponseType<GetPublicCoursesRequest>, { success: true }>;
@@ -85,7 +86,7 @@ export const load = async ({ parent, url }) => {
 
   return {
     org,
-    courses: courseData.courses,
+    courses: mapPublicCoursesToLandingPageCourses(courseData.courses),
     tagGroups: tagsResult.ok ? tagsResult.body.data : [],
     activeTags: normalizedTags,
     activeTypes: normalizedTypes,

--- a/apps/dashboard/src/routes/+layout.server.ts
+++ b/apps/dashboard/src/routes/+layout.server.ts
@@ -1,4 +1,4 @@
-import type { AccountOrg } from '$features/app/types';
+import type { PublicOrg } from '$features/app/types';
 import type { MetaTagsProps } from 'svelte-meta-tags';
 import type { UploadLimits } from '$lib/utils/config/upload-limits';
 import { PUBLIC_IS_SELFHOSTED } from '$env/static/public';
@@ -15,7 +15,7 @@ interface LoadOutput {
   orgSiteName: string;
   isOrgSite: boolean;
   skipAuth: boolean;
-  org: AccountOrg | null;
+  org: PublicOrg | null;
   baseMetaTags: MetaTagsProps;
   serverLang: string;
   localeCookie: string;

--- a/apps/dashboard/src/routes/+layout.svelte
+++ b/apps/dashboard/src/routes/+layout.svelte
@@ -30,8 +30,6 @@
   const metaTags = $derived(merge(data.baseMetaTags, page.data.pageMetaTags));
 
   onMount(() => {
-    console.log('Layout', data);
-
     const sessionUser = data?.locals?.user;
     setupCloudAnalytics(
       sessionUser ? { id: sessionUser.id, email: sessionUser.email, name: sessionUser.name } : undefined,

--- a/packages/ui/src/custom/org-landing-page/bold/course-card.svelte
+++ b/packages/ui/src/custom/org-landing-page/bold/course-card.svelte
@@ -17,6 +17,11 @@
 
   const courseTypeMeta = $derived(getCourseTypeLandingMeta(course));
   const primaryTag = $derived(getPrimaryCourseTag(course));
+  const href = $derived.by(() => {
+    if (disableCourseLinks) return undefined;
+
+    return course.link || (course.slug ? `/course/${course.slug}` : undefined);
+  });
 
   function formatCurrency(cost?: number, currency = 'USD') {
     if (!cost) return labels?.freeLabel ?? 'Free';
@@ -85,7 +90,7 @@
       <div class="ui:mt-auto ui:flex ui:items-center ui:justify-between">
         <span class="ui:font-black ui:text-lg">{course.price || formatCurrency(course.cost, course.currency)}</span>
         <Button
-          href={disableCourseLinks ? undefined : course.link}
+          {href}
           variant="outline"
           class="ui:rounded-lg ui:font-bold ui:text-sm {disableCourseLinks
             ? 'ui:pointer-events-none'


### PR DESCRIPTION
## Summary
- remove the root layout debug log that exposed the complete organization payload in browser DevTools
- serialize a narrow public organization DTO for org-site and public course routes, excluding billing, AI, internal settings, timestamps, and other account-only fields
- normalize `/courses` API results through the landing-page mapper so every course receives `/course/{slug}` links
- add a Bold theme slug fallback for direct component callers

## Verification
- `pnpm --filter @cio/dashboard exec jest --runInBand src/lib/features/app/public-org.test.ts`
- `pnpm --filter @cio/dashboard build`
- `pnpm format:check`
- `pnpm --filter @cio/ui prefix:check:staged`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Organization pages now use a curated public organization profile, limiting exposed account and billing information.
  - Course listings are transformed into the format expected by public landing pages.
  - Course cards now fall back to the course slug for navigation when no custom link is provided.

- **Bug Fixes**
  - Course card links are no longer generated when course links are disabled.
  - Public organization data is supported consistently across landing pages, courses, and layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR narrows organization data serialized by public routes and removes a browser-side debug log containing the complete layout payload.
- Introduces and tests a dedicated public organization DTO mapper.
- Applies the mapper to organization-site and public course loading paths.
- Normalizes public catalog courses so theme cards receive canonical course links.
- Adds a slug-based link fallback to the Bold theme course card.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness, security, or repository-rule violations identified.

Public organization data is consistently reduced before browser serialization, the nested course organization is already narrowed by the service, and the catalog mapper matches its downstream theme-card contract.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/lib/features/app/public-org.ts | Adds an allowlist-based mapper that excludes account-only organization and billing details from public serialization. |
| apps/dashboard/src/lib/features/app/layout-setup.ts | Converts organizations from self-hosted, custom-domain, and subdomain lookup paths into the public DTO. |
| apps/dashboard/src/routes/(org-site)/course/[slug]/+page.server.ts | Sanitizes the fallback organization lookup while retaining an already narrowed nested course organization record. |
| apps/dashboard/src/routes/(org-site)/courses/+page.server.ts | Normalizes public course results into the shape expected by landing-page theme cards. |
| apps/dashboard/src/lib/utils/store/org.ts | Allows public DTO hydration while preserving customization defaults and the plan fields used by public-page helpers. |
| packages/ui/src/custom/org-landing-page/bold/course-card.svelte | Adds a canonical slug fallback when a direct caller does not provide a course link. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Organization API response] --> B[toPublicOrg]
  B --> C[PublicOrg DTO]
  C --> D[Root org-site layout data]
  C --> E[Public course page data]
  D --> F[Browser]
  E --> F
  G[Public courses API] --> H[mapPublicCoursesToLandingPageCourses]
  H --> I[Theme CourseItem data]
  I --> F
```

<sub>Reviews (1): Last reviewed commit: ["fix(security): limit public organization..."](https://github.com/classroomio/classroomio/commit/9bebe226a971e83f075f4c204d1c498ff5e1cbe3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62726945)</sub>

<!-- /greptile_comment -->