### PR TITLE
fix(api): hide other students' scores on the course marks page

### DIFF
--- a/apps/api/src/__tests__/gradebook-privacy.test.ts
+++ b/apps/api/src/__tests__/gradebook-privacy.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@cio/db/queries/mark', () => ({
+  getMarksByCourseId: vi.fn()
+}));
+
+vi.mock('@cio/db/queries/course/people', () => ({
+  getCourseMembers: vi.fn(),
+  getCourseMember: vi.fn()
+}));
+
+vi.mock('@cio/db/queries/course', () => ({
+  getCourseWithRelations: vi.fn()
+}));
+
+vi.mock('@cio/db/queries/group', () => ({
+  isCourseTeamMemberOrOrgAdmin: vi.fn(),
+  getGroupMemberIdByCourseAndProfile: vi.fn()
+}));
+
+import { ROLE } from '@cio/utils/constants';
+import { getMarksByCourseId, type Mark } from '@cio/db/queries/mark';
+import { getCourseMember, getCourseMembers, type CourseMemberWithProfile } from '@cio/db/queries/course/people';
+import { getCourseWithRelations } from '@cio/db/queries/course';
+import { getGroupMemberIdByCourseAndProfile, isCourseTeamMemberOrOrgAdmin } from '@cio/db/queries/group';
+import { getGradebook } from '@api/services/mark/gradebook';
+import { getMarks } from '@api/services/mark';
+
+const COURSE_ID = 'course-1';
+const STUDENT_PROFILE_ID = 'profile-student-1';
+const OTHER_STUDENT_PROFILE_ID = 'profile-student-2';
+const INSTRUCTOR_PROFILE_ID = 'profile-instructor-1';
+const STUDENT_MEMBER_ID = 'member-student-1';
+const OTHER_STUDENT_MEMBER_ID = 'member-student-2';
+
+function member(
+  overrides: Partial<CourseMemberWithProfile> & Pick<CourseMemberWithProfile, 'id' | 'profileId' | 'roleId'>
+): CourseMemberWithProfile {
+  return {
+    email: null,
+    groupId: 'group-1',
+    createdAt: null,
+    certificateEarnedAt: null,
+    certificationEmailSentAt: null,
+    profile: {
+      id: overrides.profileId ?? 'profile',
+      fullname: 'Student',
+      username: null,
+      avatarUrl: null,
+      email: 'student@test.com'
+    },
+    ...overrides
+  } as CourseMemberWithProfile;
+}
+
+function mark(overrides: Partial<Mark> & Pick<Mark, 'exerciseId' | 'groupmemberId'>): Mark {
+  return {
+    courseId: COURSE_ID,
+    exerciseTitle: 'Quiz',
+    exercisePoints: 10,
+    statusId: 3,
+    totalPointsGotten: 8,
+    ...overrides
+  };
+}
+
+const studentOne = member({
+  id: STUDENT_MEMBER_ID,
+  profileId: STUDENT_PROFILE_ID,
+  roleId: ROLE.STUDENT,
+  profile: {
+    id: STUDENT_PROFILE_ID,
+    fullname: 'Ada Student',
+    username: 'ada',
+    avatarUrl: null,
+    email: 'ada@test.com'
+  }
+});
+
+const studentTwo = member({
+  id: OTHER_STUDENT_MEMBER_ID,
+  profileId: OTHER_STUDENT_PROFILE_ID,
+  roleId: ROLE.STUDENT,
+  profile: {
+    id: OTHER_STUDENT_PROFILE_ID,
+    fullname: 'Other Student',
+    username: 'other',
+    avatarUrl: null,
+    email: 'other@test.com'
+  }
+});
+
+const instructor = member({
+  id: 'member-instructor-1',
+  profileId: INSTRUCTOR_PROFILE_ID,
+  roleId: ROLE.TUTOR,
+  profile: {
+    id: INSTRUCTOR_PROFILE_ID,
+    fullname: 'Tutor',
+    username: 'tutor',
+    avatarUrl: null,
+    email: 'tutor@test.com'
+  }
+});
+
+const allMarks: Mark[] = [
+  mark({ exerciseId: 'ex-1', groupmemberId: STUDENT_MEMBER_ID, totalPointsGotten: 9, exerciseTitle: 'Quiz 1' }),
+  mark({ exerciseId: 'ex-1', groupmemberId: OTHER_STUDENT_MEMBER_ID, totalPointsGotten: 4, exerciseTitle: 'Quiz 1' }),
+  mark({ exerciseId: 'ex-2', groupmemberId: STUDENT_MEMBER_ID, totalPointsGotten: 10, exerciseTitle: 'Quiz 2' }),
+  mark({ exerciseId: 'ex-2', groupmemberId: OTHER_STUDENT_MEMBER_ID, totalPointsGotten: 2, exerciseTitle: 'Quiz 2' })
+];
+
+const studentOwnMarks = allMarks.filter((row) => row.groupmemberId === STUDENT_MEMBER_ID);
+
+describe('gradebook privacy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getCourseWithRelations).mockResolvedValue(null);
+  });
+
+  it('returns every student and score to instructors', async () => {
+    vi.mocked(isCourseTeamMemberOrOrgAdmin).mockResolvedValue(true);
+    vi.mocked(getMarksByCourseId).mockResolvedValue(allMarks);
+    vi.mocked(getCourseMembers).mockResolvedValue([studentOne, studentTwo, instructor]);
+
+    const gradebook = await getGradebook(COURSE_ID, INSTRUCTOR_PROFILE_ID);
+
+    expect(getGroupMemberIdByCourseAndProfile).not.toHaveBeenCalled();
+    expect(getCourseMember).not.toHaveBeenCalled();
+    expect(getMarksByCourseId).toHaveBeenCalledWith(COURSE_ID);
+    expect(gradebook.students.map((row) => row.id)).toEqual([STUDENT_MEMBER_ID, OTHER_STUDENT_MEMBER_ID]);
+    expect(gradebook.studentMarksByExerciseId).toEqual({
+      [STUDENT_MEMBER_ID]: { 'ex-1': '9', 'ex-2': '10' },
+      [OTHER_STUDENT_MEMBER_ID]: { 'ex-1': '4', 'ex-2': '2' }
+    });
+  });
+
+  it('returns only the viewing student and their scores to students', async () => {
+    vi.mocked(isCourseTeamMemberOrOrgAdmin).mockResolvedValue(false);
+    vi.mocked(getGroupMemberIdByCourseAndProfile).mockResolvedValue(STUDENT_MEMBER_ID);
+    vi.mocked(getMarksByCourseId).mockResolvedValue(studentOwnMarks);
+    vi.mocked(getCourseMember).mockResolvedValue(studentOne);
+
+    const gradebook = await getGradebook(COURSE_ID, STUDENT_PROFILE_ID);
+
+    expect(getCourseMembers).not.toHaveBeenCalled();
+    expect(getMarksByCourseId).toHaveBeenCalledWith(COURSE_ID, STUDENT_MEMBER_ID);
+    expect(getCourseMember).toHaveBeenCalledWith(COURSE_ID, STUDENT_MEMBER_ID);
+    expect(gradebook.students).toEqual([studentOne]);
+    expect(gradebook.studentMarksByExerciseId).toEqual({
+      [STUDENT_MEMBER_ID]: { 'ex-1': '9', 'ex-2': '10' }
+    });
+    expect(gradebook.studentMarksByExerciseId[OTHER_STUDENT_MEMBER_ID]).toBeUndefined();
+  });
+
+  it('strips other learners from a student gradebook even if marks leak from the query', async () => {
+    vi.mocked(isCourseTeamMemberOrOrgAdmin).mockResolvedValue(false);
+    vi.mocked(getGroupMemberIdByCourseAndProfile).mockResolvedValue(STUDENT_MEMBER_ID);
+    vi.mocked(getMarksByCourseId).mockResolvedValue(allMarks);
+    vi.mocked(getCourseMember).mockResolvedValue(studentOne);
+
+    const gradebook = await getGradebook(COURSE_ID, STUDENT_PROFILE_ID);
+
+    expect(gradebook.students.map((row) => row.id)).toEqual([STUDENT_MEMBER_ID]);
+    expect(Object.keys(gradebook.studentMarksByExerciseId)).toEqual([STUDENT_MEMBER_ID]);
+    expect(gradebook.studentMarksByExerciseId[OTHER_STUDENT_MEMBER_ID]).toBeUndefined();
+  });
+
+  it('returns an empty student gradebook when the viewer has no course membership row', async () => {
+    vi.mocked(isCourseTeamMemberOrOrgAdmin).mockResolvedValue(false);
+    vi.mocked(getGroupMemberIdByCourseAndProfile).mockResolvedValue(null);
+
+    const gradebook = await getGradebook(COURSE_ID, STUDENT_PROFILE_ID);
+
+    expect(getMarksByCourseId).not.toHaveBeenCalled();
+    expect(getCourseMembers).not.toHaveBeenCalled();
+    expect(gradebook.students).toEqual([]);
+    expect(gradebook.studentMarksByExerciseId).toEqual({});
+  });
+});
+
+describe('getMarks privacy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns every mark to instructors', async () => {
+    vi.mocked(isCourseTeamMemberOrOrgAdmin).mockResolvedValue(true);
+    vi.mocked(getMarksByCourseId).mockResolvedValue(allMarks);
+
+    const marks = await getMarks(COURSE_ID, INSTRUCTOR_PROFILE_ID);
+
+    expect(getGroupMemberIdByCourseAndProfile).not.toHaveBeenCalled();
+    expect(getMarksByCourseId).toHaveBeenCalledWith(COURSE_ID);
+    expect(marks).toEqual(allMarks);
+  });
+
+  it('requests only the viewing student marks', async () => {
+    vi.mocked(isCourseTeamMemberOrOrgAdmin).mockResolvedValue(false);
+    vi.mocked(getGroupMemberIdByCourseAndProfile).mockResolvedValue(STUDENT_MEMBER_ID);
+    vi.mocked(getMarksByCourseId).mockResolvedValue(studentOwnMarks);
+
+    const marks = await getMarks(COURSE_ID, STUDENT_PROFILE_ID);
+
+    expect(getMarksByCourseId).toHaveBeenCalledWith(COURSE_ID, STUDENT_MEMBER_ID);
+    expect(marks.every((row) => row.groupmemberId === STUDENT_MEMBER_ID)).toBe(true);
+  });
+
+  it('returns no marks when a student has no course membership row', async () => {
+    vi.mocked(isCourseTeamMemberOrOrgAdmin).mockResolvedValue(false);
+    vi.mocked(getGroupMemberIdByCourseAndProfile).mockResolvedValue(null);
+
+    const marks = await getMarks(COURSE_ID, STUDENT_PROFILE_ID);
+
+    expect(getMarksByCourseId).not.toHaveBeenCalled();
+    expect(marks).toEqual([]);
+  });
+});

