### PR TITLE
feat(db): learning paths schema

### DIFF
--- a/packages/db/src/relations.ts
+++ b/packages/db/src/relations.ts
@@ -16,6 +16,11 @@ import {
   group,
   groupAttendance,
   groupmember,
+  learningPath,
+  learningPathCertificateIssue,
+  learningPathCourse,
+  learningPathMember,
+  learningPathMemberCourse,
   lesson,
   lessonComment,
   lessonCompletion,
@@ -199,7 +204,8 @@ export const groupmemberRelations = relations(groupmember, ({ one, many }) => ({
   }),
   courseNewsfeeds: many(courseNewsfeed),
   courseNewsfeedComments: many(courseNewsfeedComment),
-  questionAnswers: many(questionAnswer)
+  questionAnswers: many(questionAnswer),
+  learningPathMemberCourses: many(learningPathMemberCourse)
 }));
 
 export const appsPollOptionRelations = relations(appsPollOption, ({ one, many }) => ({
@@ -534,5 +540,81 @@ export const questionAnswerRelations = relations(questionAnswer, ({ one }) => ({
   submission: one(submission, {
     fields: [questionAnswer.submissionId],
     references: [submission.id]
+  })
+}));
+
+export const learningPathRelations = relations(learningPath, ({ one, many }) => ({
+  organization: one(organization, {
+    fields: [learningPath.organizationId],
+    references: [organization.id]
+  }),
+  createdByProfile: one(profile, {
+    fields: [learningPath.createdByProfileId],
+    references: [profile.id]
+  }),
+  learningPathCourses: many(learningPathCourse),
+  learningPathMembers: many(learningPathMember),
+  learningPathCertificateIssues: many(learningPathCertificateIssue)
+}));
+
+export const learningPathCourseRelations = relations(learningPathCourse, ({ one, many }) => ({
+  learningPath: one(learningPath, {
+    fields: [learningPathCourse.learningPathId],
+    references: [learningPath.id]
+  }),
+  course: one(course, {
+    fields: [learningPathCourse.courseId],
+    references: [course.id]
+  }),
+  learningPathMemberCourses: many(learningPathMemberCourse)
+}));
+
+export const learningPathMemberRelations = relations(learningPathMember, ({ one, many }) => ({
+  learningPath: one(learningPath, {
+    fields: [learningPathMember.learningPathId],
+    references: [learningPath.id]
+  }),
+  profile: one(profile, {
+    fields: [learningPathMember.profileId],
+    references: [profile.id]
+  }),
+  role: one(role, {
+    fields: [learningPathMember.roleId],
+    references: [role.id]
+  }),
+  currentCourse: one(course, {
+    fields: [learningPathMember.currentCourseId],
+    references: [course.id]
+  }),
+  learningPathMemberCourses: many(learningPathMemberCourse)
+}));
+
+export const learningPathMemberCourseRelations = relations(learningPathMemberCourse, ({ one }) => ({
+  learningPathMember: one(learningPathMember, {
+    fields: [learningPathMemberCourse.learningPathMemberId],
+    references: [learningPathMember.id]
+  }),
+  learningPathCourse: one(learningPathCourse, {
+    fields: [learningPathMemberCourse.learningPathCourseId],
+    references: [learningPathCourse.id]
+  }),
+  groupmember: one(groupmember, {
+    fields: [learningPathMemberCourse.groupmemberId],
+    references: [groupmember.id]
+  })
+}));
+
+export const learningPathCertificateIssueRelations = relations(learningPathCertificateIssue, ({ one }) => ({
+  learningPath: one(learningPath, {
+    fields: [learningPathCertificateIssue.learningPathId],
+    references: [learningPath.id]
+  }),
+  learningPathMember: one(learningPathMember, {
+    fields: [learningPathCertificateIssue.learningPathMemberId],
+    references: [learningPathMember.id]
+  }),
+  profile: one(profile, {
+    fields: [learningPathCertificateIssue.profileId],
+    references: [profile.id]
   })
 }));

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -23,6 +23,13 @@ import {
 
 import type { AnswerData } from '@cio/question-types';
 import { COURSE_TYPE_VALUES } from '@cio/utils/constants/course-type';
+import {
+  LEARNING_PATH_COURSE_STATUS_VALUES,
+  LEARNING_PATH_DIFFICULTY_VALUES,
+  LEARNING_PATH_MEMBER_STATUS_VALUES,
+  LEARNING_PATH_STATUS_VALUES,
+  type TLearningPathVisitorAccess
+} from '@cio/utils/constants/learning-path';
 import { LESSON_VERSION_KIND_VALUES } from '@cio/utils/constants/lesson-version';
 import { sql } from 'drizzle-orm';
 
@@ -3400,6 +3407,334 @@ export const cohortGoalAssignment = pgTable(
     index('idx_cohort_goal_assignment_goal_id').on(table.goalId),
     index('idx_cohort_goal_assignment_cohort_member_id').on(table.cohortMemberId),
     index('idx_cohort_goal_assignment_due_date').on(table.dueDate)
+  ]
+);
+
+// ─── Learning Paths ──────────────────────────────────────────────────────────
+// An ordered, sequentially unlocked, bundle-priced set of courses sold on the org's
+// public site. Distinct from cohorts/programs: ordered, priced, publicly listed, and
+// certificate-bearing. Courses stay independently sellable and are never mutated by a
+// path — membership and progress live in the tables below, course enrollment keeps
+// using `groupmember`.
+
+export const learningPathStatus = pgEnum('LEARNING_PATH_STATUS', [...LEARNING_PATH_STATUS_VALUES]);
+
+export const learningPathDifficulty = pgEnum('LEARNING_PATH_DIFFICULTY', [...LEARNING_PATH_DIFFICULTY_VALUES]);
+
+export const learningPathMemberStatus = pgEnum('LEARNING_PATH_MEMBER_STATUS', [...LEARNING_PATH_MEMBER_STATUS_VALUES]);
+
+export const learningPathCourseStatus = pgEnum('LEARNING_PATH_COURSE_STATUS', [...LEARNING_PATH_COURSE_STATUS_VALUES]);
+
+export const learningPath = pgTable(
+  'learning_path',
+  {
+    id: uuid()
+      .default(sql`gen_random_uuid()`)
+      .primaryKey()
+      .notNull(),
+    organizationId: uuid('organization_id').notNull(),
+    name: varchar().notNull(),
+    /** URL segment for `/path/[slug]`; unique per org, not globally like `course.slug`. */
+    slug: varchar().notNull(),
+    description: text(),
+    coverImage: text('cover_image'),
+    status: learningPathStatus().default('DRAFT').notNull(),
+    /** Powers the Difficulty filter (My Learning, Explore) and the public stats row. */
+    difficulty: learningPathDifficulty(),
+    /**
+     * Teacher-set total study time, shown as "~38 hours" and bucketed by the Duration
+     * filter. Stored rather than derived because courses carry no duration of their own.
+     */
+    estimatedDurationMinutes: integer('estimated_duration_minutes'),
+    /** Bundle price for the whole path. Savings vs summed `course.cost` is computed at read time. */
+    cost: bigint({ mode: 'number' })
+      .default(sql`'0'`)
+      .notNull(),
+    currency: varchar().default('USD').notNull(),
+    showSavings: boolean('show_savings').default(true).notNull(),
+    sequentialUnlock: boolean('sequential_unlock').default(true).notNull(),
+    selfEnrollment: boolean('self_enrollment').default(true).notNull(),
+    autoEnroll: boolean('auto_enroll').default(true).notNull(),
+    certificateEnabled: boolean('certificate_enabled').default(true).notNull(),
+    certificateTitle: text('certificate_title'),
+    certificateIssuer: text('certificate_issuer'),
+    /** Mirrors `course.certificate.design` so path certificates render through `@cio/certificates`. */
+    certificateDesign: jsonb('certificate_design').default({}).$type<{
+      templateId?: 'classique' | 'brutalist' | 'noir' | 'poster' | 'minimal';
+      accentColor?: string;
+      subtitle?: string;
+      descriptionOverride?: string;
+      signatories?: { name: string; role: string; enabled?: boolean; signatureUrl?: string }[];
+      /** Supports `{seq}` / `{year}` / `{month}`; defaults to the `LP-XXXX-XXXX` shape. */
+      idFormat?: string;
+    }>(),
+    /**
+     * Public path page content owned by the Landing page tab. Holds copy only — `id` keys
+     * on testimonials/FAQs are client-generated list keys for editing, never foreign keys.
+     */
+    landingPage: jsonb('landing_page').default({}).$type<{
+      headline?: string;
+      subheadline?: string;
+      visitorAccess?: TLearningPathVisitorAccess;
+      outcomes?: string[];
+      skills?: string[];
+      showInstructors?: boolean;
+      showTestimonials?: boolean;
+      testimonials?: { id: string; name: string; role?: string; avatarUrl?: string; quote: string }[];
+      showFaqs?: boolean;
+      faqs?: { id: string; question: string; answer: string }[];
+      showRating?: boolean;
+      rating?: { average: number; count: number };
+    }>(),
+    /**
+     * Set the first time a teacher confirms the drag-ordering. The only setup-checklist step
+     * that cannot be derived from data (every other step reads name/courses/cost/landingPage/status).
+     */
+    courseOrderSetAt: timestamp('course_order_set_at', { withTimezone: true, mode: 'string' }),
+    createdByProfileId: uuid('created_by_profile_id'),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' }).defaultNow()
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.organizationId],
+      foreignColumns: [organization.id],
+      name: 'learning_path_organization_id_fkey'
+    }).onDelete('cascade'),
+    foreignKey({
+      columns: [table.createdByProfileId],
+      foreignColumns: [profile.id],
+      name: 'learning_path_created_by_profile_id_fkey'
+    }),
+    unique('learning_path_organization_id_slug_unique').on(table.organizationId, table.slug),
+    index('idx_learning_path_organization_id').on(table.organizationId),
+    index('idx_learning_path_organization_id_status').on(table.organizationId, table.status)
+  ]
+);
+
+export const learningPathCourse = pgTable(
+  'learning_path_course',
+  {
+    id: uuid()
+      .default(sql`gen_random_uuid()`)
+      .primaryKey()
+      .notNull(),
+    learningPathId: uuid('learning_path_id').notNull(),
+    courseId: uuid('course_id').notNull(),
+    /**
+     * 1-based position, and the gating sequence itself. Deliberately not uniquely
+     * constrained: reordering rewrites every row in one transaction, and a non-deferrable
+     * unique index would reject the intermediate states of a swap.
+     */
+    order: integer().notNull(),
+    /** Per-course outcome bullets shown on the public path page; path-scoped marketing copy. */
+    outcomes: jsonb().default([]).$type<string[]>(),
+    addedAt: timestamp('added_at', { withTimezone: true, mode: 'string' }).defaultNow().notNull()
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.learningPathId],
+      foreignColumns: [learningPath.id],
+      name: 'learning_path_course_learning_path_id_fkey'
+    }).onDelete('cascade'),
+    foreignKey({
+      columns: [table.courseId],
+      foreignColumns: [course.id],
+      name: 'learning_path_course_course_id_fkey'
+    }).onDelete('cascade'),
+    unique('learning_path_course_path_id_course_id_unique').on(table.learningPathId, table.courseId),
+    index('idx_learning_path_course_path_id_order').on(table.learningPathId, table.order),
+    // Unlock evaluation runs on every lesson/exercise completion and starts from the course.
+    index('idx_learning_path_course_course_id').on(table.courseId)
+  ]
+);
+
+export const learningPathMember = pgTable(
+  'learning_path_member',
+  {
+    id: uuid()
+      .default(sql`gen_random_uuid()`)
+      .primaryKey()
+      .notNull(),
+    learningPathId: uuid('learning_path_id').notNull(),
+    /** NULL while a batch-invited learner has not yet claimed their account. */
+    profileId: uuid('profile_id'),
+    email: text(),
+    roleId: bigint('role_id', { mode: 'number' }).notNull(),
+    enrolledAt: timestamp('enrolled_at', { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+    startedAt: timestamp('started_at', { withTimezone: true, mode: 'string' }),
+    completedAt: timestamp('completed_at', { withTimezone: true, mode: 'string' }),
+    // ── Rollup cache ──
+    // Recomputed by the same service that evaluates unlocking on lesson/exercise completion.
+    // Never a source of truth: `learning_path_member_course` plus lesson/exercise data is.
+    // Cached because People, My Learning, and the admin listing all rank and filter by it.
+    status: learningPathMemberStatus().default('NOT_STARTED').notNull(),
+    progressPercent: integer('progress_percent').default(0).notNull(),
+    completedCourseCount: integer('completed_course_count').default(0).notNull(),
+    /** Drives "Current course" in People and "Continue Learning" on the learner surfaces. */
+    currentCourseId: uuid('current_course_id'),
+    /** Backs the "active learners in the last 14 days" analytics card. */
+    lastActivityAt: timestamp('last_activity_at', { withTimezone: true, mode: 'string' })
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.learningPathId],
+      foreignColumns: [learningPath.id],
+      name: 'learning_path_member_learning_path_id_fkey'
+    }).onDelete('cascade'),
+    foreignKey({
+      columns: [table.profileId],
+      foreignColumns: [profile.id],
+      name: 'learning_path_member_profile_id_fkey'
+    }).onDelete('cascade'),
+    foreignKey({
+      columns: [table.roleId],
+      foreignColumns: [role.id],
+      name: 'learning_path_member_role_id_fkey'
+    }),
+    foreignKey({
+      columns: [table.currentCourseId],
+      foreignColumns: [course.id],
+      name: 'learning_path_member_current_course_id_fkey'
+    }).onDelete('set null'),
+    unique('learning_path_member_path_id_profile_id_unique').on(table.learningPathId, table.profileId),
+    unique('learning_path_member_path_id_email_unique').on(table.learningPathId, table.email),
+    index('idx_learning_path_member_learning_path_id').on(table.learningPathId),
+    index('idx_learning_path_member_profile_id').on(table.profileId)
+  ]
+);
+
+/**
+ * One row per member per course in a path, carrying two things: how the learner got into
+ * the course, and the path-scoped projection of their progress in it.
+ *
+ * Progress is deliberately *shared*, not forked. A learner has one `groupmember` row and
+ * one set of `lesson_completion` / `submission` rows per course no matter how many paths
+ * contain it, so a course finished standalone last year counts as done the moment the
+ * learner enrols in a path — and work done inside the path counts outside it too. The
+ * columns below are a cache of that shared truth, never a second copy of it.
+ *
+ * Access is granted by inserting into `groupmember` like every other enrolment route, so
+ * the course itself needs no knowledge of paths. `groupmemberId` + `accessGrantedByPath`
+ * record the provenance the plain `groupmember` row cannot: whether this path is the
+ * reason the learner has access (so unenrolling should take it away) or whether they
+ * already had their own enrolment (so unenrolling must leave it alone). Several paths may
+ * point at the same `groupmember` row; access is the union of the grants, which is why
+ * revocation checks for other live grants before removing anything.
+ */
+export const learningPathMemberCourse = pgTable(
+  'learning_path_member_course',
+  {
+    id: uuid()
+      .default(sql`gen_random_uuid()`)
+      .primaryKey()
+      .notNull(),
+    learningPathMemberId: uuid('learning_path_member_id').notNull(),
+    learningPathCourseId: uuid('learning_path_course_id').notNull(),
+    // ── Access provenance ──
+    /**
+     * The course enrolment this path row is attached to. NULL while the course is still
+     * locked under sequential unlock, or once a teacher removes the learner from the
+     * course directly.
+     */
+    groupmemberId: uuid('groupmember_id'),
+    /**
+     * TRUE when enrolling in the path is what created the `groupmember` row. FALSE when the
+     * learner was already enrolled and the path merely adopted the existing enrolment.
+     * Unenrolling from the path may only delete the `groupmember` row when this is TRUE and
+     * no other path holds a live grant on it.
+     */
+    accessGrantedByPath: boolean('access_granted_by_path').default(false).notNull(),
+    accessGrantedAt: timestamp('access_granted_at', { withTimezone: true, mode: 'string' }),
+    /** Set instead of deleting the row, so an accidental unenrol/re-enrol keeps its history. */
+    accessRevokedAt: timestamp('access_revoked_at', { withTimezone: true, mode: 'string' }),
+    status: learningPathCourseStatus().default('LOCKED').notNull(),
+    progressPercent: integer('progress_percent').default(0).notNull(),
+    lessonsCompleted: integer('lessons_completed').default(0).notNull(),
+    lessonsTotal: integer('lessons_total').default(0).notNull(),
+    exercisesCompleted: integer('exercises_completed').default(0).notNull(),
+    exercisesTotal: integer('exercises_total').default(0).notNull(),
+    unlockedAt: timestamp('unlocked_at', { withTimezone: true, mode: 'string' }),
+    startedAt: timestamp('started_at', { withTimezone: true, mode: 'string' }),
+    /** Renders as "Finished May 12" on the path hub and feeds the course funnel counts. */
+    completedAt: timestamp('completed_at', { withTimezone: true, mode: 'string' }),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' }).defaultNow()
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.learningPathMemberId],
+      foreignColumns: [learningPathMember.id],
+      name: 'learning_path_member_course_member_id_fkey'
+    }).onDelete('cascade'),
+    foreignKey({
+      columns: [table.learningPathCourseId],
+      foreignColumns: [learningPathCourse.id],
+      name: 'learning_path_member_course_path_course_id_fkey'
+    }).onDelete('cascade'),
+    // Set null rather than cascade: a teacher removing the learner from the course directly
+    // drops the grant but must not erase the path row or its progress cache.
+    foreignKey({
+      columns: [table.groupmemberId],
+      foreignColumns: [groupmember.id],
+      name: 'learning_path_member_course_groupmember_id_fkey'
+    }).onDelete('set null'),
+    unique('learning_path_member_course_member_id_path_course_id_unique').on(
+      table.learningPathMemberId,
+      table.learningPathCourseId
+    ),
+    index('idx_learning_path_member_course_member_id').on(table.learningPathMemberId),
+    index('idx_learning_path_member_course_path_course_id').on(table.learningPathCourseId),
+    // Reverse lookup from inside a course: "which paths put this learner here?"
+    index('idx_learning_path_member_course_groupmember_id').on(table.groupmemberId)
+  ]
+);
+
+/**
+ * Issued path certificates. A stored row rather than a render-time id (how standard course
+ * certificates work today) because the learner's Certificates page shows a stable id and a
+ * downloadable file, and the admin Certificate tab counts what has been awarded.
+ */
+export const learningPathCertificateIssue = pgTable(
+  'learning_path_certificate_issue',
+  {
+    id: uuid()
+      .default(sql`gen_random_uuid()`)
+      .primaryKey()
+      .notNull(),
+    learningPathId: uuid('learning_path_id').notNull(),
+    learningPathMemberId: uuid('learning_path_member_id').notNull(),
+    profileId: uuid('profile_id').notNull(),
+    /** Human-facing id shown on the certificate face, e.g. `LP-8F42-19AC`. */
+    certificateId: varchar('certificate_id').notNull(),
+    /** Frozen at issue time so a later rename of the path never rewrites history. */
+    title: text().notNull(),
+    issuer: text(),
+    issuedAt: timestamp('issued_at', { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+    status: varchar().default('valid').notNull(),
+    revokedAt: timestamp('revoked_at', { withTimezone: true, mode: 'string' }),
+    fileUrl: text('file_url')
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.learningPathId],
+      foreignColumns: [learningPath.id],
+      name: 'learning_path_certificate_issue_learning_path_id_fkey'
+    }).onDelete('cascade'),
+    foreignKey({
+      columns: [table.learningPathMemberId],
+      foreignColumns: [learningPathMember.id],
+      name: 'learning_path_certificate_issue_member_id_fkey'
+    }).onDelete('cascade'),
+    foreignKey({
+      columns: [table.profileId],
+      foreignColumns: [profile.id],
+      name: 'learning_path_certificate_issue_profile_id_fkey'
+    }).onDelete('cascade'),
+    unique('learning_path_certificate_issue_certificate_id_key').on(table.certificateId),
+    // One live certificate per membership; re-issuing updates the row rather than adding one.
+    unique('learning_path_certificate_issue_member_id_key').on(table.learningPathMemberId),
+    index('idx_learning_path_certificate_issue_profile_id').on(table.profileId),
+    index('idx_learning_path_certificate_issue_learning_path_id').on(table.learningPathId)
   ]
 );
 

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -236,6 +236,23 @@ export type TNewAiAgentRunStep = typeof schema.aiAgentRunStep.$inferInsert;
 export type TAiAgentRunEvent = typeof schema.aiAgentRunEvent.$inferSelect;
 export type TNewAiAgentRunEvent = typeof schema.aiAgentRunEvent.$inferInsert;
 
