### PR TITLE
fix(ci): provide compose secrets before starting PR demo Postgres

### DIFF
--- a/.github/scripts/prepare-pr-demo-env.sh
+++ b/.github/scripts/prepare-pr-demo-env.sh
@@ -11,6 +11,13 @@ AUTH_SECRET="${BETTER_AUTH_SECRET:-$(openssl rand -hex 32)}"
 
 mkdir -p apps/api apps/dashboard packages/db
 
+# Root .env is required even when only starting postgres/redis — docker compose
+# interpolates api/dashboard service env vars while parsing the whole file.
+cat > .env <<EOF
+BETTER_AUTH_SECRET=${AUTH_SECRET}
+PRIVATE_SERVER_KEY=${SERVER_KEY}
+EOF
+
 cat > apps/api/.env <<EOF
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/classroomio
 REDIS_URL=redis://localhost:6379
@@ -30,4 +37,4 @@ EOF
 
 cp packages/db/.env.example packages/db/.env
 
-echo "Prepared API, dashboard, and db env files for PR demo CI."
+echo "Prepared root, API, dashboard, and db env files for PR demo CI."

--- a/.github/workflows/pr-demo.yml
+++ b/.github/workflows/pr-demo.yml
@@ -161,6 +161,10 @@ jobs:
           bash .github/scripts/validate-pr-demo-spec.sh "$SPEC"
           echo "path=${SPEC}" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare demo env files
+        if: steps.gate.outputs.run_demo == 'true'
+        run: bash .github/scripts/prepare-pr-demo-env.sh
+
       - name: Start Postgres and Redis
         if: steps.gate.outputs.run_demo == 'true'
         run: docker compose -f docker-compose.yaml up -d postgres redis
@@ -178,10 +182,6 @@ jobs:
           done
           echo "::error::Postgres did not become ready in time."
           exit 1
-
-      - name: Prepare demo env files
-        if: steps.gate.outputs.run_demo == 'true'
-        run: bash .github/scripts/prepare-pr-demo-env.sh
 
       - name: Build workspace for db seed
         if: steps.gate.outputs.run_demo == 'true'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What failed

[PR demo run on #1103](https://github.com/classroomio/classroomio/actions/runs/34756553056/job/103721929988) — generate succeeded, run failed immediately on:

```text
docker compose -f docker-compose.yaml up -d postgres redis
error while interpolating services.api.environment.BETTER_AUTH_SECRET:
required variable BETTER_AUTH_SECRET is missing a value
```

Compose parses the whole file (including `api` / `dashboard` `${VAR:?…}` entries) even when only starting `postgres` and `redis`. Env prep ran **after** that step and only wrote `apps/*/.env`, not a root `.env`.

## Fix

1. Run `prepare-pr-demo-env.sh` **before** `docker compose up`
2. Have that script also write a root `.env` with `BETTER_AUTH_SECRET` and `PRIVATE_SERVER_KEY` (same values as the app env files)

## How to verify

1. Merge this to `main`
2. Rebase the target feature PR onto `main` (so it picks up the workflow), then remove/re-add `demo-pr`
3. Confirm the run job gets past “Start Postgres and Redis”

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a060c4-6561-713c-83d2-6aeabce8b10d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a060c4-6561-713c-83d2-6aeabce8b10d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes PR demo startup by generating environment files before invoking Docker Compose and adding the two required interpolation values to the root `.env`.
- Moves demo environment preparation ahead of Postgres and Redis startup.
- Reuses the generated authentication and server keys across the root, API, and dashboard environment files.
- Satisfies all required Docker Compose interpolations encountered during whole-file parsing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and directly addresses the reported Docker Compose interpolation failure.

The generated root environment file is available at the correct location before Compose runs, contains every required variable, and introduces no conflicting setup or cleanup behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/scripts/prepare-pr-demo-env.sh | Adds a root Compose interpolation environment file using the same generated secrets as the application environment files. |
| .github/workflows/pr-demo.yml | Runs environment preparation before Docker Compose starts the PR demo dependencies. |

<sub>Reviews (1): Last reviewed commit: ["fix(ci): write root .env before docker c..."](https://github.com/classroomio/classroomio/commit/86636da99566771fb6933d2a23ea39093b21d2c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63647759)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved demo environment setup by generating a root environment configuration alongside service-specific files.
  - Demo workflows now prepare environment files earlier, before starting required services.
  - Removed a redundant environment-preparation step from the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->