### PR TITLE
fix(ci): trigger PR demo workflow from main via pull_request_target

### DIFF
--- a/.github/workflows/pr-demo.yml
+++ b/.github/workflows/pr-demo.yml
@@ -3,9 +3,14 @@ name: PR demo (Playwright)
 # Label `demo-pr` (by rotimi-best) → OpenCode writes an ephemeral Playwright spec,
 # CI runs preview build + Playwright, uploads video artifacts, comments on the PR.
 # Policy B: demo failures warn but do not fail the workflow.
+#
+# Uses pull_request_target (not pull_request) so the workflow file is read from the
+# base branch (main). With pull_request + labeled, GitHub only runs workflows that
+# already exist on the PR head — so labeling a feature branch that predates this
+# file would do nothing. Jobs still check out the PR head SHA explicitly below.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 permissions:
@@ -26,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # pull_request_target defaults to the base ref — always pin the PR head SHA.
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What happened

Labeling https://github.com/classroomio/classroomio/pull/1103 with `demo-pr` did nothing.

**Cause:** `on: pull_request` + `types: [labeled]` only runs workflow files that exist on the **PR head branch**. #1103’s branch predates `pr-demo.yml`, so GitHub never scheduled the workflow even though it is on `main`.

## Fix

Switch the trigger to `pull_request_target` + `labeled` so the workflow file is read from the **base branch (`main`)**. Jobs still check out the labeled PR’s immutable `head.sha` (and fork `repository`) explicitly — they do not use the default base-ref checkout from `pull_request_target`.

## Security notes

- Still gated to label `demo-pr` added by `rotimi-best` only
- `OPENCODE_API_KEY` only in the `generate` job (no `pnpm install` there)
- `run` job has no OpenCode secret; checks out PR head and runs Playwright after validation
- Prefer merging this before re-labeling feature PRs

## How to verify

1. Merge this PR to `main`
2. On #1103 (or any PR): remove `demo-pr` if present, then add it again as `rotimi-best`
3. Confirm **PR demo (Playwright)** appears under Actions and comments on the PR

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a060c4-6561-713c-83d2-6aeabce8b10d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a060c4-6561-713c-83d2-6aeabce8b10d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