+// ─── Learning paths ──────────────────────────────────────────────────────────
+
+export type TLearningPath = typeof schema.learningPath.$inferSelect;
+export type TNewLearningPath = typeof schema.learningPath.$inferInsert;
+
+export type TLearningPathCourse = typeof schema.learningPathCourse.$inferSelect;
+export type TNewLearningPathCourse = typeof schema.learningPathCourse.$inferInsert;
+
+export type TLearningPathMember = typeof schema.learningPathMember.$inferSelect;
+export type TNewLearningPathMember = typeof schema.learningPathMember.$inferInsert;
+
+export type TLearningPathMemberCourse = typeof schema.learningPathMemberCourse.$inferSelect;
+export type TNewLearningPathMemberCourse = typeof schema.learningPathMemberCourse.$inferInsert;
+
+export type TLearningPathCertificateIssue = typeof schema.learningPathCertificateIssue.$inferSelect;
+export type TNewLearningPathCertificateIssue = typeof schema.learningPathCertificateIssue.$inferInsert;
+
 // ─── Job state ───────────────────────────────────────────────────────────────
 
 export type TJobStatus = (typeof schema.jobStatus.enumValues)[number];

--- a/packages/utils/src/constants/index.ts
+++ b/packages/utils/src/constants/index.ts
@@ -4,6 +4,7 @@ export * from './content';
 export * from './course-type';
 export * from './domains';
 export * from './embeds';