--- a/apps/api/src/routes/course/mark.ts
+++ b/apps/api/src/routes/course/mark.ts
@@ -8,8 +8,9 @@ import { handleError } from '@api/utils/errors';
 export const markRouter = new Hono()
   .get('/gradebook', authMiddleware, courseMemberMiddleware, async (c) => {
     try {
+      const user = c.get('user')!;
       const courseId = c.req.param('courseId')!;
-      const gradebook = await getGradebook(courseId);
+      const gradebook = await getGradebook(courseId, user.id);
       return c.json({ success: true, data: gradebook }, 200);
     } catch (error) {
       return handleError(c, error, 'Failed to get gradebook');
@@ -17,8 +18,9 @@ export const markRouter = new Hono()
   })
   .get('/', authMiddleware, courseMemberMiddleware, async (c) => {
     try {
+      const user = c.get('user')!;
       const courseId = c.req.param('courseId')!;
-      const marks = await getMarks(courseId);
+      const marks = await getMarks(courseId, user.id);
 
       return c.json({ success: true, data: marks }, 200);
     } catch (error) {

--- a/apps/api/src/services/mark/gradebook.ts
+++ b/apps/api/src/services/mark/gradebook.ts
@@ -1,9 +1,10 @@
 import { ContentType, ROLE } from '@cio/utils/constants';
 import { getMarksByCourseId, type Mark } from '@cio/db/queries/mark';
-import { getCourseMembers } from '@cio/db/queries/course/people';
+import { getCourseMember, getCourseMembers, type CourseMemberWithProfile } from '@cio/db/queries/course/people';
 import { getCourseWithRelations } from '@cio/db/queries/course';
 import { buildCourseContent, type CourseContentItem } from '@api/services/course/utils';
 import { AppError, ErrorCodes } from '@api/utils/errors';
+import { resolveMarksViewerScope } from './mark';
 
 export type GradebookExercise = {
   id: string;
@@ -14,7 +15,7 @@ export type GradebookExercise = {
 export type GradebookStudentMarks = Record<string, Record<string, string>>;
 
 export type GradebookResponse = {
-  students: Awaited<ReturnType<typeof getCourseMembers>>;
+  students: CourseMemberWithProfile[];
   exercises: GradebookExercise[];
   studentMarksByExerciseId: GradebookStudentMarks;
 };
@@ -61,34 +62,86 @@ function buildExercises(marks: Mark[], contentItems: CourseContentItem[]): Grade
     const fromMarks = marksByExerciseId.get(id)!;
     return {
       id,
-      title: fromMarks?.title ?? '',
-      points: fromMarks?.points ?? 0
+      title: fromMarks.title ?? '',
+      points: fromMarks.points ?? 0
     };
   });
 }
 
+function scopeStudentMarksToMember(
+  studentMarksByExerciseId: GradebookStudentMarks,
+  groupMemberId: string | null
+): GradebookStudentMarks {
+  if (!groupMemberId) {
+    return {};
+  }
+
+  const ownMarks = studentMarksByExerciseId[groupMemberId];
+  if (!ownMarks) {
+    return {};
+  }
+
+  return { [groupMemberId]: ownMarks };
+}
+
+async function loadGradebookStudents(
+  courseId: string,
+  canViewAllMarks: boolean,
+  groupMemberId: string | null
+): Promise<CourseMemberWithProfile[]> {
+  if (canViewAllMarks) {
+    const members = await getCourseMembers(courseId);
+    return members.filter((member) => Number(member.roleId) === ROLE.STUDENT);
+  }
+
+  if (!groupMemberId) {
+    return [];
+  }
+
+  const member = await getCourseMember(courseId, groupMemberId);
+  if (!member || Number(member.roleId) !== ROLE.STUDENT) {
+    return [];
+  }
+
+  return [member];
+}
+
+function flattenCourseContentItems(course: Awaited<ReturnType<typeof getCourseWithRelations>>): CourseContentItem[] {
+  if (course?.contentItems == null) {
+    return [];
+  }
+
+  const isGrouping = course.metadata?.isContentGroupingEnabled ?? true;
+  const content = buildCourseContent(course.contentItems, isGrouping);
+  return content.grouped ? (content.sections ?? []).flatMap((section) => section.items ?? []) : (content.items ?? []);
+}
+
 /**
- * Returns all data needed to render the marks gradebook: students, exercises in order, and marks per student per exercise.
+ * Returns data needed to render the marks gradebook: students, exercises in order,
+ * and marks per student per exercise.
+ *
+ * Instructors see every learner. Students only receive their own row and scores.
  */
-export async function getGradebook(courseId: string): Promise<GradebookResponse> {
+export async function getGradebook(courseId: string, profileId: string): Promise<GradebookResponse> {
   try {
-    const [marks, members, course] = await Promise.all([
-      getMarksByCourseId(courseId),
-      getCourseMembers(courseId),
-      getCourseWithRelations(courseId)
-    ]);
+    const { canViewAllMarks, groupMemberId } = await resolveMarksViewerScope(courseId, profileId);
 
-    const students = members.filter((m) => Number(m.roleId) === ROLE.STUDENT);
+    const marksPromise = canViewAllMarks
+      ? getMarksByCourseId(courseId)
+      : groupMemberId
+        ? getMarksByCourseId(courseId, groupMemberId)
+        : Promise.resolve([] as Mark[]);
+    const studentsPromise = loadGradebookStudents(courseId, canViewAllMarks, groupMemberId);
+    const coursePromise = getCourseWithRelations(courseId);
 
-    let contentItems: CourseContentItem[] = [];
-    if (course?.contentItems != null) {
-      const isGrouping = course.metadata?.isContentGroupingEnabled ?? true;
-      const content = buildCourseContent(course.contentItems, isGrouping);
-      contentItems = content.grouped ? (content.sections ?? []).flatMap((s) => s.items ?? []) : (content.items ?? []);
-    }
+    const [marks, students, course] = await Promise.all([marksPromise, studentsPromise, coursePromise]);
 
+    const contentItems = flattenCourseContentItems(course);
     const exercises = buildExercises(marks, contentItems);
-    const studentMarksByExerciseId = buildStudentMarksByExerciseId(marks);
+    const allStudentMarksByExerciseId = buildStudentMarksByExerciseId(marks);
+    const studentMarksByExerciseId = canViewAllMarks
+      ? allStudentMarksByExerciseId
+      : scopeStudentMarksToMember(allStudentMarksByExerciseId, groupMemberId);
 
     return {
       students,

--- a/apps/api/src/services/mark/mark.ts
+++ b/apps/api/src/services/mark/mark.ts
@@ -1,15 +1,47 @@
 import { AppError, ErrorCodes } from '@api/utils/errors';
 import { getMarksByCourseId } from '@cio/db/queries/mark';
+import { getGroupMemberIdByCourseAndProfile, isCourseTeamMemberOrOrgAdmin } from '@cio/db/queries/group';
+
+export type MarksViewerScope = {
+  canViewAllMarks: boolean;
+  groupMemberId: string | null;
+};
+
+/**
+ * Instructors (course admin/tutor or org admin) may see every learner's scores.
+ * Students are scoped to their own group membership.
+ */
+export async function resolveMarksViewerScope(courseId: string, profileId: string): Promise<MarksViewerScope> {
+  const canViewAllMarks = await isCourseTeamMemberOrOrgAdmin(courseId, profileId);
+
+  if (canViewAllMarks) {
+    return { canViewAllMarks: true, groupMemberId: null };
+  }
+
+  const groupMemberId = await getGroupMemberIdByCourseAndProfile(courseId, profileId);
+  return { canViewAllMarks: false, groupMemberId };
+}
 
 /**
  * Gets marks for a course
  * Marks are computed from submissions and exercises using a database function
  * @param courseId Course ID
- * @returns Array of mark records
+ * @param profileId Viewing user's profile ID
+ * @returns Array of mark records visible to the viewer
  */
-export async function getMarks(courseId: string) {
+export async function getMarks(courseId: string, profileId: string) {
   try {
-    return await getMarksByCourseId(courseId);
+    const { canViewAllMarks, groupMemberId } = await resolveMarksViewerScope(courseId, profileId);
+
+    if (canViewAllMarks) {
+      return await getMarksByCourseId(courseId);
+    }
+
+    if (!groupMemberId) {
+      return [];
+    }
+
+    return await getMarksByCourseId(courseId, groupMemberId);
   } catch (error) {
     throw new AppError(error instanceof Error ? error.message : 'Failed to get marks', ErrorCodes.INTERNAL_ERROR, 500);
   }

--- a/packages/db/src/queries/mark/mark.ts
+++ b/packages/db/src/queries/mark/mark.ts
@@ -20,10 +20,16 @@ export interface Mark {
  * Gets marks for a course
  * Converts the get_marks() PostgreSQL function to a Drizzle query
  * @param courseId Course ID
+ * @param submittedBy Optional group member ID. When set, only that learner's
+ * submissions are joined so other students' scores never leave the database.
  * @returns Array of mark records
  */
-export async function getMarksByCourseId(courseId: string): Promise<Mark[]> {
+export async function getMarksByCourseId(courseId: string, submittedBy?: string): Promise<Mark[]> {
   try {
+    const submissionJoin = submittedBy
+      ? and(eq(schema.exercise.id, schema.submission.exerciseId), eq(schema.submission.submittedBy, submittedBy))
+      : eq(schema.exercise.id, schema.submission.exerciseId);
+
     const result = await db
       .select({
         courseId: schema.course.id,
@@ -40,7 +46,7 @@ export async function getMarksByCourseId(courseId: string): Promise<Mark[]> {
         schema.course,
         or(eq(schema.exercise.courseId, schema.course.id), eq(schema.lesson.courseId, schema.course.id))
       )
-      .leftJoin(schema.submission, eq(schema.exercise.id, schema.submission.exerciseId))
+      .leftJoin(schema.submission, submissionJoin)
       .innerJoin(schema.question, eq(schema.question.exerciseId, schema.exercise.id))
       .where(eq(schema.course.id, courseId))
       .groupBy(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The course marks page loads `/course/:courseId/mark/gradebook`. That endpoint (and the raw marks list) returned every learner in the course plus all of their scores to any course member, including students.

Students can open Marks when org grading customization is enabled. They should only see their own row. Instructors (course admin/tutor or org admin) still get the full class gradebook.

This scopes both endpoints by the viewer:

- Instructors receive every student and every score
- Students receive only their own membership row and marks
- The marks query can join a single learner's submissions so other scores never leave the database
- The gradebook also drops any other students' marks before responding, in case the query result is broader than expected

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

1. Log in as a course instructor and open a course Marks page. Confirm every enrolled student and their scores still appear, and CSV/PDF export still works.
2. Log in as a student in the same course (grading customization enabled so Marks is visible). Confirm the table shows only that student.
3. As the student, inspect the `/mark/gradebook` and `/mark` API responses and confirm other learners' names, emails, and scores are not present.

Automated coverage: `pnpm --filter @cio/api exec vitest run src/__tests__/gradebook-privacy.test.ts`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] If I am a first-time or external contributor, I signed the [ClassroomIO Contributor License Agreement](https://forms.gle/XsXdfGcgJpWtNuzs7)
- [ ] If this PR changes `pnpm-lock.yaml`, `.github/workflows/**`, or publish config: call that out in the PR description

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the ClassroomIO Docs if changes were necessary

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1705635d-56ec-45f2-a40b-14502bc8d568?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1705635d-56ec-45f2-a40b-14502bc8d568&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Gradebooks and marks are now filtered based on the viewer’s permissions.
  - Instructors and authorized administrators can continue viewing all student marks.
  - Students see only their own marks and gradebook information.
  - Students without course membership receive empty results instead of unrelated data.
  - Prevented other learners’ marks from appearing in student views.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes course marks and gradebook responses according to the authenticated viewer.
- Course and organization instructors retain access to the complete gradebook.
- Students receive only their own membership row and submission scores.
- The database query filters joined submissions by group-member ID, with an additional response-level safeguard for gradebook marks.
- Privacy-focused tests cover instructor, student, defensive-filtering, and missing-membership cases.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and correctly prevents students from receiving other learners’ scores.

The authenticated identity and membership identifiers align with the query contracts, instructor roles remain authorized, student submissions are filtered at the database join, and the gradebook adds a second response-level boundary.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/course/mark.ts | Passes the authenticated viewer ID into marks and gradebook services. |
| apps/api/src/services/mark/mark.ts | Resolves whether the viewer can access all marks or only their own membership’s marks. |
| apps/api/src/services/mark/gradebook.ts | Loads viewer-scoped students and marks and defensively removes marks belonging to other learners. |
| packages/db/src/queries/mark/mark.ts | Optionally restricts the submission join to one group member. |
| apps/api/src/__tests__/gradebook-privacy.test.ts | Tests full instructor access, student-only access, defensive filtering, and missing-membership behavior. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Authenticated marks request] --> B{Course tutor/admin or org admin?}
  B -->|Yes| C[Query all course marks]
  C --> D[Return all student rows and scores]
  B -->|No| E[Resolve viewer's group-member ID]
  E --> F{Membership found?}
  F -->|No| G[Return empty marks or gradebook]
  F -->|Yes| H[Join submissions for that member only]
  H --> I[Load only viewer's membership row]
  I --> J[Scope gradebook map to viewer ID]
  J --> K[Return viewer's row and scores]
```

<sub>Reviews (1): Last reviewed commit: ["fix(api): hide other students&#39; scores on..."](https://github.com/classroomio/classroomio/commit/52d103a6ef315280df94f3b13a57e37c4b89a2fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63455548)</sub>

<!-- /greptile_comment -->