+export * from './learning-path';
 export * from './lesson-version';
 export * from './error-codes';
 export * from './b64-envelope';

--- a/packages/utils/src/constants/learning-path.ts
+++ b/packages/utils/src/constants/learning-path.ts
@@ -1,0 +1,24 @@
+/** Postgres `LEARNING_PATH_STATUS` enum values — shared by Drizzle schema and Zod validation. */
+export const LEARNING_PATH_STATUS_VALUES = ['ACTIVE', 'DRAFT', 'ARCHIVED'] as const;
+
+export type TLearningPathStatus = (typeof LEARNING_PATH_STATUS_VALUES)[number];
+
+/** Postgres `LEARNING_PATH_DIFFICULTY` enum values — powers the Difficulty filter and the public stats row. */
+export const LEARNING_PATH_DIFFICULTY_VALUES = ['BEGINNER', 'INTERMEDIATE', 'ADVANCED'] as const;
+
+export type TLearningPathDifficulty = (typeof LEARNING_PATH_DIFFICULTY_VALUES)[number];
+
+/** How much of a path a non-enrolled visitor may explore on the public path page. */
+export const LEARNING_PATH_VISITOR_ACCESS_VALUES = ['teaser', 'syllabus', 'preview'] as const;
+
+export type TLearningPathVisitorAccess = (typeof LEARNING_PATH_VISITOR_ACCESS_VALUES)[number];
+
+/** Postgres `LEARNING_PATH_MEMBER_STATUS` enum values — a member's rolled-up progress through a path. */
+export const LEARNING_PATH_MEMBER_STATUS_VALUES = ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] as const;
+
+export type TLearningPathMemberStatus = (typeof LEARNING_PATH_MEMBER_STATUS_VALUES)[number];
+
+/** Postgres `LEARNING_PATH_COURSE_STATUS` enum values — one member's state on one course of a path. */
+export const LEARNING_PATH_COURSE_STATUS_VALUES = ['LOCKED', 'NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] as const;
+
+export type TLearningPathCourseStatus = (typeof LEARNING_PATH_COURSE_STATUS_VALUES)[number];

--- a/packages/utils/src/validation/index.ts
+++ b/packages/utils/src/validation/index.ts
@@ -8,6 +8,7 @@ export * from './assets';
 export * from './course';
 export * from './course-import';
 export * from './exercise';
+export * from './learning-path';
 export * from './lesson';
 export * from './mail';
 export * from './media';

--- a/packages/utils/src/validation/learning-path/index.ts
+++ b/packages/utils/src/validation/learning-path/index.ts
@@ -1,0 +1,1 @@
+export * from './learning-path';

--- a/packages/utils/src/validation/learning-path/learning-path.ts
+++ b/packages/utils/src/validation/learning-path/learning-path.ts
@@ -1,0 +1,135 @@
+import * as z from 'zod';
+
+import {
+  LEARNING_PATH_DIFFICULTY_VALUES,
+  LEARNING_PATH_STATUS_VALUES,
+  LEARNING_PATH_VISITOR_ACCESS_VALUES
+} from '../../constants/learning-path';
+import { ROLE } from '../../constants/roles';
+
+export const ZLearningPathStatus = z.enum(LEARNING_PATH_STATUS_VALUES);
+export const ZLearningPathDifficulty = z.enum(LEARNING_PATH_DIFFICULTY_VALUES);
+export const ZLearningPathVisitorAccess = z.enum(LEARNING_PATH_VISITOR_ACCESS_VALUES);
+
+const ZLearningPathTestimonial = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1).max(120),
+  role: z.string().max(160).optional(),
+  avatarUrl: z.string().url().optional(),
+  quote: z.string().min(1).max(1000)
+});
+
+const ZLearningPathFaq = z.object({
+  id: z.string().min(1),
+  question: z.string().min(1).max(300),
+  answer: z.string().min(1).max(2000)
+});
+
+export const ZLearningPathLandingPage = z.object({
+  headline: z.string().max(160).optional(),
+  subheadline: z.string().max(600).optional(),
+  visitorAccess: ZLearningPathVisitorAccess.optional(),
+  outcomes: z.array(z.string().min(1).max(300)).max(12).optional(),
+  skills: z.array(z.string().min(1).max(60)).max(24).optional(),
+  showInstructors: z.boolean().optional(),
+  showTestimonials: z.boolean().optional(),
+  testimonials: z.array(ZLearningPathTestimonial).max(24).optional(),
+  showFaqs: z.boolean().optional(),
+  faqs: z.array(ZLearningPathFaq).max(24).optional(),
+  showRating: z.boolean().optional(),
+  rating: z.object({ average: z.number().min(0).max(5), count: z.number().int().min(0) }).optional()
+});
+export type TLearningPathLandingPage = z.infer<typeof ZLearningPathLandingPage>;
+
+export const ZLearningPathCertificateDesign = z.object({
+  templateId: z.enum(['classique', 'brutalist', 'noir', 'poster', 'minimal']).optional(),
+  accentColor: z.string().max(40).optional(),
+  subtitle: z.string().max(160).optional(),
+  descriptionOverride: z.string().max(600).optional(),
+  signatories: z
+    .array(
+      z.object({
+        name: z.string().max(120),
+        role: z.string().max(120),
+        enabled: z.boolean().optional(),
+        signatureUrl: z.string().url().optional()
+      })
+    )
+    .max(2)
+    .optional(),
+  idFormat: z.string().max(60).optional()
+});
+export type TLearningPathCertificateDesign = z.infer<typeof ZLearningPathCertificateDesign>;
+
+export const ZCreateLearningPath = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).optional(),
+  slug: z
+    .string()
+    .min(1)
+    .max(255)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Use lowercase letters, numbers, and hyphens')
+    .optional()
+});
+export type TCreateLearningPath = z.infer<typeof ZCreateLearningPath>;
+
+export const ZUpdateLearningPath = z.object({
+  name: z.string().min(1).max(255).optional(),
+  slug: z
+    .string()
+    .min(1)
+    .max(255)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Use lowercase letters, numbers, and hyphens')
+    .optional(),
+  description: z.string().max(2000).nullable().optional(),
+  coverImage: z.string().url().nullable().optional(),
+  status: ZLearningPathStatus.optional(),
+  difficulty: ZLearningPathDifficulty.nullable().optional(),
+  estimatedDurationMinutes: z.number().int().min(0).max(100000).nullable().optional(),
+  cost: z.number().int().min(0).optional(),
+  currency: z.string().length(3).optional(),
+  showSavings: z.boolean().optional(),
+  sequentialUnlock: z.boolean().optional(),
+  selfEnrollment: z.boolean().optional(),
+  autoEnroll: z.boolean().optional(),
+  certificateEnabled: z.boolean().optional(),
+  certificateTitle: z.string().max(255).nullable().optional(),
+  certificateIssuer: z.string().max(255).nullable().optional(),
+  certificateDesign: ZLearningPathCertificateDesign.optional(),
+  landingPage: ZLearningPathLandingPage.optional()
+});
+export type TUpdateLearningPath = z.infer<typeof ZUpdateLearningPath>;
+
+export const ZAddCourseToLearningPath = z.object({
+  courseId: z.string().uuid(),
+  outcomes: z.array(z.string().min(1).max(300)).max(8).optional()
+});
+export type TAddCourseToLearningPath = z.infer<typeof ZAddCourseToLearningPath>;
+
+export const ZUpdateLearningPathCourse = z.object({
+  outcomes: z.array(z.string().min(1).max(300)).max(8)
+});
+export type TUpdateLearningPathCourse = z.infer<typeof ZUpdateLearningPathCourse>;
+
+/** Full ordered list of the path's courses — reordering rewrites every position at once. */
+export const ZReorderLearningPathCourses = z.object({
+  courseIds: z.array(z.string().uuid()).min(1)
+});
+export type TReorderLearningPathCourses = z.infer<typeof ZReorderLearningPathCourses>;
+
+export const ZAddLearningPathMembers = z.object({
+  members: z
+    .array(
+      z.object({
+        profileId: z.string().uuid().optional(),
+        email: z.string().email().optional(),
+        name: z.string().optional(),
+        roleId: z.union([z.literal(ROLE.TUTOR), z.literal(ROLE.STUDENT)])
+      })
+    )
+    .min(1)
+    .refine((members) => members.every((member) => member.profileId || member.email), {
+      message: 'Each member must include a profileId or email'
+    })
+});
+export type TAddLearningPathMembers = z.infer<typeof ZAddLearningPathMembers>;

--- a/prd/learning-paths/README.md
+++ b/prd/learning-paths/README.md
@@ -195,6 +195,31 @@ Let orgs package multiple courses into an **ordered, sequentially unlocked, bund
 - Students: read path data they're members of; public endpoints serve ACTIVE paths only.
 - DRAFT paths: admin/tutor only. ARCHIVED: hidden everywhere, data preserved.
 
+#### Access & progression when a course is both standalone and inside a path
+
+A course can be sold on its own *and* be step 3 of a path, and a learner may already have been enrolled in it long before the path existed. Two rules settle every case:
+
+**1. One progression, always shared.** A learner has exactly one enrolment and one progress record per course, no matter how many paths contain it. There is no path-scoped copy of a course, no second set of lesson completions, no "path version" of a certificate. Consequences, all intended:
+
+- A course the learner finished standalone last year shows as **already complete** the moment they enrol in the path, and immediately counts toward path completion and toward unlocking the next course.
+- Work done inside the path counts outside it. Finishing step 3 within the path earns the ordinary course certificate too.
+- A learner enrolled in two paths that share a course sees one progression in both.
+
+This matches how Coursera Specializations behave (a course completed on its own counts toward the Specialization) and how Docebo learning plans derive plan status from the underlying course enrolment statuses. The alternative — requiring learners to re-take a course *through* the path for it to count, as Coursera's enterprise learning paths do — is the behaviour to avoid: it makes learners repeat work they have already done, and it is the single most common complaint about path features in other LMSs.
+
+**2. Access is granted through `groupmember`, with provenance recorded.** Enrolling in a path inserts ordinary `groupmember` rows, the same way cohorts already do (`insertGroupMembersOnConflictDoNothing`). The course side needs no knowledge of paths: `isUserCourseMemberOrOrgAdmin` keeps working unchanged.
+
+What a bare `groupmember` row cannot express is *why* the learner is there, so `learning_path_member_course` records it:
+
+- `groupmemberId` — which course enrolment this path step is attached to.
+- `accessGrantedByPath` — TRUE when path enrolment created that row, FALSE when the learner already had their own enrolment and the path merely adopted it.
+
+That single boolean answers both directions of the question. From the course: join `groupmember → learning_path_member_course → learning_path` to list who is here because of a path, and who enrolled directly. From the path: know whether unenrolling may take course access away.
+
+**Access is the union of grants, and revocation is conservative.** Several paths may point at the same `groupmember` row. Removing a learner from a path sets `accessRevokedAt` and deletes the `groupmember` row *only* when `accessGrantedByPath` is TRUE and no other path holds a live grant on it. A learner who bought the course directly never loses it by leaving a path. This mirrors Moodle's enrolment-instance model, where a user can hold several enrolment rows in one course from different methods and access is the union of them.
+
+**Sequential unlock gates the grant, not just the UI.** Under `sequentialUnlock`, the `groupmember` row for a later course is not created until that course unlocks — locked means genuinely no access, not a hidden link. Under `autoEnroll` with sequential unlock off, all rows are created at enrolment time.
+
 ---
 
 ## Technical Design
@@ -203,34 +228,67 @@ Let orgs package multiple courses into an **ordered, sequentially unlocked, bund
 
 ```
 learning_path
-  id uuid PK · organizationId FK(organization, cascade) · name varchar · slug varchar (unique per org)
+  id uuid PK · organizationId FK(organization, cascade) · name varchar · slug varchar
   description text · coverImage text · status LEARNING_PATH_STATUS default 'DRAFT'
-  cost numeric · currency varchar default 'USD' · showSavings boolean default true
+  difficulty LEARNING_PATH_DIFFICULTY nullable      -- Difficulty filter + public stats row
+  estimatedDurationMinutes integer nullable          -- "~38 hours"; Duration filter buckets
+  cost bigint default 0 · currency varchar default 'USD' · showSavings boolean default true
   sequentialUnlock boolean default true · selfEnrollment boolean default true · autoEnroll boolean default true
   certificateEnabled boolean default true · certificateTitle text · certificateIssuer text
+  certificateDesign jsonb   -- mirrors course.certificate.design so @cio/certificates can render it
   landingPage jsonb  -- { headline, subheadline, visitorAccess: 'teaser'|'syllabus'|'preview',
                      --   outcomes: string[], skills: string[], showInstructors, testimonials: [...],
-                     --   showTestimonials, faqs: [...], showFaqs }
+                     --   showTestimonials, faqs: [...], showFaqs, showRating, rating }
   visitorAccess is inside landingPage; no relational IDs inside the jsonb (per repo rule)
+  courseOrderSetAt timestamptz nullable   -- only setup-checklist step not derivable from data
   createdByProfileId FK(profile) · createdAt / updatedAt
+  unique(organizationId, slug) · index(organizationId) · index(organizationId, status)
 
 learning_path_course
-  id uuid PK · pathId FK(learning_path, cascade) · courseId FK(course, cascade)
+  id uuid PK · learningPathId FK(learning_path, cascade) · courseId FK(course, cascade)
   order integer NOT NULL          -- 1-based position; the gating sequence
-  unique(pathId, courseId) · unique(pathId, order) · index(pathId)
+  outcomes jsonb default []       -- per-course bullets on the public path page
+  addedAt timestamptz
+  unique(pathId, courseId) · index(pathId, order) · index(courseId)
+  -- NOT unique(pathId, order): reordering rewrites every row in one transaction and a
+  -- non-deferrable unique index rejects the intermediate states of a swap.
 
 learning_path_member
-  id uuid PK · pathId FK(learning_path, cascade) · profileId FK(profile) · roleId FK(role)
-  enrolledAt timestamptz · completedAt timestamptz nullable
-  certificateIssuedAt timestamptz nullable · certificateId varchar nullable
-  unique(pathId, profileId) · index(pathId) · index(profileId)
+  id uuid PK · learningPathId FK(learning_path, cascade) · profileId FK(profile) nullable · email text
+  roleId FK(role) · enrolledAt · startedAt · completedAt timestamptz nullable
+  -- rollup cache, recomputed alongside unlock evaluation; never source of truth:
+  status LEARNING_PATH_MEMBER_STATUS · progressPercent integer · completedCourseCount integer
+  currentCourseId FK(course, set null) · lastActivityAt timestamptz
+  unique(pathId, profileId) · unique(pathId, email) · index(pathId) · index(profileId)
+
+learning_path_member_course
+  id uuid PK · learningPathMemberId FK(cascade) · learningPathCourseId FK(cascade)
+  -- access provenance (see "Access & progression" above):
+  groupmemberId FK(groupmember, set null) nullable
+  accessGrantedByPath boolean default false · accessGrantedAt · accessRevokedAt timestamptz nullable
+  -- progress cache of the shared course record:
+  status LEARNING_PATH_COURSE_STATUS default 'LOCKED' · progressPercent integer
+  lessonsCompleted / lessonsTotal / exercisesCompleted / exercisesTotal integer
+  unlockedAt · startedAt · completedAt · updatedAt timestamptz
+  unique(memberId, pathCourseId) · index(memberId) · index(pathCourseId) · index(groupmemberId)
+
+learning_path_certificate_issue
+  id uuid PK · learningPathId FK(cascade) · learningPathMemberId FK(cascade) · profileId FK(cascade)
+  certificateId varchar UNIQUE     -- LP-8F42-19AC, shown on the learner's Certificates page
+  title text · issuer text         -- frozen at issue time
+  issuedAt · status default 'valid' · revokedAt · fileUrl
+  unique(learningPathMemberId)
 
 enum LEARNING_PATH_STATUS: ACTIVE | DRAFT | ARCHIVED
+enum LEARNING_PATH_DIFFICULTY: BEGINNER | INTERMEDIATE | ADVANCED
+enum LEARNING_PATH_MEMBER_STATUS: NOT_STARTED | IN_PROGRESS | COMPLETED
+enum LEARNING_PATH_COURSE_STATUS: LOCKED | NOT_STARTED | IN_PROGRESS | COMPLETED
 ```
 
 Notes:
-- No denormalized progress on `learning_path_member` beyond `completedAt`; per-course progress is computed from existing lesson-completion + exercise-submission data (already queried for course cards).
+- The progress columns on `learning_path_member` and `learning_path_member_course` are a **cache** of lesson-completion + exercise-submission data, not a second copy of it. They exist because People, My Learning, the admin listing, and the analytics funnel all rank, filter, and aggregate by them. Any read may recompute; nothing may diverge.
 - Savings figure is computed at read time from the sum of `course.cost` over path courses — never stored.
+- `estimatedDurationMinutes` and `difficulty` are stored because nothing derivable backs them: courses carry no duration or difficulty column of their own.
 - Schema work stops at a passing `@cio/db` build; migrations are handled outside this workflow.
 
 ### Completion / unlock logic (service layer)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the database schema for Learning Paths, derived from `prd/learning-paths/README.md` and the prototypes in `prototypes/learning-paths/` (per the PRD, the prototype wins on any UI detail).

## Tables

- `learning_path` — org-scoped, slug-unique, status/difficulty/duration, bundle pricing, the three enrollment-and-flow switches, certificate config, and the landing-page jsonb blob.
- `learning_path_course` — ordered membership plus per-course marketing outcomes. `order` is deliberately *not* uniquely constrained: reordering rewrites every row in one transaction and a non-deferrable unique index rejects the intermediate states of a swap.
- `learning_path_member` — enrollment plus a clearly labelled rollup cache (status, progress, completed-course count, current course, last activity) that People, My Learning, the admin listing and analytics all filter and rank by.
- `learning_path_member_course` — access provenance and the per-course progress projection.
- `learning_path_certificate_issue` — issued certificates, because the learner's Certificates page shows a stable `LP-XXXX-XXXX` id and a downloadable file.

## Access and progression

A course can be sold standalone *and* be step 3 of a path, and a learner may already have been enrolled before the path existed. Two rules:

**One progression, always shared.** One `groupmember` row and one progress record per learner per course regardless of how many paths contain it. A course finished standalone counts as complete the moment the learner enrolls in the path, and work done inside the path counts outside it. This matches Coursera Specializations and Docebo learning plans; it avoids the Coursera-enterprise behaviour where a course only counts if you took it *through* the path.

**Access flows through `groupmember`, with provenance recorded.** Path enrollment inserts ordinary `groupmember` rows, exactly like cohorts already do, so `isUserCourseMemberOrOrgAdmin` is unchanged. `learning_path_member_course.groupmemberId` plus `accessGrantedByPath` record what a bare `groupmember` row cannot: whether the path is the reason the learner has access. Unenrolling deletes the `groupmember` row only when the path created it and no other path holds a live grant, so a directly-enrolled learner never loses a course by leaving a path. This mirrors Moodle's enrolment-instance model, where access is the union of grants.

## Also included

- `LEARNING_PATH_*` enum value constants in `@cio/utils`, shared with the Drizzle `pgEnum`s.
- Inferred row types in `packages/db/src/types.ts` and Drizzle `relations()` blocks.
- Zod schemas under `packages/utils/src/validation/learning-path/`.
- The PRD's Technical Design data model updated to match, and a new "Access & progression" subsection under Access control.

No migration is included — the PRD scopes this workflow to a passing `@cio/db` build, with migrations handled separately. Generation was run locally to confirm the schema produces valid SQL, then discarded.

## Verification

`pnpm --filter @cio/utils build`, `pnpm --filter @cio/db build`, `npx drizzle-kit generate` and `pnpm format:check` all pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0909e-2824-7952-82b3-f6861c127546?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0909e-2824-7952-82b3-f6861c127546&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

